### PR TITLE
refactor: :recycle: refactor dashboard to use kpi cards

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,18 +1,12 @@
 "use client";
 
 import React, { useEffect, useState, useCallback } from "react";
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-  Legend,
-} from 'recharts'
 import { SkeletonMetricsCard } from '@/components/ui/Skeleton'
-import { MainLayout } from "@/components/layout"
+import { KpiCard } from '@/components/dashboard/KpiCard'
+import { SettlementSpeedCard } from '@/components/dashboard/SettlementSpeedCard'
+import { LiquidityDepthCard } from '@/components/dashboard/LiquidityDepthCard'
+import { CorridorHealthCard } from '@/components/dashboard/CorridorHealthCard'
+import { TopAssetsCard } from '@/components/dashboard/TopAssetsCard'
 
 type Corridor = {
   id: string;
@@ -99,116 +93,19 @@ export default function DashboardPage() {
 
       {data && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="col-span-1 bg-white rounded shadow p-4">
-            <h2 className="text-sm text-gray-500">
-              Total Payment Success Rate
-            </h2>
-            <div className="mt-3 flex items-end gap-4">
-              <div className="text-4xl font-bold">
-                {(data.totalSuccessRate * 100).toFixed(2)}%
-              </div>
-              <div className="text-sm text-gray-500">(last 24h)</div>
-            </div>
-          </div>
+          <KpiCard
+            title="Total Payment Success Rate"
+            value={`${(data.totalSuccessRate * 100).toFixed(2)}%`}
+            subtitle="(last 24h)"
+          />
 
-          <div className="col-span-1 lg:col-span-2 bg-white rounded shadow p-4">
-            <h2 className="text-sm text-gray-500">
-              Settlement Speed (ms) — last 24 points
-            </h2>
-            <div style={{ width: "100%", height: 220 }} className="mt-3">
-              <ResponsiveContainer>
-                <LineChart data={data.timeseries}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis
-                    dataKey="ts"
-                    tickFormatter={(s) => new Date(s).getHours() + ":00"}
-                  />
-                  <YAxis />
-                  <Tooltip
-                    labelFormatter={(s) => new Date(s).toLocaleString()}
-                  />
-                  <Legend />
-                  <Line
-                    type="monotone"
-                    dataKey="settlementMs"
-                    stroke="#8884d8"
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
+          <SettlementSpeedCard data={data.timeseries} />
 
-          <div className="col-span-1 lg:col-span-2 bg-white rounded shadow p-4">
-            <h2 className="text-sm text-gray-500">
-              Liquidity Depth / TVL (24h)
-            </h2>
-            <div style={{ width: "100%", height: 240 }} className="mt-3">
-              <ResponsiveContainer>
-                <LineChart data={data.timeseries}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis
-                    dataKey="ts"
-                    tickFormatter={(s) => new Date(s).getHours() + ":00"}
-                  />
-                  <YAxis />
-                  <Tooltip
-                    labelFormatter={(s) => new Date(s).toLocaleString()}
-                  />
-                  <Legend />
-                  <Line
-                    type="monotone"
-                    dataKey="tvl"
-                    stroke="#82ca9d"
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
+          <LiquidityDepthCard data={data.timeseries} />
 
-          <div className="col-span-1 bg-white rounded shadow p-4">
-            <h2 className="text-sm text-gray-500">Active Corridor Health</h2>
-            <ul className="mt-3 space-y-3">
-              {data.activeCorridors.map((c) => (
-                <li key={c.id} className="flex items-center justify-between">
-                  <div>
-                    <div className="font-medium">{c.id}</div>
-                    <div className="text-sm text-gray-500">
-                      Success: {(c.successRate * 100).toFixed(2)}%
-                    </div>
-                  </div>
-                  <div className="text-sm font-semibold">
-                    {(c.health * 100).toFixed(0)}%
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
+          <CorridorHealthCard corridors={data.activeCorridors} />
 
-          <div className="col-span-1 lg:col-span-2 bg-white rounded shadow p-4">
-            <h2 className="text-sm text-gray-500">Top-performing Assets</h2>
-            <div className="mt-3 overflow-auto">
-              <table className="w-full text-left text-sm">
-                <thead className="text-gray-500 text-xs uppercase">
-                  <tr>
-                    <th className="pb-2">Asset</th>
-                    <th className="pb-2">Volume</th>
-                    <th className="pb-2">TVL</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.topAssets.map((a) => (
-                    <tr key={a.asset} className="border-t">
-                      <td className="py-2 font-medium">{a.asset}</td>
-                      <td className="py-2">{a.volume.toLocaleString()}</td>
-                      <td className="py-2">${a.tvl.toLocaleString()}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
+          <TopAssetsCard assets={data.topAssets} />
         </div>
       )}
     </div>

--- a/frontend/src/components/dashboard/CorridorHealthCard.tsx
+++ b/frontend/src/components/dashboard/CorridorHealthCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface Corridor {
+  id: string;
+  health: number;
+  successRate: number;
+}
+
+interface CorridorHealthCardProps {
+  corridors: Corridor[];
+}
+
+export function CorridorHealthCard({ corridors }: CorridorHealthCardProps) {
+  return (
+    <div className="col-span-1 bg-white rounded shadow p-4">
+      <h2 className="text-sm text-gray-500">Active Corridor Health</h2>
+      <ul className="mt-3 space-y-3">
+        {corridors.map((c) => (
+          <li key={c.id} className="flex items-center justify-between">
+            <div>
+              <div className="font-medium">{c.id}</div>
+              <div className="text-sm text-gray-500">
+                Success: {(c.successRate * 100).toFixed(2)}%
+              </div>
+            </div>
+            <div className="text-sm font-semibold">
+              {(c.health * 100).toFixed(0)}%
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/KpiCard.tsx
+++ b/frontend/src/components/dashboard/KpiCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  className?: string;
+}
+
+export function KpiCard({ title, value, subtitle, className = '' }: KpiCardProps) {
+  return (
+    <div className={`col-span-1 bg-white rounded shadow p-4 ${className}`}>
+      <h2 className="text-sm text-gray-500">{title}</h2>
+      <div className="mt-3 flex items-end gap-4">
+        <div className="text-4xl font-bold">{value}</div>
+        {subtitle && <div className="text-sm text-gray-500">{subtitle}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/LiquidityDepthCard.tsx
+++ b/frontend/src/components/dashboard/LiquidityDepthCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+
+interface TimePoint {
+  ts: string;
+  tvl: number;
+}
+
+interface LiquidityDepthCardProps {
+  data: TimePoint[];
+}
+
+export function LiquidityDepthCard({ data }: LiquidityDepthCardProps) {
+  return (
+    <div className="col-span-1 lg:col-span-2 bg-white rounded shadow p-4">
+      <h2 className="text-sm text-gray-500">
+        Liquidity Depth / TVL (24h)
+      </h2>
+      <div style={{ width: "100%", height: 240 }} className="mt-3">
+        <ResponsiveContainer>
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="ts"
+              tickFormatter={(s) => new Date(s).getHours() + ":00"}
+            />
+            <YAxis />
+            <Tooltip
+              labelFormatter={(s) => new Date(s).toLocaleString()}
+            />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="tvl"
+              stroke="#82ca9d"
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/SettlementSpeedCard.tsx
+++ b/frontend/src/components/dashboard/SettlementSpeedCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+
+interface TimePoint {
+  ts: string;
+  settlementMs: number;
+}
+
+interface SettlementSpeedCardProps {
+  data: TimePoint[];
+}
+
+export function SettlementSpeedCard({ data }: SettlementSpeedCardProps) {
+  return (
+    <div className="col-span-1 lg:col-span-2 bg-white rounded shadow p-4">
+      <h2 className="text-sm text-gray-500">
+        Settlement Speed (ms) — last 24 points
+      </h2>
+      <div style={{ width: "100%", height: 220 }} className="mt-3">
+        <ResponsiveContainer>
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="ts"
+              tickFormatter={(s) => new Date(s).getHours() + ":00"}
+            />
+            <YAxis />
+            <Tooltip
+              labelFormatter={(s) => new Date(s).toLocaleString()}
+            />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="settlementMs"
+              stroke="#8884d8"
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/TopAssetsCard.tsx
+++ b/frontend/src/components/dashboard/TopAssetsCard.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface TopAsset {
+  asset: string;
+  volume: number;
+  tvl: number;
+}
+
+interface TopAssetsCardProps {
+  assets: TopAsset[];
+}
+
+export function TopAssetsCard({ assets }: TopAssetsCardProps) {
+  return (
+    <div className="col-span-1 lg:col-span-2 bg-white rounded shadow p-4">
+      <h2 className="text-sm text-gray-500">Top-performing Assets</h2>
+      <div className="mt-3 overflow-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="text-gray-500 text-xs uppercase">
+            <tr>
+              <th className="pb-2">Asset</th>
+              <th className="pb-2">Volume</th>
+              <th className="pb-2">TVL</th>
+            </tr>
+          </thead>
+          <tbody>
+            {assets.map((a) => (
+              <tr key={a.asset} className="border-t">
+                <td className="py-2 font-medium">{a.asset}</td>
+                <td className="py-2">{a.volume.toLocaleString()}</td>
+                <td className="py-2">${a.tvl.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -1,0 +1,5 @@
+export { KpiCard } from './KpiCard';
+export { SettlementSpeedCard } from './SettlementSpeedCard';
+export { LiquidityDepthCard } from './LiquidityDepthCard';
+export { CorridorHealthCard } from './CorridorHealthCard';
+export { TopAssetsCard } from './TopAssetsCard';


### PR DESCRIPTION
# ♻️  Refactor Dashboard to Use KPI Cards


- [ ] Closes #47 

---

### 📌 Type of Change

- [x] Refactored dashboard page to use modular KPI card components
- [x] Created reusable KPI card component (`KpiCard`)
- [x] Extracted dashboard metrics into separate card components
- [x] Added component exports for dashboard cards
- [x] Improved code organization and maintainability

