### PR TITLE
refresh

### DIFF
--- a/frontend/src/components/DataRefreshIndicator.tsx
+++ b/frontend/src/components/DataRefreshIndicator.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React from "react";
+
+export interface DataRefreshIndicatorProps {
+  /** Timestamp of the last successful data update. */
+  lastUpdated: Date | null;
+  /** Seconds remaining until the next auto-refresh. Must be >= 0. */
+  secondsUntilRefresh: number;
+  /** Total auto-refresh interval in seconds (used to calculate ring progress). */
+  refreshIntervalSec?: number;
+  /** True while a refresh is running. */
+  isRefreshing: boolean;
+  /** Called when the user clicks the manual refresh button. */
+  onRefresh: () => void;
+  className?: string;
+}
+
+/** SVG countdown ring radius and derived values. */
+const RADIUS = 8;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function DataRefreshIndicator({
+  lastUpdated,
+  secondsUntilRefresh,
+  refreshIntervalSec = 30,
+  isRefreshing,
+  onRefresh,
+  className = "",
+}: DataRefreshIndicatorProps) {
+  // Progress fraction: 0 = just refreshed (full ring), 1 = about to refresh (empty)
+  const progress =
+    refreshIntervalSec > 0 ? 1 - secondsUntilRefresh / refreshIntervalSec : 0;
+  const strokeDashoffset = CIRCUMFERENCE * progress;
+
+  const formattedTime = lastUpdated
+    ? lastUpdated.toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      })
+    : "—";
+
+  return (
+    <div
+      className={`flex items-center gap-2 flex-wrap ${className}`}
+      aria-label="Data refresh status"
+    >
+      {/* ── Last updated badge ─────────────────────────────────── */}
+      <div
+        className="px-3 py-1.5 glass rounded-lg text-[10px] font-mono uppercase tracking-widest text-muted-foreground whitespace-nowrap"
+        title={
+          lastUpdated
+            ? `Last updated: ${lastUpdated.toLocaleString()}`
+            : "No data yet"
+        }
+      >
+        Last Update:{" "}
+        <span className="text-foreground font-semibold">{formattedTime}</span>
+      </div>
+
+      {/* ── Countdown ring badge ────────────────────────────────── */}
+      <div
+        className="flex items-center gap-1.5 px-3 py-1.5 glass rounded-lg text-[10px] font-mono uppercase tracking-widest text-muted-foreground whitespace-nowrap"
+        title={`Auto-refresh in ${secondsUntilRefresh}s`}
+      >
+        {/* Animated circular progress ring */}
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          className="shrink-0"
+          aria-hidden="true"
+        >
+          {/* Track */}
+          <circle
+            cx="10"
+            cy="10"
+            r={RADIUS}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            className="text-muted opacity-30"
+          />
+          {/* Progress arc (rotated so it starts at the top) */}
+          <circle
+            cx="10"
+            cy="10"
+            r={RADIUS}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={strokeDashoffset}
+            className="text-accent transition-[stroke-dashoffset] duration-1000 ease-linear"
+            style={{ transform: "rotate(-90deg)", transformOrigin: "50% 50%" }}
+          />
+        </svg>
+
+        {isRefreshing ? (
+          <span className="text-accent animate-pulse">Refreshing…</span>
+        ) : (
+          <>
+            Next refresh in{" "}
+            <span className="text-foreground font-semibold tabular-nums">
+              {secondsUntilRefresh}s
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* ── Manual refresh button ───────────────────────────────── */}
+      <button
+        onClick={onRefresh}
+        disabled={isRefreshing}
+        aria-label="Manually refresh data"
+        title="Refresh now"
+        className={[
+          "flex items-center gap-1.5 px-4 py-1.5",
+          "bg-accent text-accent-foreground rounded-lg",
+          "text-[10px] font-bold uppercase tracking-widest",
+          "transition-all duration-200",
+          "hover:scale-105 hover:shadow-[0_0_14px_var(--glow-accent-shadow)]",
+          "active:scale-95",
+          "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100",
+        ].join(" ")}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`w-3 h-3 ${isRefreshing ? "animate-spin" : ""}`}
+          aria-hidden="true"
+        >
+          <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+          <path d="M21 3v5h-5" />
+          <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+          <path d="M3 21v-5h5" />
+        </svg>
+        {isRefreshing ? "Refreshing" : "Refresh"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDataRefresh.ts
+++ b/frontend/src/hooks/useDataRefresh.ts
@@ -1,0 +1,138 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface UseDataRefreshOptions {
+  /** Auto-refresh interval in milliseconds. Defaults to 30 000 ms. */
+  refreshIntervalMs?: number;
+  /** Async callback invoked on each auto or manual refresh. */
+  onRefresh?: () => Promise<void>;
+  /** Whether to trigger an immediate refresh on mount. Defaults to false. */
+  refreshOnMount?: boolean;
+}
+
+export interface UseDataRefreshReturn {
+  /** Timestamp of the last successful data refresh. */
+  lastUpdated: Date | null;
+  /** Seconds remaining until the next auto-refresh. */
+  secondsUntilRefresh: number;
+  /** True while an in-flight refresh is pending. */
+  isRefreshing: boolean;
+  /** Call to immediately trigger a manual refresh and reset the countdown. */
+  triggerRefresh: () => Promise<void>;
+  /** Call to manually push the lastUpdated time (e.g., on a WS message). */
+  markUpdated: () => void;
+}
+
+export function useDataRefresh({
+  refreshIntervalMs = 30_000,
+  onRefresh,
+  refreshOnMount = false,
+}: UseDataRefreshOptions = {}): UseDataRefreshReturn {
+  const refreshIntervalSec = Math.max(1, Math.round(refreshIntervalMs / 1000));
+
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [secondsUntilRefresh, setSecondsUntilRefresh] =
+    useState(refreshIntervalSec);
+
+  // Tracks elapsed seconds since the last countdown reset so we can rebuild
+  // the countdown even when the component-level interval is re-created.
+  const elapsedRef = useRef(0);
+  const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+    null,
+  );
+  const autoRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const clearTimers = useCallback(() => {
+    if (countdownIntervalRef.current !== null) {
+      clearInterval(countdownIntervalRef.current);
+      countdownIntervalRef.current = null;
+    }
+    if (autoRefreshTimeoutRef.current !== null) {
+      clearTimeout(autoRefreshTimeoutRef.current);
+      autoRefreshTimeoutRef.current = null;
+    }
+  }, []);
+
+  const startCountdown = useCallback(() => {
+    clearTimers();
+    elapsedRef.current = 0;
+    setSecondsUntilRefresh(refreshIntervalSec);
+
+    // Tick every second to update the visible countdown
+    countdownIntervalRef.current = setInterval(() => {
+      elapsedRef.current += 1;
+      const remaining = Math.max(0, refreshIntervalSec - elapsedRef.current);
+      setSecondsUntilRefresh(remaining);
+    }, 1_000);
+
+    // Schedule the auto-refresh at the full interval
+    autoRefreshTimeoutRef.current = setTimeout(async () => {
+      if (onRefresh) {
+        setIsRefreshing(true);
+        try {
+          await onRefresh();
+          setLastUpdated(new Date());
+        } catch (err) {
+          console.error("[useDataRefresh] Auto-refresh failed:", err);
+        } finally {
+          setIsRefreshing(false);
+        }
+      }
+      // Restart the countdown after the refresh completes
+      startCountdown();
+    }, refreshIntervalMs);
+  }, [clearTimers, onRefresh, refreshIntervalMs, refreshIntervalSec]);
+
+  // Bootstrap: kick off the countdown on mount (and whenever the interval changes)
+  useEffect(() => {
+    startCountdown();
+    return clearTimers;
+  }, [startCountdown, clearTimers]);
+
+  // Optional: fire an immediate refresh on mount
+  useEffect(() => {
+    if (!refreshOnMount || !onRefresh) return;
+    (async () => {
+      setIsRefreshing(true);
+      try {
+        await onRefresh();
+        setLastUpdated(new Date());
+      } catch (err) {
+        console.error("[useDataRefresh] Mount refresh failed:", err);
+      } finally {
+        setIsRefreshing(false);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /** Manually trigger a refresh, reset the countdown. */
+  const triggerRefresh = useCallback(async () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    try {
+      if (onRefresh) await onRefresh();
+      setLastUpdated(new Date());
+    } catch (err) {
+      console.error("[useDataRefresh] Manual refresh failed:", err);
+    } finally {
+      setIsRefreshing(false);
+    }
+    startCountdown();
+  }, [isRefreshing, onRefresh, startCountdown]);
+
+  /** Push a lastUpdated timestamp without triggering a full refresh cycle. */
+  const markUpdated = useCallback(() => {
+    setLastUpdated(new Date());
+  }, []);
+
+  return {
+    lastUpdated,
+    secondsUntilRefresh,
+    isRefreshing,
+    triggerRefresh,
+    markUpdated,
+  };
+}


### PR DESCRIPTION
## Description
Implements Issue #50 — adds a polished **Data Refresh Indicator** to the dashboard header, replacing the previous basic "Last Update" label and hard `window.location.reload()` button with a fully-featured, animated component.
## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [x] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
## Related Issue
Closes #304
## Changes Made
- **[src/hooks/useDataRefresh.ts](cci:7://file:///Users/macbookpro/Desktop/insights/frontend/src/hooks/useDataRefresh.ts:0:0-0:0)** — new custom hook encapsulating:
  - `lastUpdated` timestamp state
  - `secondsUntilRefresh` countdown (configurable interval, default 30 s)
  - `isRefreshing` in-flight flag
  - `triggerRefresh()` for manual refresh (resets the countdown)
  - `markUpdated()` to push a timestamp update from WebSocket events without re-fetching
- **[src/components/DataRefreshIndicator.tsx](cci:7://file:///Users/macbookpro/Desktop/insights/frontend/src/components/DataRefreshIndicator.tsx:0:0-0:0)** — new UI component featuring:
  - **Last Update badge** — displays `HH:MM:SS` of last data update
  - **Countdown badge** — "Next refresh in Xs" with an animated SVG circular progress ring
  - **Manual Refresh button** — spinning icon while in-flight; styled to match the dark glassmorphism design system
- **[src/app/dashboard/page.tsx](cci:7://file:///Users/macbookpro/Desktop/insights/frontend/src/app/dashboard/page.tsx:0:0-0:0)** — refactored:
  - Removed standalone `lastUpdate` state and `window.location.reload()` button
  - Wired [useDataRefresh](cci:1://file:///Users/macbookpro/Desktop/insights/frontend/src/hooks/useDataRefresh.ts:24:0-137:1) to re-fetch `/api/dashboard` every 30 s automatically
  - WebSocket [onCorridorUpdate](cci:1://file:///Users/macbookpro/Desktop/insights/frontend/src/app/dashboard/page.tsx:101:4-112:5) / [onAnchorUpdate](cci:1://file:///Users/macbookpro/Desktop/insights/frontend/src/app/dashboard/page.tsx:120:6-123:7) callbacks now call `markUpdated()` instead of managing their own state
  - Renders `<DataRefreshIndicator>` in the dashboard header
## Testing
### Frontend
```bash
cd frontend
pnpm lint