### PR TITLE
feat(analytics): Restrict Snapshot Submission Access

### DIFF
--- a/contracts/analytics/src/tests.rs
+++ b/contracts/analytics/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use soroban_sdk::{testutils::Ledger, BytesN, Env};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, BytesN, Env};
 
 fn create_test_hash(env: &Env, value: u8) -> BytesN<32> {
     BytesN::from_array(env, &[value; 32])
@@ -8,43 +8,52 @@ fn create_test_hash(env: &Env, value: u8) -> BytesN<32> {
 #[test]
 fn test_initialization() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     assert_eq!(client.get_latest_epoch(), 0);
     assert_eq!(client.get_snapshot_history().len(), 0);
     assert_eq!(client.get_latest_snapshot(), None);
+    assert_eq!(client.get_admin(), Some(admin));
 }
 
 #[test]
-fn test_initialize_idempotent() {
+#[should_panic(expected = "Contract already initialized")]
+fn test_initialize_cannot_reinitialize() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
-    client.initialize();
-
-    assert_eq!(client.get_latest_epoch(), 0);
-    assert_eq!(client.get_snapshot_history().len(), 0);
+    client.initialize(&admin);
+    // Second initialization should fail
+    client.initialize(&admin);
 }
 
 #[test]
 fn test_submit_single_snapshot() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     env.ledger().set_timestamp(1234);
 
     let epoch = 1u64;
     let hash = create_test_hash(&env, 1);
 
-    let timestamp = client.submit_snapshot(&epoch, &hash);
+    let timestamp = client.submit_snapshot(&epoch, &hash, &admin);
 
     assert_eq!(timestamp, 1234);
 
@@ -64,22 +73,25 @@ fn test_submit_single_snapshot() {
 #[test]
 fn test_multiple_snapshots_strictly_increasing_epochs() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     let epoch1 = 1u64;
     let hash1 = create_test_hash(&env, 1);
-    client.submit_snapshot(&epoch1, &hash1);
+    client.submit_snapshot(&epoch1, &hash1, &admin);
 
     let epoch2 = 2u64;
     let hash2 = create_test_hash(&env, 2);
-    client.submit_snapshot(&epoch2, &hash2);
+    client.submit_snapshot(&epoch2, &hash2, &admin);
 
     let epoch3 = 3u64;
     let hash3 = create_test_hash(&env, 3);
-    client.submit_snapshot(&epoch3, &hash3);
+    client.submit_snapshot(&epoch3, &hash3, &admin);
 
     assert_eq!(client.get_snapshot(&epoch1).unwrap().hash, hash1);
     assert_eq!(client.get_snapshot(&epoch2).unwrap().hash, hash2);
@@ -104,15 +116,18 @@ fn test_multiple_snapshots_strictly_increasing_epochs() {
 #[test]
 fn test_non_sequential_epochs_monotonic_order() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     let epochs = [1u64, 5u64, 10u64];
     for (i, &epoch) in epochs.iter().enumerate() {
         let hash = create_test_hash(&env, (i + 1) as u8);
-        client.submit_snapshot(&epoch, &hash);
+        client.submit_snapshot(&epoch, &hash, &admin);
     }
 
     for (i, &epoch) in epochs.iter().enumerate() {
@@ -128,20 +143,23 @@ fn test_non_sequential_epochs_monotonic_order() {
 #[test]
 fn test_historical_data_integrity_after_new_submissions() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     env.ledger().set_timestamp(100);
     let epoch1 = 1u64;
     let hash1 = create_test_hash(&env, 1);
-    let timestamp1 = client.submit_snapshot(&epoch1, &hash1);
+    let timestamp1 = client.submit_snapshot(&epoch1, &hash1, &admin);
 
     env.ledger().set_timestamp(200);
     let epoch2 = 2u64;
     let hash2 = create_test_hash(&env, 2);
-    let timestamp2 = client.submit_snapshot(&epoch2, &hash2);
+    let timestamp2 = client.submit_snapshot(&epoch2, &hash2, &admin);
 
     let snapshot1_before = client.get_snapshot(&epoch1).unwrap();
     let snapshot2_before = client.get_snapshot(&epoch2).unwrap();
@@ -149,7 +167,7 @@ fn test_historical_data_integrity_after_new_submissions() {
     env.ledger().set_timestamp(300);
     let epoch3 = 5u64;
     let hash3 = create_test_hash(&env, 5);
-    client.submit_snapshot(&epoch3, &hash3);
+    client.submit_snapshot(&epoch3, &hash3, &admin);
 
     let snapshot1_after = client.get_snapshot(&epoch1).unwrap();
     let snapshot2_after = client.get_snapshot(&epoch2).unwrap();
@@ -165,10 +183,13 @@ fn test_historical_data_integrity_after_new_submissions() {
 #[test]
 fn test_get_nonexistent_snapshot() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     assert_eq!(client.get_snapshot(&999), None);
 }
@@ -177,63 +198,75 @@ fn test_get_nonexistent_snapshot() {
 #[should_panic(expected = "Invalid epoch: must be greater than 0")]
 fn test_invalid_epoch_zero() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     let hash = create_test_hash(&env, 1);
-    client.submit_snapshot(&0, &hash);
+    client.submit_snapshot(&0, &hash, &admin);
 }
 
 #[test]
 #[should_panic(expected = "already exists")]
 fn test_duplicate_epoch_fails() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     let epoch = 1u64;
     let hash1 = create_test_hash(&env, 1);
     let hash2 = create_test_hash(&env, 2);
 
-    client.submit_snapshot(&epoch, &hash1);
-    client.submit_snapshot(&epoch, &hash2);
+    client.submit_snapshot(&epoch, &hash1, &admin);
+    client.submit_snapshot(&epoch, &hash2, &admin);
 }
 
 #[test]
 #[should_panic(expected = "Epoch monotonicity violated")]
 fn test_older_epoch_rejected() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     let epoch_new = 10u64;
     let hash_new = create_test_hash(&env, 10);
-    client.submit_snapshot(&epoch_new, &hash_new);
+    client.submit_snapshot(&epoch_new, &hash_new, &admin);
     assert_eq!(client.get_latest_epoch(), epoch_new);
 
     let epoch_old = 5u64;
     let hash_old = create_test_hash(&env, 5);
-    client.submit_snapshot(&epoch_old, &hash_old);
+    client.submit_snapshot(&epoch_old, &hash_old, &admin);
 }
 
 #[test]
 fn test_bounded_storage_growth_simulation() {
     let env = Env::default();
+    env.mock_all_auths();
+    
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize();
+    client.initialize(&admin);
 
     let num_epochs = 100u64;
     for epoch in 1..=num_epochs {
         let hash = create_test_hash(&env, (epoch % 255) as u8);
-        client.submit_snapshot(&epoch, &hash);
+        client.submit_snapshot(&epoch, &hash, &admin);
     }
 
     for epoch in 1..=num_epochs {
@@ -243,4 +276,142 @@ fn test_bounded_storage_growth_simulation() {
     assert_eq!(client.get_latest_epoch(), num_epochs);
     assert_eq!(client.get_snapshot_history().len(), num_epochs as u32);
     assert_eq!(client.get_all_epochs().len(), num_epochs as u32);
+}
+
+// ============================================================================
+// Access Control Tests - Tests for Issue #41
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_unauthorized_submission_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let unauthorized_user = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let epoch = 1u64;
+    let hash = create_test_hash(&env, 1);
+    
+    // Attempt to submit snapshot with unauthorized address should fail
+    client.submit_snapshot(&epoch, &hash, &unauthorized_user);
+}
+
+#[test]
+fn test_authorized_submission_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    
+    env.ledger().set_timestamp(1000);
+
+    let epoch = 1u64;
+    let hash = create_test_hash(&env, 1);
+    
+    // Authorized admin should be able to submit
+    let timestamp = client.submit_snapshot(&epoch, &hash, &admin);
+    
+    assert_eq!(timestamp, 1000);
+    assert_eq!(client.get_latest_epoch(), epoch);
+    
+    let snapshot = client.get_snapshot(&epoch).unwrap();
+    assert_eq!(snapshot.hash, hash);
+}
+
+#[test]
+fn test_get_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    
+    // Before initialization, admin should be None
+    assert_eq!(client.get_admin(), None);
+    
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    
+    // After initialization, admin should match
+    assert_eq!(client.get_admin(), Some(admin));
+}
+
+#[test]
+fn test_set_admin_by_authorized_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+    
+    // Current admin transfers rights to new admin
+    client.set_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), Some(new_admin.clone()));
+    
+    // New admin can now submit snapshots
+    let epoch = 1u64;
+    let hash = create_test_hash(&env, 1);
+    client.submit_snapshot(&epoch, &hash, &new_admin);
+    
+    assert_eq!(client.get_latest_epoch(), epoch);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_set_admin_by_unauthorized_user_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let unauthorized_user = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    
+    // Unauthorized user attempts to change admin should fail
+    client.set_admin(&unauthorized_user, &new_admin);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_old_admin_cannot_submit_after_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    
+    // Transfer admin rights
+    client.set_admin(&admin, &new_admin);
+    
+    // Old admin should no longer be able to submit
+    let epoch = 1u64;
+    let hash = create_test_hash(&env, 1);
+    client.submit_snapshot(&epoch, &hash, &admin);
 }


### PR DESCRIPTION
## Description

This PR implements access control for snapshot submission in the analytics contract. Previously, any address could submit snapshots, which enabled potential malicious overwrites. Now, only an authorized admin address can submit snapshots.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## Related Issue

Closes #41

## Changes Made

### Contract Changes (`contracts/analytics/src/lib.rs`)

- **Added `Admin` DataKey**: New storage key to persist the authorized submitter address
- **Updated `initialize()`**: Now accepts an `admin: Address` parameter to set the authorized submitter during contract initialization. Also prevents re-initialization by checking if admin is already set
- **Updated `submit_snapshot()`**: 
  - Added `caller: Address` parameter
  - Validates caller authentication using `require_auth()`
  - Verifies caller matches the stored admin address
  - Rejects unauthorized calls with a clear panic message
- **Added `get_admin()`**: Query function to retrieve the current admin address
- **Added `set_admin()`**: Allows the current admin to transfer admin rights to a new address (also requires authentication)

### Test Changes (`contracts/analytics/src/tests.rs`)

- Updated all existing tests to use the new `initialize(admin)` and `submit_snapshot(epoch, hash, admin)` signatures
- Added new access control tests:
  - `test_unauthorized_submission_fails` - Verifies non-admin addresses cannot submit
  - `test_authorized_submission_succeeds` - Verifies admin can submit successfully
  - `test_get_admin` - Tests admin query functionality
  - `test_set_admin_by_authorized_admin` - Tests admin transfer works
  - `test_set_admin_by_unauthorized_user_fails` - Verifies only admin can transfer rights
  - `test_old_admin_cannot_submit_after_transfer` - Ensures old admin loses access after transfer
  - `test_initialize_cannot_reinitialize` - Prevents re-initialization attacks

## Testing

### Contracts
```bash
cd contracts/analytics
cargo test
```

**Results:** All 17 tests pass ✅

```
running 17 tests
test tests::test_get_admin ... ok
test tests::test_authorized_submission_succeeds ... ok
test tests::test_get_nonexistent_snapshot ... ok
test tests::test_initialization ... ok
test tests::test_historical_data_integrity_after_new_submissions ... ok
test tests::test_bounded_storage_growth_simulation ... ok
test tests::test_multiple_snapshots_strictly_increasing_epochs ... ok
test tests::test_non_sequential_epochs_monotonic_order ... ok
test tests::test_duplicate_epoch_fails - should panic ... ok
test tests::test_initialize_cannot_reinitialize - should panic ... ok
test tests::test_invalid_epoch_zero - should panic ... ok
test tests::test_old_admin_cannot_submit_after_transfer - should panic ... ok
test tests::test_set_admin_by_authorized_admin ... ok
test tests::test_unauthorized_submission_fails - should panic ... ok
test tests::test_set_admin_by_unauthorized_user_fails - should panic ... ok
test tests::test_submit_single_snapshot ... ok
test tests::test_older_epoch_rejected - should panic ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### WASM Build
```bash
cargo build --target wasm32-unknown-unknown --release
```
**Result:** Compiles successfully ✅

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

### Breaking Change Notice

This is a **breaking change** for the `initialize()` and `submit_snapshot()` functions:

**Before:**
```rust
pub fn initialize(env: Env)
pub fn submit_snapshot(env: Env, epoch: u64, hash: BytesN<32>) -> u64
```

**After:**
```rust
pub fn initialize(env: Env, admin: Address)
pub fn submit_snapshot(env: Env, epoch: u64, hash: BytesN<32>, caller: Address) -> u64
```

Any existing integrations calling these functions will need to be updated to provide the required `Address` parameters.

### Security Considerations

- The admin address is stored in instance storage and persists across invocations
- Authentication is enforced via Soroban's `require_auth()` mechanism
- Admin transfer requires authentication from the current admin
- Contract cannot be re-initialized once an admin is set