### PR TITLE
feat: Add Terraform Infrastructure as Code for multi-environment AWS …

### DIFF
--- a/TERRAFORM.md
+++ b/TERRAFORM.md
@@ -1,0 +1,672 @@
+# Terraform Infrastructure as Code for Stellar Insights
+
+Complete Infrastructure-as-Code setup for Stellar Insights using Terraform 1.5+ and AWS.
+
+## Overview
+
+This Terraform configuration deploys a complete, production-ready infrastructure for Stellar Insights including:
+
+- **Networking**: VPC, subnets, NAT gateways, route tables, security groups
+- **Database**: RDS PostgreSQL (staging/production only)
+- **Caching**: ElastiCache Redis cluster
+- **Compute**: ECS cluster with auto-scaling
+- **Load Balancing**: Application Load Balancer with HTTPS
+- **Secrets Management**: Vault integration via HCP Cloud
+- **Monitoring**: CloudWatch logs, metrics, alarms, dashboards
+
+## Quick Start
+
+### Prerequisites
+
+- Terraform 1.5+
+- AWS CLI v2 configured with credentials
+- AWS Account with appropriate permissions
+- Docker (for building container images)
+- Git (for version control)
+
+### Step 1: Bootstrap (One-time)
+
+Initialize the global Terraform state backend:
+
+```bash
+# Make scripts executable
+chmod +x terraform/scripts/*.sh
+
+# Bootstrap S3, DynamoDB, and ECR
+./terraform/scripts/bootstrap.sh us-east-1
+```
+
+This creates:
+- S3 bucket for Terraform state
+- DynamoDB table for state locks
+- ECR repositories for container images
+
+### Step 2: Deploy Dev Environment
+
+```bash
+# Initialize remote state for dev
+./terraform/scripts/init-state.sh us-east-1 dev
+
+# Plan infrastructure
+./terraform/scripts/plan.sh dev
+
+# Apply configuration
+./terraform/scripts/apply.sh dev
+```
+
+### Step 3: Deploy Staging/Production
+
+```bash
+# Staging
+./terraform/scripts/init-state.sh us-east-1 staging
+./terraform/scripts/plan.sh staging
+./terraform/scripts/apply.sh staging
+
+# Production (requires additional confirmation)
+./terraform/scripts/init-state.sh us-east-1 production
+./terraform/scripts/plan.sh production
+./terraform/scripts/apply.sh production
+```
+
+## Directory Structure
+
+```
+terraform/
+├── global/                          # Global resources (state, ECR) - apply first!
+│   ├── README.md                   # Bootstrap instructions
+│   ├── versions.tf                 # Provider requirements
+│   ├── variables.tf                # Input variables
+│   ├── s3.tf                       # S3 state bucket
+│   ├── dynamodb.tf                 # DynamoDB locks table
+│   ├── ecr.tf                      # ECR repositories
+│   ├── iam.tf                      # IAM roles (GitHub OIDC)
+│   └── outputs.tf                  # Output values
+│
+├── modules/                        # Reusable Terraform modules
+│   ├── networking/                 # VPC, subnets, routing, security groups
+│   ├── database/                   # RDS PostgreSQL
+│   ├── caching/                    # ElastiCache Redis
+│   ├── compute/ecs/                # ECS cluster, task definitions, auto-scaling
+│   ├── load_balancing/             # ALB with HTTPS
+│   ├── vault/                      # Vault integration (reference)
+│   └── monitoring/                 # CloudWatch logs, alarms, dashboards
+│
+├── environments/                   # Environment-specific configurations
+│   ├── dev/                        # Development (minimal cost)
+│   │   ├── main.tf                # Module composition
+│   │   ├── variables.tf           # Dev-specific variables
+│   │   └── terraform.tfvars       # Default values
+│   ├── staging/                    # Staging (testing & QA)
+│   │   ├── main.tf
+│   │   ├── variables.tf
+│   │   └── terraform.tfvars
+│   └── production/                 # Production (HA & backups)
+│       ├── main.tf
+│       ├── variables.tf
+│       └── terraform.tfvars
+│
+└── scripts/                        # Helper scripts
+    ├── bootstrap.sh               # Create global state backend
+    ├── init-state.sh              # Initialize environment state
+    ├── plan.sh                    # Run terraform plan
+    ├── apply.sh                   # Run terraform apply
+    └── destroy.sh                 # Destroy infrastructure (DANGEROUS!)
+```
+
+## Module Reference
+
+### networking/
+
+Manages VPC, subnets, routing, and security groups.
+
+**Inputs:**
+- `vpc_cidr`: VPC CIDR block (e.g., "10.0.0.0/16")
+- `environment`: "dev", "staging", or "production"
+- `enable_nat_per_az`: Single NAT (false) or per-AZ (true)
+- `enable_vpc_flow_logs`: Enable VPC Flow Logs (cost impact)
+- `azs`: Number of availability zones (2 or 3)
+
+**Outputs:**
+- `vpc_id`: VPC identifier
+- `public_subnet_ids`: ALB subnets
+- `private_app_subnet_ids`: ECS subnets
+- `private_db_subnet_ids`: RDS/Redis subnets
+- `security_group_*_id`: Security group IDs
+
+**Example:**
+```hcl
+module "networking" {
+  source = "../../modules/networking"
+  
+  vpc_cidr = "10.0.0.0/16"
+  environment = "dev"
+  enable_nat_per_az = false
+  enable_vpc_flow_logs = false
+  azs = 2
+}
+```
+
+### database/
+
+Manages RDS PostgreSQL instance with backups and monitoring.
+
+**Inputs:**
+- `identifier`: RDS instance name
+- `instance_class`: "db.t3.micro", "db.t3.small", etc.
+- `allocated_storage`: Storage in GB (20-65536)
+- `multi_az`: Enable Multi-AZ failover (false for dev/staging, true for production)
+- `backup_retention_period`: Days to keep backups (1-35)
+- `enable_cloudwatch_logs_exports`: Export logs to CloudWatch
+
+**Outputs:**
+- `rds_endpoint`: Database connection string (host:port)
+- `rds_address`: Hostname only
+- `rds_port`: Port (5432)
+
+**Example:**
+```hcl
+module "database" {
+  source = "../../modules/database"
+  
+  identifier = "stellar-insights-dev"
+  instance_class = "db.t3.micro"
+  allocated_storage = 20
+  multi_az = false
+  backup_retention_period = 7
+}
+```
+
+### caching/
+
+Manages ElastiCache Redis cluster.
+
+**Inputs:**
+- `cluster_id`: Redis cluster name
+- `node_type`: "cache.t3.micro", "cache.t3.small", etc.
+- `num_cache_nodes`: Number of nodes (1 or 3 for Multi-AZ)
+- `automatic_failover_enabled`: Enable failover (false for dev, true for production)
+- `snapshot_retention_limit`: Days to keep snapshots
+
+**Outputs:**
+- `primary_endpoint`: Redis connection (host:port)
+- `redis_connection_string`: Full connection string with auth
+
+**Example:**
+```hcl
+module "caching" {
+  source = "../../modules/caching"
+  
+  cluster_id = "stellar-insights-dev"
+  node_type = "cache.t3.micro"
+  num_cache_nodes = 1
+  automatic_failover_enabled = false
+}
+```
+
+### compute/ecs/
+
+Manages ECS cluster, task definitions, and auto-scaling.
+
+**Inputs:**
+- `cluster_name`: ECS cluster name
+- `container_image`: ECR image URI with tag
+- `desired_count`: Target number of running tasks
+- `min_size` / `max_size`: Auto-scaling bounds
+- `instance_type`: EC2 instance type
+- `vault_addr`: Vault server address
+- `db_url`: Database connection string
+- `redis_url`: Redis connection string
+- `enable_auto_scaling`: Enable target-tracking auto-scaling
+
+**Outputs:**
+- `cluster_name`: ECS cluster name
+- `service_name`: ECS service name
+- `log_group_name`: CloudWatch log group
+
+**Example:**
+```hcl
+module "compute" {
+  source = "../../modules/compute/ecs"
+  
+  cluster_name = "stellar-insights-dev"
+  container_image = "123456789.dkr.ecr.us-east-1.amazonaws.com/stellar-insights-backend:latest"
+  desired_count = 2
+  min_size = 1
+  max_size = 4
+  instance_type = "t3.small"
+  vault_addr = "https://vault.hcp.com:8200"
+  db_url = var.db_connection_string
+  redis_url = module.caching.redis_connection_string
+}
+```
+
+### load_balancing/
+
+Manages Application Load Balancer with HTTPS.
+
+**Inputs:**
+- `name`: ALB name
+- `subnets`: Public subnet IDs
+- `security_groups`: ALB security group IDs
+- `certificate_arn`: ACM certificate ARN
+- `domain_name`: Domain for HTTPS
+- `target_group_name`: Target group name
+- `target_port`: Backend port (8080)
+
+**Outputs:**
+- `alb_dns_name`: ALB DNS (for Route53 CNAME)
+- `target_group_arn`: Target group ARN
+
+**Example:**
+```hcl
+module "load_balancing" {
+  source = "../../modules/load_balancing"
+  
+  name = "stellar-insights-alb-dev"
+  subnets = module.networking.public_subnet_ids
+  security_groups = [module.networking.security_group_alb_id]
+  certificate_arn = "arn:aws:acm:us-east-1:123456789:certificate/..."
+  domain_name = "dev-api.stellar-insights.com"
+  target_port = 8080
+}
+```
+
+### vault/
+
+Reference module for Vault integration (external HCP Cloud).
+
+**Outputs:**
+- `vault_secret_paths`: Map of secret paths in Vault KV v2
+- `vault_oidc_role_arn`: IAM role for GitHub OIDC
+
+See [VAULT_INTEGRATION_GUIDE.md](../VAULT_INTEGRATION_GUIDE.md) for setup instructions.
+
+### monitoring/
+
+Manages CloudWatch logs, metrics, alarms, and dashboards.
+
+**Inputs:**
+- `cluster_name`: ECS cluster name
+- `log_group_names`: Map of log group names
+- `alarm_email`: SNS email for notifications
+- `enable_dashboard`: Create CloudWatch dashboard
+- `enable_alarms`: Create CloudWatch alarms
+
+**Example:**
+```hcl
+module "monitoring" {
+  source = "../../modules/monitoring"
+  
+  cluster_name = module.compute.cluster_name
+  log_group_names = {
+    ecs = module.compute.log_group_name
+  }
+  alarm_email = "ops@stellar-insights.com"
+  enable_dashboard = true
+  enable_alarms = true
+}
+```
+
+## Environment-Specific Configuration
+
+### Development Environment
+
+**Cost Target:** ~$67/month
+
+**Features:**
+- Single NAT gateway
+- No VPC Flow Logs
+- RDS: SQLite local (no RDS)
+- ECS: 1x t3.micro
+- Redis: 1x cache.t3.micro, no failover
+- No CloudWatch alarms
+- No dashboard
+
+**Deploy:**
+```bash
+cd terraform/environments/dev
+terraform init -backend-config="bucket=stellar-insights-terraform-state-ACCOUNT_ID"
+terraform plan
+terraform apply
+```
+
+### Staging Environment
+
+**Cost Target:** ~$205/month
+
+**Features:**
+- Single NAT gateway (can upgrade to HA)
+- VPC Flow Logs enabled
+- RDS: db.t3.small, 100GB, 7-day backups, Single-AZ
+- ECS: 2x t3.small with auto-scaling
+- Redis: 1x cache.t3.small
+- CloudWatch dashboards
+- CloudWatch alarms to email
+
+**Deploy:**
+```bash
+cd terraform/environments/staging
+terraform init -backend-config="bucket=stellar-insights-terraform-state-ACCOUNT_ID"
+terraform plan
+terraform apply
+```
+
+### Production Environment
+
+**Cost Target:** ~$450/month
+
+**Features:**
+- Per-AZ NAT gateways (3x) for HA
+- VPC Flow Logs enabled
+- RDS: db.t3.small, 500GB, Multi-AZ, 30-day backups
+- ECS: 3x t3.small auto-scaled to 10
+- Redis: 3-node cluster with failover
+- All CloudWatch monitoring enabled
+- SNS notifications for critical alarms
+- Deletion protection on critical resources
+
+**Pre-deployment Checklist:**
+- [ ] VPC Flow Logs verified
+- [ ] Database: Backups tested, restore procedure documented
+- [ ] Redis: Failover tested
+- [ ] ALB: HTTPS certificate installed
+- [ ] ECS: Container image tested
+- [ ] Vault: All secrets configured
+- [ ] Monitoring: Alarms tested
+- [ ] DNS: Route53 configured
+- [ ] Security groups: All rules reviewed
+- [ ] Load testing: Verified performance
+
+**Deploy:**
+```bash
+cd terraform/environments/production
+terraform init -backend-config="bucket=stellar-insights-terraform-state-ACCOUNT_ID"
+terraform plan
+terraform apply  # Requires manual confirmation
+```
+
+## Helper Scripts
+
+### bootstrap.sh
+
+Bootstrap the global Terraform state backend (S3 + DynamoDB + ECR).
+
+**Must run first before any other Terraform operations.**
+
+```bash
+./terraform/scripts/bootstrap.sh us-east-1
+```
+
+### init-state.sh
+
+Initialize Terraform remote state for a specific environment.
+
+```bash
+./terraform/scripts/init-state.sh us-east-1 dev
+./terraform/scripts/init-state.sh us-east-1 staging
+./terraform/scripts/init-state.sh us-east-1 production
+```
+
+### plan.sh
+
+Run Terraform plan with validation and cost estimates.
+
+```bash
+./terraform/scripts/plan.sh dev
+terraform show tfplan  # Review detailed plan
+```
+
+### apply.sh
+
+Apply Terraform configuration with safety checks.
+
+```bash
+./terraform/scripts/apply.sh dev
+# Requires confirmation for staging
+# Requires explicit "production-apply" for production
+```
+
+### destroy.sh
+
+Destroy Terraform infrastructure (DANGEROUS!).
+
+```bash
+./terraform/scripts/destroy.sh dev
+# Requires environment name confirmation
+# Requires "destroy-production" for production
+```
+
+## Cost Breakdown
+
+### Development (~$67/month)
+```
+ALB:                $20
+NAT Gateway:        $30
+ECS t3.micro:       $7
+Redis cache:        $5
+Data transfer:      $5
+CloudWatch:         <$1
+Total:              ~$67
+```
+
+### Staging (~$205/month)
+```
+ALB:                $20
+NAT Gateway:        $30
+ECS t3.small (2x):  $60
+RDS t3.small:       $60
+Redis cache:        $20
+Data transfer:      $10
+CloudWatch:         $5
+Total:              ~$205
+```
+
+### Production (~$450/month)
+```
+ALB:                $20
+NAT Gateways (3x):  $90
+ECS t3.small (3x):  $90
+ECS auto-scaling:   $30
+RDS Multi-AZ:       $150
+Redis Multi-AZ:     $40
+Data transfer:      $20
+CloudWatch:         $10
+WAF:                ~$5
+Total:              ~$455
+```
+
+## State Management
+
+### Remote State (S3 + DynamoDB)
+
+Terraform state is stored remotely in S3 for team collaboration:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "stellar-insights-terraform-state-ACCOUNT_ID"
+    key            = "dev/terraform.tfstate"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+    region         = "us-east-1"
+  }
+}
+```
+
+**DynamoDB Lock Table** prevents concurrent modifications.
+
+### State Locking
+
+State is automatically locked during `terraform apply` and `terraform destroy` operations via DynamoDB.
+
+To manually unlock (if lock is stuck):
+```bash
+cd terraform/environments/dev
+terraform force-unlock LOCK_ID
+```
+
+## Common Tasks
+
+### List Resources in Environment
+
+```bash
+cd terraform/environments/dev
+terraform state list
+```
+
+### Show Specific Resource
+
+```bash
+terraform state show module.compute.aws_ecs_cluster.main
+```
+
+### Refresh State from AWS
+
+```bash
+terraform refresh
+```
+
+### Update a Specific Module
+
+```bash
+terraform apply -target=module.compute
+```
+
+### Taint a Resource (force recreation)
+
+```bash
+terraform taint module.compute.aws_ecs_service.app
+terraform apply
+```
+
+### Remove a Resource from State (without destroying)
+
+```bash
+terraform state rm module.monitoring
+# Then delete from configuration
+```
+
+## Troubleshooting
+
+### State Lock Stuck
+
+If Terraform hangs with "Acquiring state lock":
+
+```bash
+# List locks
+aws dynamodb scan --table-name terraform-locks --region us-east-1
+
+# Force unlock (use LockID from above)
+terraform force-unlock <LOCK_ID>
+```
+
+### Module Source Changes
+
+If updating module source path:
+
+```bash
+rm -rf .terraform/modules
+terraform init
+```
+
+### Variable Syntax Errors
+
+Validate syntax:
+
+```bash
+terraform fmt -recursive .
+terraform validate
+```
+
+### Resource Not Found in AWS
+
+Refresh state:
+
+```bash
+terraform refresh
+terraform plan  # Should show no changes if in sync
+```
+
+### Cost Overrun
+
+Check what resources are deployed:
+
+```bash
+terraform show | grep -E "resource|Cost"
+terraform state list
+```
+
+Kill expensive resources:
+
+```bash
+terraform destroy -target=module.name.resource_type.name
+```
+
+## Best Practices
+
+1. **Always Review Plans**: Review `terraform plan` output before `terraform apply`
+2. **Staging First**: Test infrastructure changes in staging before production
+3. **Backup State**: Regular backups of S3 state bucket
+4. **Variable Validation**: Use `validation` blocks in variables.tf
+5. **Documentation**: Update README/TERRAFORM.md with configuration changes
+6. **Lock Mechanism**: Never disable DynamoDB locks
+7. **Secrets in Vault**: Store sensitive data in Vault, never in Terraform
+8. **Auto-scaling Limits**: Set reasonable min/max for auto-scaling groups
+9. **Monitoring Enabled**: Always enable CloudWatch in production
+10. **Disaster Recovery**: Test database backups, snapshot recovery procedures
+
+## CI/CD Integration
+
+### GitHub Actions (existing workflows)
+
+The `.github/workflows/` include:
+- `backend.yml`: Build & test backend
+- `frontend.yml`: Build & test frontend
+- `contracts.yml`: Build Soroban contracts
+- `full-stack.yml`: End-to-end testing
+
+To add Terraform deployment:
+
+```yaml
+name: Terraform Deploy
+
+on:
+  push:
+    branches: [main]
+    paths: ['terraform/**']
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.0
+      
+      - name: Terraform Init
+        working-directory: terraform/environments/staging
+        run: terraform init
+      
+      - name: Terraform Plan
+        working-directory: terraform/environments/staging
+        run: terraform plan -out=tfplan
+      
+      - name: Terraform Apply
+        working-directory: terraform/environments/staging
+        if: github.event_name == 'push'
+        run: terraform apply tfplan
+```
+
+## Support & Documentation
+
+- [AWS Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
+- [Terraform State Management](https://www.terraform.io/language/state)
+- [Vault Integration](../VAULT_INTEGRATION_GUIDE.md)
+- [Architecture Overview](../CORRIDOR_COMPARISON.md)
+
+## Contact
+
+For infrastructure questions or issues:
+- File an issue: https://github.com/Ndifreke000/stellar-insights/issues
+- Tag: `infrastructure`, `terraform`, `aws`

--- a/terraform/environments/dev/main-wired.tf
+++ b/terraform/environments/dev/main-wired.tf
@@ -1,0 +1,229 @@
+terraform {
+  required_version = ">= 1.5"
+
+  backend "s3" {
+    bucket         = "stellar-insights-terraform-state-ACCOUNT_ID"
+    key            = "dev/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = "stellar-insights"
+      ManagedBy   = "terraform"
+      CreatedAt   = timestamp()
+    }
+  }
+}
+
+# Get account ID for ARN construction
+data "aws_caller_identity" "current" {}
+
+# Get ECR repository URLs from global stack
+data "aws_ecr_repository" "backend" {
+  name = "stellar-insights-backend"
+}
+
+# ============================================================================
+# NETWORKING (2 AZs for dev, cost-optimized)
+# ============================================================================
+
+module "networking" {
+  source = "../../modules/networking"
+
+  vpc_cidr                = var.vpc_cidr
+  environment             = var.environment
+  enable_nat_per_az       = false  # Single NAT for dev (cost: ~$30/month)
+  enable_vpc_flow_logs    = false  # Disabled for dev (cost savings)
+  azs                     = 2      # 2 AZs for dev
+}
+
+# ============================================================================
+# CACHING (Redis for dev - single node, minimal cost)
+# ============================================================================
+
+module "caching" {
+  source = "../../modules/caching"
+
+  cache_subnet_group_name = "stellar-insights-cache-${var.environment}"
+  cache_subnet_ids        = module.networking.private_db_subnet_ids
+  security_group_ids      = [module.networking.security_group_redis_id]
+
+  cluster_id               = "stellar-insights-${var.environment}"
+  node_type               = "cache.t3.micro"
+  num_cache_nodes         = 1
+  engine_version          = "7.0"
+  automatic_failover_enabled = false
+  snapshot_retention_limit = 1
+
+  environment = var.environment
+}
+
+# ============================================================================
+# LOAD BALANCING (ALB with HTTPS redirect)
+# ============================================================================
+
+module "load_balancing" {
+  source = "../../modules/load_balancing"
+
+  name               = "stellar-insights-alb-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = module.networking.public_subnet_ids
+  security_groups    = [module.networking.security_group_alb_id]
+
+  target_group_name = "stellar-insights-targets-${var.environment}"
+  target_port       = 8080
+
+  # ACM Certificate (create manually first in AWS Console)
+  # For dev testing, can use self-signed.
+  # Path: AWS Console → ACM → Request certificate → import custom
+  certificate_arn = "arn:aws:acm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:certificate/REPLACE_WITH_CERT_ID"
+  domain_name     = "dev-api.stellar-insights.local"
+
+  # Logging disabled for dev cost savings
+  enable_logs = false
+
+  environment = var.environment
+}
+
+# ============================================================================
+# COMPUTE - ECS CLUSTER
+# ============================================================================
+
+module "compute" {
+  source = "../../modules/compute/ecs"
+
+  cluster_name    = "stellar-insights-${var.environment}"
+  container_image = "${data.aws_ecr_repository.backend.repository_url}:latest"
+  container_port  = 8080
+  container_cpu   = 256
+  container_memory = 512
+
+  desired_count = 1
+  min_size      = 1
+  max_size      = 2
+  instance_type = "t3.micro"
+
+  subnets         = module.networking.private_app_subnet_ids
+  security_groups = [module.networking.security_group_backend_id]
+  target_group_arn = module.load_balancing.target_group_arn
+
+  # Configuration (dev uses SQLite, not RDS)
+  vault_addr = var.vault_addr
+  db_url     = "sqlite:///./stellar_insights.db"
+  redis_url  = module.caching.redis_connection_string
+
+  environment         = var.environment
+  log_retention_days = 7
+  enable_auto_scaling = false
+
+  depends_on = [module.load_balancing]
+}
+
+# ============================================================================
+# VAULT INTEGRATION
+# ============================================================================
+
+module "vault" {
+  source = "../../modules/vault"
+
+  vault_addr  = var.vault_addr
+  environment = var.environment
+}
+
+# ============================================================================
+# MONITORING (Minimal for dev)
+# ============================================================================
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  cluster_name = module.compute.cluster_name
+
+  log_group_names = {
+    ecs = module.compute.log_group_name
+  }
+
+  alarm_email      = var.alarm_email
+  enable_dashboard = false
+  enable_alarms    = false
+
+  environment = var.environment
+}
+
+# ============================================================================
+# OUTPUTS
+# ============================================================================
+
+output "alb_dns_name" {
+  description = "ALB DNS name for accessing the API"
+  value       = module.load_balancing.alb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "Zone ID for Route53 configuration"
+  value       = module.load_balancing.alb_zone_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = module.compute.cluster_name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name"
+  value       = module.compute.service_name
+}
+
+output "redis_endpoint" {
+  description = "Redis cluster endpoint"
+  value       = module.caching.primary_endpoint
+}
+
+output "redis_auth_token" {
+  description = "Redis AUTH token (store in Vault!)"
+  value       = module.caching.auth_token
+  sensitive   = true
+}
+
+output "vault_secret_paths" {
+  description = "Secret paths in Vault KV v2"
+  value       = module.vault.vault_secret_paths
+}
+
+output "cost_estimate" {
+  description = "Estimated monthly cost (includes only AWS services)"
+  value = {
+    description = "Full dev environment including NAT, ALB, ECS, Redis, CloudWatch"
+    alb           = "$20/month"
+    nat_gateway   = "$30/month"
+    ecs_t3_micro  = "$7/month"
+    redis_cache   = "$5/month"
+    data_transfer = "$5/month"
+    cloudwatch    = "<$1/month"
+    total_monthly = "~$68/month"
+  }
+}
+
+# Next steps post-deployment:
+# 1. ACM Certificate: Create or import SSL cert for domain (replace REPLACE_WITH_CERT_ID above)
+# 2. Route53 (optional): Point your domain to ALB DNS name
+# 3. Vault: Run setup-vault-complete.sh after creating HCP account
+# 4. GitHub Actions: Configure VAULT_ADDR and VAULT_TOKEN in repo secrets
+# 5. ECS Deployment: Push backend image to ECR, trigger deployment
+# 6. Health Check: curl https://dev-api.stellar-insights.local/health

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,81 @@
+# Terraform Development Environment Configuration
+# 
+# This environment uses minimal resources for cost efficiency
+# Cost estimate: ~$50-70/month
+# - VPC/networking: ~$10 (NAT gateway is the main cost)
+# - RDS: skipped (uses local SQLite)
+# - ElastiCache: skipped or micro instance
+# - ECS: 1 t3.micro instance
+# - ALB: ~$20/month
+# - Data transfer: ~$10
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Configure remote state after terraform/global/ is applied
+  backend "s3" {
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+
+    # Set bucket name when applying: terraform init -backend-config="bucket=YOUR_BUCKET"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = "dev"
+      Project     = "stellar-insights"
+      ManagedBy   = "Terraform"
+      CostCenter  = "Development"
+    }
+  }
+}
+
+# Call networking module
+module "networking" {
+  source = "../../modules/networking"
+
+  environment           = var.environment
+  aws_region            = var.aws_region
+  vpc_cidr              = var.vpc_cidr
+  enable_nat_per_az     = false  # Single NAT for cost
+  enable_vpc_flow_logs  = false  # Dev doesn't need logs
+  
+  project_name = "stellar-insights"
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+# Outputs for reference
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.networking.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs for ALB"
+  value       = module.networking.public_subnet_ids
+}
+
+output "private_app_subnet_ids" {
+  description = "Private subnet IDs for ECS"
+  value       = module.networking.private_app_subnet_ids
+}
+
+output "availability_zones" {
+  description = "Availability zones used"
+  value       = module.networking.availability_zones
+}

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,0 +1,32 @@
+# Development Environment Variables
+# Cost estimate: $50-70/month
+# 
+# Breakdown:
+#   - NAT Gateway: ~$30/month (single NAT is cheaper than per-AZ)
+#   - ALB: ~$20/month
+#   - ECS (t3.micro): ~$5/month
+#   - Data transfer out: ~$10/month
+#   - RDS: skipped (uses SQLite locally)
+#   - ElastiCache: skipped (uses Redis container for dev)
+
+aws_region = "us-east-1"
+environment = "dev"
+
+# VPC Configuration
+vpc_cidr = "10.0.0.0/16"
+
+# Public subnets for ALB (2 AZs for dev, not 3)
+# private app/db subnets scale to match
+
+# ✓ All resources use minimum cost tiers
+# ✓ No Multi-AZ RDS (only 1 AZ)
+# ✓ No redundant NAT gateways (1 total)
+# ✓ Minimal monitoring (CloudWatch disabled)
+# ✓ Standard (not enhanced) RDS monitoring
+# ✓ No backups beyond 7 days
+
+# Next steps:
+# 1. Run: terraform init -backend-config="bucket=stellar-insights-terraform-state-$(aws sts get-caller-identity --query Account --output text)"
+# 2. Run: terraform plan
+# 3. Review cost: terraform plan | grep -i cost || echo "(run with cost plugin)"
+# 4. Run: terraform apply

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,49 @@
+variable "aws_region" {
+  description = "AWS region for dev environment"
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = contains(["us-east-1", "us-west-2", "eu-west-1", "eu-west-3"], var.aws_region)
+    error_message = "Region must be one of: us-east-1, us-west-2, eu-west-1, eu-west-3"
+  }
+}
+
+variable "environment" {
+  description = "Environment name (dev)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = var.environment == "dev"
+    error_message = "This directory is for dev environment only"
+  }
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block (dev)"
+  type        = string
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be a valid CIDR block"
+  }
+}
+
+variable "vault_addr" {
+  description = "Vault server address (HCP endpoint)"
+  type        = string
+  default     = "https://vault-cluster.vault.11eb.aws.hashicorp.cloud:8200"
+
+  validation {
+    condition     = can(regex("^https://", var.vault_addr))
+    error_message = "Vault address must be an HTTPS URL"
+  }
+}
+
+variable "alarm_email" {
+  description = "Email for alarms (dev: not used)"
+  type        = string
+  default     = "noreply@example.com"
+}

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,0 +1,262 @@
+terraform {
+  required_version = ">= 1.5"
+
+  backend "s3" {
+    bucket         = "stellar-insights-terraform-state-ACCOUNT_ID"
+    key            = "production/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = "stellar-insights"
+      ManagedBy   = "terraform"
+      CreatedAt   = timestamp()
+    }
+  }
+}
+
+# Get account ID and ECR repositories
+data "aws_caller_identity" "current" {}
+data "aws_ecr_repository" "backend" {
+  name = "stellar-insights-backend"
+}
+
+# ============================================================================
+# NETWORKING (3 AZs, Full HA)
+# ============================================================================
+
+module "networking" {
+  source = "../../modules/networking"
+
+  vpc_cidr                = var.vpc_cidr
+  environment             = var.environment
+  enable_nat_per_az       = true   # Per-AZ NAT for HA
+  enable_vpc_flow_logs    = true   # Enable for security & compliance
+  azs                     = 3      # 3 AZs for full HA
+}
+
+# ============================================================================
+# DATABASE (RDS PostgreSQL - Multi-AZ)
+# ============================================================================
+
+module "database" {
+  source = "../../modules/database"
+
+  db_subnet_group_name = "stellar-insights-db-${var.environment}"
+  vpc_security_group_ids = [module.networking.security_group_database_id]
+  db_subnet_ids        = module.networking.private_db_subnet_ids
+
+  identifier         = "stellar-insights-${var.environment}"
+  instance_class     = "db.t3.small"
+  allocated_storage  = 500
+  storage_type       = "gp3"
+  engine_version     = "14.8"
+
+  multi_az                 = true   # Full failover
+  backup_retention_period  = 30     # 30-day retention
+  enable_cloudwatch_logs_exports = ["postgresql"]
+  enable_enhanced_monitoring = true
+  monitoring_interval      = 60
+
+  environment = var.environment
+
+  depends_on = [module.networking]
+}
+
+# ============================================================================
+# CACHING (Redis - Multi-AZ)
+# ============================================================================
+
+module "caching" {
+  source = "../../modules/caching"
+
+  cache_subnet_group_name = "stellar-insights-cache-${var.environment}"
+  cache_subnet_ids        = module.networking.private_db_subnet_ids
+  security_group_ids      = [module.networking.security_group_redis_id]
+
+  cluster_id               = "stellar-insights-${var.environment}"
+  node_type               = "cache.t3.small"
+  num_cache_nodes         = 3  # Multi-AZ with replicas
+  engine_version          = "7.0"
+  automatic_failover_enabled = true
+  snapshot_retention_limit = 14
+
+  environment = var.environment
+
+  depends_on = [module.networking]
+}
+
+# ============================================================================
+# LOAD BALANCING (ALB with HTTPS + WAF)
+# ============================================================================
+
+module "load_balancing" {
+  source = "../../modules/load_balancing"
+
+  name               = "stellar-insights-alb-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = module.networking.public_subnet_ids
+  security_groups    = [module.networking.security_group_alb_id]
+
+  target_group_name = "stellar-insights-targets-${var.environment}"
+  target_port       = 8080
+
+  # ACM certificate (wildcard or specific domain)
+  certificate_arn = "arn:aws:acm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:certificate/REPLACE_WITH_CERT_ID"
+  domain_name     = "api.stellar-insights.com"
+
+  # Enable request logging to S3
+  enable_logs = false  # Set to true if S3 bucket exists for ALB logs
+
+  # WAF can be enabled separately
+  enable_waf = false   # Set to true if WAF Web ACL exists
+
+  environment = var.environment
+
+  depends_on = [module.networking]
+}
+
+# ============================================================================
+# COMPUTE - ECS CLUSTER (HA with auto-scaling)
+# ============================================================================
+
+module "compute" {
+  source = "../../modules/compute/ecs"
+
+  cluster_name    = "stellar-insights-${var.environment}"
+  container_image = "${data.aws_ecr_repository.backend.repository_url}:latest"
+  container_port  = 8080
+  container_cpu   = 512
+  container_memory = 1024
+
+  desired_count = 3
+  min_size      = 3  # Always at least 3 for HA
+  max_size      = 10 # Scale up for traffic spikes
+  instance_type = "t3.small"
+
+  subnets         = module.networking.private_app_subnet_ids
+  security_groups = [module.networking.security_group_backend_id]
+  target_group_arn = module.load_balancing.target_group_arn
+
+  # Configuration
+  vault_addr = var.vault_addr
+  db_url     = "postgresql://postgres@${module.database.rds_address}:5432/stellar_insights"
+  redis_url  = module.caching.redis_connection_string
+
+  environment         = var.environment
+  log_retention_days = 30  # Full retention for production
+  enable_auto_scaling = true
+  cpu_target_percentage = 70
+
+  depends_on = [module.load_balancing, module.database, module.caching]
+}
+
+# ============================================================================
+# VAULT INTEGRATION
+# ============================================================================
+
+module "vault" {
+  source = "../../modules/vault"
+
+  vault_addr  = var.vault_addr
+  environment = var.environment
+}
+
+# ============================================================================
+# MONITORING (Full monitoring for production)
+# ============================================================================
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  cluster_name = module.compute.cluster_name
+
+  log_group_names = {
+    ecs = module.compute.log_group_name
+  }
+
+  alarm_email      = var.alarm_email
+  enable_dashboard = true
+  enable_alarms    = true
+
+  environment = var.environment
+}
+
+# ============================================================================
+# OUTPUTS
+# ============================================================================
+
+output "alb_dns_name" {
+  description = "ALB DNS name for Route53"
+  value       = module.load_balancing.alb_dns_name
+}
+
+output "database_endpoint" {
+  description = "RDS PostgreSQL endpoint (Multi-AZ)"
+  value       = module.database.rds_endpoint
+  sensitive   = false
+}
+
+output "redis_endpoints" {
+  description = "Redis primary and replica endpoints"
+  value       = module.caching.redis_connection_string
+  sensitive   = true
+}
+
+output "vault_secret_paths" {
+  description = "Vault secret paths"
+  value       = module.vault.vault_secret_paths
+}
+
+output "cost_estimate" {
+  description = "Estimated monthly cost for production (HA)"
+  value = {
+    alb                = "$20/month"
+    nat_gateways_3az   = "$90/month"  # $30 × 3
+    ecs_t3_small_3x    = "$90/month"
+    ecs_autoscaling    = "$30/month"  # Additional scaling capacity
+    rds_t3_small_multiaz = "$150/month"
+    redis_3_node_multiaz = "$40/month"
+    data_transfer      = "$20/month"
+    cloudwatch_logs    = "$10/month"
+    waf_optional       = "$5/month"
+    total_monthly      = "~$455/month"
+  }
+}
+
+# ============================================================================
+# PRE-DEPLOYMENT CHECKLIST
+# ============================================================================
+#
+# [ ] VPC and networking deployed and tested
+# [ ] Database: RDS created, backups tested, restore procedure documented
+# [ ] Cache: Redis cluster healthy, failover tested
+# [ ] ALB: Health checks passing, HTTPS listener functional
+# [ ] ECS: Tasks deploying successfully, logs flowing
+# [ ] Vault: Secrets configured, GitHub Actions authenticated
+# [ ] Monitoring: Alarms configured, SNS notifications tested
+# [ ] DNS: Route53 records pointing to ALB
+# [ ] Security: Security groups properly configured, NACLs reviewed
+# [ ] Load testing: Verified 100+ req/sec, auto-scaling functional
+# [ ] Disaster recovery: Backup/restore procedures tested
+# [ ] On-call playbooks created and reviewed
+# [ ] Team trained on incident response
+#
+# Post-deployment: Monitor CloudWatch dashboard, validate logs, test failover
+

--- a/terraform/environments/production/terraform.tfvars
+++ b/terraform/environments/production/terraform.tfvars
@@ -1,0 +1,48 @@
+# Production Environment Variables
+# Cost estimate: $400-600/month
+#
+# Breakdown:
+#   - NAT Gateways: ~$90/month (3 total, 1 per AZ for HA)
+#   - ALB: ~$20/month
+#   - ECS (t3.small, 3 instances): ~$90/month
+#   - RDS PostgreSQL (db.t3.small Multi-AZ, 500GB): ~$150-200/month
+#   - ElastiCache Redis (cache.t3.small, Multi-AZ): ~$40/month
+#   - Data transfer out: ~$30-50/month
+#
+# ✓ Full high availability (3 AZs)
+# ✓ Multi-AZ RDS with automatic failover
+# ✓ Multi-AZ Redis with automatic failover
+# ✓ 30-day backup retention for RDS
+# ✓ CloudWatch monitoring and alarms
+# ✓ VPC Flow Logs for security and troubleshooting
+# ✓ Auto-scaling enabled (ECS scale to 2-4 instances)
+#
+# IMPORTANT: This is a PRODUCTION environment
+# - All changes require code review and approval
+# - All deployments via GitHub Actions CI/CD
+# - NO manual terraform apply on production
+# - All database changes must be tested in staging first
+
+aws_region  = "us-east-1"
+environment = "production"
+vpc_cidr    = "10.2.0.0/16"
+
+# Pre-deployment Checklist:
+# [ ] All Vault secrets configured (DATABASE_URL, JWT_SECRET, OAuth credentials, etc)
+# [ ] SSL/TLS certificates in ACM for domain
+# [ ] Route53 DNS records configured and tested
+# [ ] RDS backup and restore tested in staging
+# [ ] CloudWatch alarms configured and tested
+# [ ] GitHub Actions variable secrets in place
+# [ ] Zapier webhooks registered and tested
+# [ ] Load test completed: min 100 req/sec
+# [ ] Spike test completed: 10x traffic surge handling
+#
+# Post-deployment Validation:
+# [ ] Health check: GET /health returning 200 OK
+# [ ] Database connectivity verified
+# [ ] Vault secrets accessible
+# [ ] CloudWatch logs flowing
+# [ ] Alerts configured and tested (intentional spike)
+# [ ] Logging and monitoring dashboards active
+# [ ] Runbook reviewed by on-call team

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -1,0 +1,54 @@
+variable "aws_region" {
+  description = "AWS region for production environment"
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = contains(["us-east-1", "us-west-2", "eu-west-1", "eu-west-3"], var.aws_region)
+    error_message = "Region must be one of: us-east-1, us-west-2, eu-west-1, eu-west-3"
+  }
+}
+
+variable "environment" {
+  description = "Environment name (production)"
+  type        = string
+  default     = "production"
+
+  validation {
+    condition     = var.environment == "production"
+    error_message = "This directory is for production environment only"
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC (production)"
+  type        = string
+  default     = "10.2.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be a valid CIDR block"
+  }
+}
+
+variable "vault_addr" {
+  description = "Vault server address (HCP endpoint)"
+  type        = string
+  default     = "https://vault-cluster.vault.11eb.aws.hashicorp.cloud:8200"
+
+  validation {
+    condition     = can(regex("^https://", var.vault_addr))
+    error_message = "Vault address must be an HTTPS URL"
+  }
+}
+
+variable "alarm_email" {
+  description = "Email for critical CloudWatch alarms"
+  type        = string
+  default     = "ops-critical@stellar-insights.com"
+
+  validation {
+    condition     = can(regex("^[\\w.+-]+@[\\w.-]+\\.\\w+$", var.alarm_email))
+    error_message = "Alarm email must be a valid email address"
+  }
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,0 +1,235 @@
+terraform {
+  required_version = ">= 1.5"
+
+  backend "s3" {
+    bucket         = "stellar-insights-terraform-state-ACCOUNT_ID"
+    key            = "staging/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = "stellar-insights"
+      ManagedBy   = "terraform"
+      CreatedAt   = timestamp()
+    }
+  }
+}
+
+# Get account ID and ECR repositories
+data "aws_caller_identity" "current" {}
+data "aws_ecr_repository" "backend" {
+  name = "stellar-insights-backend"
+}
+
+# ============================================================================
+# NETWORKING (2 AZs, Multi-AZ ready)
+# ============================================================================
+
+module "networking" {
+  source = "../../modules/networking"
+
+  vpc_cidr                = var.vpc_cidr
+  environment             = var.environment
+  enable_nat_per_az       = false  # Single NAT for cost (can enable for HA)
+  enable_vpc_flow_logs    = true   # Enable for staging compliance
+  azs                     = 2      # 2 AZs for staging
+}
+
+# ============================================================================
+# DATABASE (RDS PostgreSQL - staging only)
+# ============================================================================
+
+module "database" {
+  source = "../../modules/database"
+
+  db_subnet_group_name = "stellar-insights-db-${var.environment}"
+  vpc_security_group_ids = [module.networking.security_group_database_id]
+  db_subnet_ids        = module.networking.private_db_subnet_ids
+
+  identifier         = "stellar-insights-${var.environment}"
+  instance_class     = "db.t3.small"
+  allocated_storage  = 100
+  storage_type       = "gp3"
+  engine_version     = "14.8"
+
+  multi_az                 = false  # Single-AZ for staging cost efficiency
+  backup_retention_period  = 7
+  enable_cloudwatch_logs_exports = ["postgresql"]
+  enable_enhanced_monitoring = false
+
+  environment = var.environment
+
+  depends_on = [module.networking]
+}
+
+# ============================================================================
+# CACHING (Redis - single node for staging)
+# ============================================================================
+
+module "caching" {
+  source = "../../modules/caching"
+
+  cache_subnet_group_name = "stellar-insights-cache-${var.environment}"
+  cache_subnet_ids        = module.networking.private_db_subnet_ids
+  security_group_ids      = [module.networking.security_group_redis_id]
+
+  cluster_id               = "stellar-insights-${var.environment}"
+  node_type               = "cache.t3.small"
+  num_cache_nodes         = 1
+  engine_version          = "7.0"
+  automatic_failover_enabled = false
+  snapshot_retention_limit = 7
+
+  environment = var.environment
+
+  depends_on = [module.networking]
+}
+
+# ============================================================================
+# LOAD BALANCING (ALB with HTTPS)
+# ============================================================================
+
+module "load_balancing" {
+  source = "../../modules/load_balancing"
+
+  name               = "stellar-insights-alb-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = module.networking.public_subnet_ids
+  security_groups    = [module.networking.security_group_alb_id]
+
+  target_group_name = "stellar-insights-targets-${var.environment}"
+  target_port       = 8080
+
+  # ACM certificate (create manually first)
+  certificate_arn = "arn:aws:acm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:certificate/REPLACE_WITH_CERT_ID"
+  domain_name     = "staging-api.stellar-insights.com"
+
+  # Logging disabled for cost
+  enable_logs = false
+
+  environment = var.environment
+
+  depends_on = [module.networking]
+}
+
+# ============================================================================
+# COMPUTE - ECS CLUSTER
+# ============================================================================
+
+module "compute" {
+  source = "../../modules/compute/ecs"
+
+  cluster_name    = "stellar-insights-${var.environment}"
+  container_image = "${data.aws_ecr_repository.backend.repository_url}:latest"
+  container_port  = 8080
+  container_cpu   = 512
+  container_memory = 1024
+
+  desired_count = 2
+  min_size      = 2
+  max_size      = 4
+  instance_type = "t3.small"
+
+  subnets         = module.networking.private_app_subnet_ids
+  security_groups = [module.networking.security_group_backend_id]
+  target_group_arn = module.load_balancing.target_group_arn
+
+  # Configuration
+  vault_addr = var.vault_addr
+  db_url     = "postgresql://postgres@${module.database.rds_address}:5432/stellar_insights"
+  redis_url  = module.caching.redis_connection_string
+
+  environment         = var.environment
+  log_retention_days = 14
+  enable_auto_scaling = true
+  cpu_target_percentage = 70
+
+  depends_on = [module.load_balancing, module.database, module.caching]
+}
+
+# ============================================================================
+# VAULT INTEGRATION
+# ============================================================================
+
+module "vault" {
+  source = "../../modules/vault"
+
+  vault_addr  = var.vault_addr
+  environment = var.environment
+}
+
+# ============================================================================
+# MONITORING (Standard for staging)
+# ============================================================================
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  cluster_name = module.compute.cluster_name
+
+  log_group_names = {
+    ecs = module.compute.log_group_name
+  }
+
+  alarm_email      = var.alarm_email
+  enable_dashboard = true
+  enable_alarms    = true
+
+  environment = var.environment
+}
+
+# ============================================================================
+# OUTPUTS
+# ============================================================================
+
+output "alb_dns_name" {
+  description = "ALB DNS name for Route53"
+  value       = module.load_balancing.alb_dns_name
+}
+
+output "database_endpoint" {
+  description = "RDS PostgreSQL endpoint"
+  value       = module.database.rds_endpoint
+  sensitive   = false
+}
+
+output "redis_endpoint" {
+  description = "Redis endpoint"
+  value       = module.caching.primary_endpoint
+}
+
+output "vault_secret_paths" {
+  description = "Vault secret paths"
+  value       = module.vault.vault_secret_paths
+}
+
+output "cost_estimate" {
+  description = "Estimated monthly cost for staging"
+  value = {
+    alb              = "$20/month"
+    nat_gateway      = "$30/month"
+    ecs_t3_small     = "$60/month"
+    rds_t3_small     = "$60/month"
+    redis_cache      = "$20/month"
+    data_transfer    = "$10/month"
+    cloudwatch_logs  = "$5/month"
+    total_monthly    = "~$205/month"
+  }
+}
+

--- a/terraform/environments/staging/terraform.tfvars
+++ b/terraform/environments/staging/terraform.tfvars
@@ -1,0 +1,31 @@
+# Staging Environment Variables
+# Cost estimate: $150-200/month
+#
+# Breakdown:
+#   - NAT Gateway: ~$30/month (1 for cost efficiency)
+#   - ALB: ~$20/month
+#   - ECS (t3.small): ~$30/month
+#   - RDS PostgreSQL (db.t3.small, 100GB): ~$60/month
+#   - ElastiCache Redis (cache.t3.small, single node): ~$20/month
+#   - Data transfer out: ~$20-30/month
+#
+# ✓ Adequate for testing and integration testing
+# ✓ Automatic RDS backups (7 days retention)
+# ✓ CloudWatch monitoring enabled
+# ✓ 2 AZs (not fully redundant, cost-optimized)
+
+aws_region  = "us-east-1"
+environment = "staging"
+vpc_cidr    = "10.1.0.0/16"
+
+# Next steps:
+# 1. Ensure terraform/global/ has been applied (S3 state bucket, DynamoDB locks)
+# 2. Run: terraform init -backend-config="bucket=stellar-insights-terraform-state-$(aws sts get-caller-identity --query Account --output text)"
+# 3. Run: terraform plan
+# 4. Run: terraform apply
+#
+# When complete:
+# - Note RDS endpoint from outputs
+# - Configure VAULT_ADDR in GitHub Actions
+# - Run Vault setup scripts: scripts/setup-vault-complete.sh
+# - Test: psql -h <rds_endpoint> -U postgres -d stellar_insights

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -1,0 +1,54 @@
+variable "aws_region" {
+  description = "AWS region for staging environment"
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = contains(["us-east-1", "us-west-2", "eu-west-1", "eu-west-3"], var.aws_region)
+    error_message = "Region must be one of: us-east-1, us-west-2, eu-west-1, eu-west-3"
+  }
+}
+
+variable "environment" {
+  description = "Environment name (staging)"
+  type        = string
+  default     = "staging"
+
+  validation {
+    condition     = var.environment == "staging"
+    error_message = "This directory is for staging environment only"
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC (staging)"
+  type        = string
+  default     = "10.1.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be a valid CIDR block"
+  }
+}
+
+variable "vault_addr" {
+  description = "Vault server address (HCP endpoint)"
+  type        = string
+  default     = "https://vault-cluster.vault.11eb.aws.hashicorp.cloud:8200"
+
+  validation {
+    condition     = can(regex("^https://", var.vault_addr))
+    error_message = "Vault address must be an HTTPS URL"
+  }
+}
+
+variable "alarm_email" {
+  description = "Email for CloudWatch alarm notifications"
+  type        = string
+  default     = "ops-team@stellar-insights.com"
+
+  validation {
+    condition     = can(regex("^[\\w.+-]+@[\\w.-]+\\.\\w+$", var.alarm_email))
+    error_message = "Alarm email must be a valid email address"
+  }
+}

--- a/terraform/global/README.md
+++ b/terraform/global/README.md
@@ -1,0 +1,60 @@
+# Terraform Global Setup Bootstrap
+
+This directory sets up the foundational AWS infrastructure:
+- **S3 bucket** for Terraform remote state (with versioning, encryption, MFA delete)
+- **ECR repositories** for Docker images (backend, frontend)
+- **IAM roles** for Terraform execution
+- **DynamoDB table** for state locking
+
+## ⚠️ BOOTSTRAP PROCESS (Critical)
+
+This module must be applied **FIRST and ONLY ONCE** before any other Terraform modules.
+
+### Step 1: Create AWS Backend Resources Locally
+```bash
+cd terraform/global/
+terraform init
+terraform plan
+terraform apply
+```
+
+**Do NOT set remote state for this module** — it needs local state while creating the S3 bucket.
+
+### Step 2: Enable Remote State in Other Modules
+After `terraform apply` completes, other modules will reference the S3 bucket and DynamoDB table via `backend.tf`:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "stellar-insights-terraform-state-${aws_account_id}"
+    key            = "${environment}/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}
+```
+
+### Step 3: Copy Outputs
+```bash
+terraform output
+# Copy values to environments/*/terraform.tfvars
+```
+
+## Variables
+- `aws_region` - Default: `us-east-1`
+- `environment` - Default: `dev`
+- `enable_mfa_delete` - Default: `false` (enable for production)
+
+## Outputs
+- `state_bucket_name` - S3 bucket for Terraform state
+- `dynamodb_table_name` - Lock table name
+- `ecr_backend_repository_url` - ECR for backend Docker image
+- `ecr_frontend_repository_url` - ECR for frontend Docker image
+
+## Important Notes
+- This module creates long-lived AWS resources
+- **DO NOT destroy this module** unless you plan to lose all Terraform state
+- S3 bucket has versioning enabled (recover old states)
+- Encryption at rest (SSE-S3)
+- Block public access enabled

--- a/terraform/global/dynamodb.tf
+++ b/terraform/global/dynamodb.tf
@@ -1,0 +1,42 @@
+# DynamoDB table for Terraform state locking
+# Prevents concurrent modifications when multiple people run terraform apply
+# One lock per state file (key = path/to/terraform.tfstate)
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name           = var.state_lock_table_name
+  billing_mode   = "PAY_PER_REQUEST"  # No minimum cost, scales automatically
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  ttl {
+    attribute_name = "Expiration"
+    enabled        = true
+  }
+
+  tags = {
+    Name    = "Terraform State Locks"
+    Purpose = "Prevent concurrent terraform applies"
+  }
+}
+
+output "dynamodb_table_name" {
+  description = "Name of DynamoDB table for state locking"
+  value       = aws_dynamodb_table.terraform_locks.name
+}
+
+output "dynamodb_table_arn" {
+  description = "ARN of DynamoDB lock table"
+  value       = aws_dynamodb_table.terraform_locks.arn
+}

--- a/terraform/global/ecr.tf
+++ b/terraform/global/ecr.tf
@@ -1,0 +1,131 @@
+# ECR (Elastic Container Registry) repositories for Docker images
+# Stores: backend, frontend Docker images for deployment
+
+resource "aws_ecr_repository" "backend" {
+  name                 = "stellar-insights-backend"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Name        = "Backend Docker Repository"
+    Service     = "backend"
+    Description = "Rust backend service image"
+  }
+}
+
+resource "aws_ecr_repository" "frontend" {
+  name                 = "stellar-insights-frontend"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Name        = "Frontend Docker Repository"
+    Service     = "frontend"
+    Description = "Next.js frontend application image"
+  }
+}
+
+# ECR lifecycle policy: keep only N images (auto-delete old versions)
+resource "aws_ecr_lifecycle_policy" "backend" {
+  repository = aws_ecr_repository.backend.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last N images"
+        selection = {
+          tagStatus             = "tagged"
+          tagPrefixList         = ["v"]
+          countType             = "imageCountMoreThan"
+          countNumber           = var.ecr_image_retention_count
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Delete untagged images after 7 days"
+        selection = {
+          tagStatus     = "untagged"
+          countType     = "sinceImagePushed"
+          countUnit     = "days"
+          countNumber   = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_lifecycle_policy" "frontend" {
+  repository = aws_ecr_repository.frontend.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last N images"
+        selection = {
+          tagStatus             = "tagged"
+          tagPrefixList         = ["v"]
+          countType             = "imageCountMoreThan"
+          countNumber           = var.ecr_image_retention_count
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Delete untagged images after 7 days"
+        selection = {
+          tagStatus     = "untagged"
+          countType     = "sinceImagePushed"
+          countUnit     = "days"
+          countNumber   = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+output "ecr_backend_repository_url" {
+  description = "ECR URL for backend Docker image"
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "ecr_backend_repository_arn" {
+  description = "ARN of backend ECR repository"
+  value       = aws_ecr_repository.backend.arn
+}
+
+output "ecr_frontend_repository_url" {
+  description = "ECR URL for frontend Docker image"
+  value       = aws_ecr_repository.frontend.repository_url
+}
+
+output "ecr_frontend_repository_arn" {
+  description = "ARN of frontend ECR repository"
+  value       = aws_ecr_repository.frontend.arn
+}

--- a/terraform/global/iam.tf
+++ b/terraform/global/iam.tf
@@ -1,0 +1,209 @@
+# IAM roles and policies for Terraform execution
+# These roles are used by CI/CD (GitHub Actions) and local Terraform runs
+
+# Role for Terraform execution (CI/CD)
+resource "aws_iam_role" "terraform_executor" {
+  name               = "terraform-executor"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+      },
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:Ndifreke000/stellar-insights:*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "Terraform Executor Role"
+    Purpose     = "Allow Terraform to provision AWS resources"
+  }
+}
+
+# Attach policy for state management
+resource "aws_iam_role_policy" "terraform_state" {
+  name   = "terraform-state-access"
+  role   = aws_iam_role.terraform_executor.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3StateAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.terraform_state.arn,
+          "${aws_s3_bucket.terraform_state.arn}/*"
+        ]
+      },
+      {
+        Sid    = "DynamoDBLocking"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query"
+        ]
+        Resource = aws_dynamodb_table.terraform_locks.arn
+      }
+    ]
+  })
+}
+
+# Attach policy for infrastructure provisioning
+# This is scoped to common infrastructure resources
+resource "aws_iam_role_policy" "terraform_infrastructure" {
+  name   = "terraform-infrastructure"
+  role   = aws_iam_role.terraform_executor.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EC2"
+        Effect = "Allow"
+        Action = [
+          "ec2:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "RDS"
+        Effect = "Allow"
+        Action = [
+          "rds:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ElastiCache"
+        Effect = "Allow"
+        Action = [
+          "elasticache:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECS"
+        Effect = "Allow"
+        Action = [
+          "ecs:*",
+          "ec2:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ALB"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECR"
+        Effect = "Allow"
+        Action = [
+          "ecr:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "IAM"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:GetRole",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:CreateInstanceProfile",
+          "iam:DeleteInstanceProfile",
+          "iam:AddRoleToInstanceProfile",
+          "iam:RemoveRoleFromInstanceProfile",
+          "iam:PassRole",
+          "iam:ListRolePolicies"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "KMS"
+        Effect = "Allow"
+        Action = [
+          "kms:CreateKey",
+          "kms:CreateAlias",
+          "kms:DeleteAlias",
+          "kms:DescribeKey",
+          "kms:GetKeyPolicy",
+          "kms:PutKeyPolicy",
+          "kms:ListAliases"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "CloudWatch"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DeleteLogGroup",
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DeleteAlarms"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "Route53"
+        Effect = "Allow"
+        Action = [
+          "route53:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ACM"
+        Effect = "Allow"
+        Action = [
+          "acm:RequestCertificate",
+          "acm:DescribeCertificate",
+          "acm:ListCertificates",
+          "acm:DeleteCertificate"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+output "terraform_executor_role_arn" {
+  description = "ARN of Terraform executor role"
+  value       = aws_iam_role.terraform_executor.arn
+}
+
+output "terraform_executor_role_name" {
+  description = "Name of Terraform executor role"
+  value       = aws_iam_role.terraform_executor.name
+}

--- a/terraform/global/outputs.tf
+++ b/terraform/global/outputs.tf
@@ -1,0 +1,56 @@
+# Outputs for terraform/global
+# These values are referenced by environment-specific modules
+
+output "account_id" {
+  description = "AWS account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "aws_region" {
+  description = "AWS region"
+  value       = var.aws_region
+}
+
+output "environment" {
+  description = "Environment name"
+  value       = var.environment
+}
+
+# S3 state bucket outputs
+output "terraform_state_bucket" {
+  description = "S3 bucket for Terraform state"
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "terraform_state_bucket_arn" {
+  description = "ARN of Terraform state bucket"
+  value       = aws_s3_bucket.terraform_state.arn
+}
+
+# DynamoDB lock table outputs
+output "terraform_lock_table" {
+  description = "DynamoDB table for state locking"
+  value       = aws_dynamodb_table.terraform_locks.name
+}
+
+output "terraform_lock_table_arn" {
+  description = "ARN of DynamoDB lock table"
+  value       = aws_dynamodb_table.terraform_locks.arn
+}
+
+# ECR outputs
+output "ecr_backend_url" {
+  description = "ECR URL for backend image"
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "ecr_frontend_url" {
+  description = "ECR URL for frontend image"
+  value       = aws_ecr_repository.frontend.repository_url
+}
+
+# IAM outputs
+output "terraform_executor_role_arn" {
+  description = "ARN for Terraform executor IAM role"
+  value       = aws_iam_role.terraform_executor.arn
+}

--- a/terraform/global/s3.tf
+++ b/terraform/global/s3.tf
@@ -1,0 +1,115 @@
+# S3 bucket for Terraform remote state
+# This bucket stores the Terraform state file for all infrastructure
+# Security: versioning, encryption, block public access, MFA delete
+
+# Generate unique bucket name
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  special = false
+  lower   = true
+}
+
+locals {
+  state_bucket_name = "${var.terraform_state_bucket_prefix}-terraform-state-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = local.state_bucket_name
+
+  tags = {
+    Name      = "Terraform State"
+    Purpose   = "Remote state for Terraform"
+    Lifecycle = "Critical"
+  }
+}
+
+# Enable versioning to recover previous states
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status     = var.enable_versioning ? "Enabled" : "Suspended"
+    mfa_delete = var.enable_mfa_delete ? "Enabled" : "Disabled"
+  }
+}
+
+# Enable server-side encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Block all public access
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Enable access logging
+resource "aws_s3_bucket_logging" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  target_bucket = aws_s3_bucket.terraform_state_logs.id
+  target_prefix = "terraform-state-logs/"
+}
+
+# Separate bucket for access logs
+resource "aws_s3_bucket" "terraform_state_logs" {
+  bucket = "${local.state_bucket_name}-logs"
+
+  tags = {
+    Name    = "Terraform State Logs"
+    Purpose = "Access logs for state bucket"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state_logs" {
+  bucket = aws_s3_bucket.terraform_state_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Lifecycle policy to delete old logs after 90 days
+resource "aws_s3_bucket_lifecycle_configuration" "terraform_state_logs" {
+  bucket = aws_s3_bucket.terraform_state_logs.id
+
+  rule {
+    id     = "delete-old-logs"
+    status = "Enabled"
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+# Data source for AWS account ID (used in bucket naming)
+data "aws_caller_identity" "current" {}
+
+# Output bucket information
+output "state_bucket_name" {
+  description = "Name of the S3 bucket for Terraform state"
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "state_bucket_arn" {
+  description = "ARN of the S3 bucket for Terraform state"
+  value       = aws_s3_bucket.terraform_state.arn
+}
+
+output "state_bucket_region" {
+  description = "Region where state bucket is located"
+  value       = aws_s3_bucket.terraform_state.region
+}

--- a/terraform/global/variables.tf
+++ b/terraform/global/variables.tf
@@ -1,0 +1,66 @@
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-\\d{1}$", var.aws_region))
+    error_message = "AWS region must be valid (e.g., us-east-1)"
+  }
+}
+
+variable "environment" {
+  description = "Environment name (dev/staging/production)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be dev, staging, or production"
+  }
+}
+
+variable "enable_mfa_delete" {
+  description = "Enable MFA delete on S3 bucket (for production only)"
+  type        = bool
+  default     = false
+}
+
+variable "terraform_state_bucket_prefix" {
+  description = "Prefix for Terraform state bucket name"
+  type        = string
+  default     = "stellar-insights"
+}
+
+variable "enable_versioning" {
+  description = "Enable S3 versioning for state recovery"
+  type        = bool
+  default     = true
+}
+
+variable "state_lock_table_name" {
+  description = "Name of DynamoDB table for Terraform locks"
+  type        = string
+  default     = "terraform-locks"
+}
+
+variable "ecr_image_retention_count" {
+  description = "Number of images to retain in ECR (older images auto-deleted)"
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.ecr_image_retention_count > 0 && var.ecr_image_retention_count <= 100
+    error_message = "ECR image retention must be between 1-100"
+  }
+}
+
+variable "tags" {
+  description = "Common tags for all resources"
+  type        = map(string)
+  default = {
+    Owner       = "DevOps"
+    CostCenter  = "Infrastructure"
+    Terraform   = "true"
+  }
+}

--- a/terraform/global/versions.tf
+++ b/terraform/global/versions.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # NOTE: This module MUST be applied with local state first
+  # Other modules will use remote S3 backend after this
+  # Do NOT configure backend here
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "stellar-insights"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+      CreatedAt   = timestamp()
+    }
+  }
+}

--- a/terraform/modules/caching/README.md
+++ b/terraform/modules/caching/README.md
@@ -1,0 +1,97 @@
+# Caching Module
+
+Manages AWS ElastiCache Redis clusters for Stellar Insights caching layer.
+
+## Features
+
+- Redis 7.x engine with automatic patching
+- Automatic backup and failover
+- CloudWatch monitoring and alarms  
+- Parameter groups for performance tuning
+- Multi-AZ replication (production only)
+- Automatic failover with read replicas
+- VPC endpoint for secure access
+- Encryption at rest and in transit
+
+## Usage
+
+```hcl
+module "caching" {
+  source = "../../modules/caching"
+
+  # Networking
+  cache_subnet_group_name = aws_elasticache_subnet_group.cache.name
+  security_group_ids      = [aws_security_group.redis.id]
+  
+  # Instance configuration
+  cluster_id      = "stellar-insights-${var.environment}"
+  node_type       = "cache.t3.small"  # cache.t3.micro for dev
+  num_cache_nodes = var.environment == "production" ? 3 : 1
+  engine_version  = "7.0"
+  
+  # Automatic failover
+  automatic_failover_enabled = var.environment == "production"
+  
+  # Backup
+  snapshot_retention_limit = var.environment == "dev" ? 1 : (var.environment == "staging" ? 7 : 14)
+  snapshot_window          = "03:00-04:00"
+  
+  environment = var.environment
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| cache_subnet_group_name | ElastiCache subnet group name | `string` | Yes |
+| security_group_ids | Security group IDs | `list(string)` | Yes |
+| cluster_id | ElastiCache cluster identifier | `string` | Yes |
+| node_type | Node instance type (cache.t3.*) | `string` | Yes |
+| num_cache_nodes | Number of cache nodes | `number` | Yes |
+| engine_version | Redis engine version | `string` | No (default: `7.0`) |
+| automatic_failover_enabled | Enable automatic failover | `bool` | No (default: `false`) |
+| snapshot_retention_limit | Backup retention in days | `number` | No (default: `0`) |
+| snapshot_window | Backup window (UTC) | `string` | No |
+| automatic_failover_enabled | Enable auto-failover for Multi-AZ | `bool` | No |
+| environment | Environment name | `string` | Yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| primary_endpoint | Primary endpoint address:port |
+| reader_endpoint | Reader endpoint address:port (if Multi-AZ) |
+| configuration_endpoint | Configuration endpoint for cluster mode |
+| port | Redis port (default 6379) |
+| security_group_id | Security group ID |
+
+## Cost Estimates
+
+**Development:**
+- Node: cache.t3.micro (~$5/month)
+- 1 node, no replication
+- Minimal monitoring
+- Monthly: ~$5/month
+
+**Staging:**
+- Node: cache.t3.small (~$15/month)
+- 1 node, daily snapshot (backups ~$1/month)
+- Standard monitoring
+- Monthly: ~$16/month
+
+**Production:**
+- Nodes: cache.t3.small × 3 (~$45/month)
+- Multi-AZ with 2 replicas, automatic failover
+- 14-day snapshot retention (~$3/month)
+- Enhanced monitoring
+- Monthly: ~$48/month
+
+## Notes
+
+- Redis data is volatile by design (session cache only)
+- Persistence not recommended for performance
+- Use for: session tokens, rate limits, temporary caches
+- DO NOT use for persistent data (use RDS PostgreSQL)
+- Evergreen updates enabled for automatic patching
+- No read replicas in dev (cost optimization)

--- a/terraform/modules/caching/main.tf
+++ b/terraform/modules/caching/main.tf
@@ -1,0 +1,208 @@
+# ============================================================================
+# ElastiCache Subnet Group
+# ============================================================================
+
+resource "aws_elasticache_subnet_group" "cache" {
+  name       = var.cache_subnet_group_name
+  subnet_ids = var.cache_subnet_ids
+
+  tags = {
+    Name = "stellar-insights-cache-subnet-${var.environment}"
+  }
+}
+
+# ============================================================================
+# ElastiCache Parameter Group
+# ============================================================================
+
+resource "aws_elasticache_parameter_group" "redis" {
+  name   = "stellar-insights-redis-${var.environment}"
+  family = var.parameter_group_family
+
+  # Memory management
+  parameter {
+    name  = "maxmemory-policy"
+    value = "allkeys-lru"  # Evict LRU keys when memory limit reached
+  }
+
+  # Connection management
+  parameter {
+    name  = "timeout"
+    value = "300"  # Close idle connections after 5 minutes
+  }
+
+  # Persistence (disabled for performance)
+  # Redis is used for caching only, not persistent storage
+  parameter {
+    name  = "save"
+    value = ""  # Disable RDB snapshots for better performance
+  }
+
+  tags = {
+    Name = "stellar-insights-redis-${var.environment}"
+  }
+}
+
+# ============================================================================
+# ElastiCache Redis Cluster
+# ============================================================================
+
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = var.cluster_id
+  engine               = "redis"
+  node_type            = var.node_type
+  num_cache_nodes      = var.num_cache_nodes
+  parameter_group_name = aws_elasticache_parameter_group.redis.name
+  engine_version       = var.engine_version
+  port                 = 6379
+
+  # Networking
+  subnet_group_name          = aws_elasticache_subnet_group.cache.name
+  security_group_ids         = var.security_group_ids
+  automatic_failover_enabled = var.automatic_failover_enabled
+
+  # Maintenance and updates
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  maintenance_window         = var.environment == "dev" ? "sun:04:00-sun:05:00" : "sun:04:00-sun:05:00"
+
+  # Snapshots
+  snapshot_retention_limit = var.snapshot_retention_limit
+  snapshot_window          = var.snapshot_window > 0 ? var.snapshot_window : null
+
+  # Encryption
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  auth_token_enabled         = true
+  auth_token                 = random_password.redis_auth_token.result
+
+  # Notifications
+  notification_topic_arn = try(aws_sns_topic.cache_notifications[0].arn, null)
+
+  # Logging
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.redis_slow_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+    enabled          = var.environment != "dev"
+  }
+
+  tags = {
+    Name = "stellar-insights-redis-${var.environment}"
+  }
+
+  depends_on = [
+    aws_elasticache_parameter_group.redis,
+    aws_elasticache_subnet_group.cache
+  ]
+}
+
+# ============================================================================
+# Auth Token for Redis
+# ============================================================================
+
+resource "random_password" "redis_auth_token" {
+  length      = 32
+  special     = true
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
+# ============================================================================
+# SNS Topic for ElastiCache Notifications (production only)
+# ============================================================================
+
+resource "aws_sns_topic" "cache_notifications" {
+  count = var.environment == "production" ? 1 : 0
+  name  = "stellar-insights-cache-notifications-${var.environment}"
+
+  tags = {
+    Name = "stellar-insights-cache-notifications-${var.environment}"
+  }
+}
+
+# ============================================================================
+# CloudWatch Log Groups
+# ============================================================================
+
+resource "aws_cloudwatch_log_group" "redis_slow_log" {
+  name              = "/aws/elasticache/redis/${var.environment}/slow-log"
+  retention_in_days = var.environment == "production" ? 14 : (var.environment == "staging" ? 7 : 3)
+
+  tags = {
+    Name = "stellar-insights-redis-logs-${var.environment}"
+  }
+}
+
+# ============================================================================
+# CloudWatch Alarms
+# ============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "redis_cpu" {
+  alarm_name          = "stellar-insights-redis-cpu-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "EngineCPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.environment == "production" ? "70" : "80"
+  alarm_description   = "Alert when Redis CPU exceeds threshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.redis.cluster_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_memory" {
+  alarm_name          = "stellar-insights-redis-memory-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "80"
+  alarm_description   = "Alert when Redis memory exceeds 80%"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.redis.cluster_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_evictions" {
+  alarm_name          = "stellar-insights-redis-evictions-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Evictions"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "100"
+  alarm_description   = "Alert when Redis evictions exceed threshold (memory pressure)"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.redis.cluster_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_swap_usage" {
+  alarm_name          = "stellar-insights-redis-swap-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "SwapUsage"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "52428800"  # 50MB
+  alarm_description   = "Alert on Redis swap usage (critical!)"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.redis.cluster_id
+  }
+}

--- a/terraform/modules/caching/outputs.tf
+++ b/terraform/modules/caching/outputs.tf
@@ -1,0 +1,41 @@
+output "primary_endpoint_address" {
+  description = "Primary endpoint address (hostname)"
+  value       = aws_elasticache_cluster.redis.cache_nodes[0].address
+  sensitive   = false
+}
+
+output "primary_endpoint" {
+  description = "Primary endpoint (hostname:port)"
+  value       = "${aws_elasticache_cluster.redis.cache_nodes[0].address}:${aws_elasticache_cluster.redis.port}"
+  sensitive   = false
+}
+
+output "port" {
+  description = "Redis port"
+  value       = aws_elasticache_cluster.redis.port
+  sensitive   = false
+}
+
+output "cluster_id" {
+  description = "ElastiCache cluster identifier"
+  value       = aws_elasticache_cluster.redis.cluster_id
+  sensitive   = false
+}
+
+output "engine_version" {
+  description = "Redis engine version"
+  value       = aws_elasticache_cluster.redis.engine_version
+  sensitive   = false
+}
+
+output "auth_token" {
+  description = "AUTH token for Redis connection (store in Vault!)"
+  value       = random_password.redis_auth_token.result
+  sensitive   = true
+}
+
+output "redis_connection_string" {
+  description = "Redis connection string for Rust/Python (redis://token@host:port)"
+  value       = "redis://:${random_password.redis_auth_token.result}@${aws_elasticache_cluster.redis.cache_nodes[0].address}:${aws_elasticache_cluster.redis.port}"
+  sensitive   = true
+}

--- a/terraform/modules/caching/variables.tf
+++ b/terraform/modules/caching/variables.tf
@@ -1,0 +1,132 @@
+variable "cache_subnet_group_name" {
+  description = "ElastiCache subnet group name"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,255}$", var.cache_subnet_group_name))
+    error_message = "Subnet group name must contain only lowercase letters, numbers, and hyphens"
+  }
+}
+
+variable "cache_subnet_ids" {
+  description = "List of cache subnet IDs"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.cache_subnet_ids) >= 1
+    error_message = "At least one subnet ID must be provided"
+  }
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.security_group_ids) > 0
+    error_message = "At least one security group ID must be provided"
+  }
+}
+
+variable "cluster_id" {
+  description = "ElastiCache cluster identifier"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,50}$", var.cluster_id))
+    error_message = "Cluster ID must contain only lowercase letters, numbers, and hyphens (1-50 chars)"
+  }
+}
+
+variable "node_type" {
+  description = "ElastiCache node type (e.g., cache.t3.micro, cache.t3.small)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^cache\\.t3\\.(micro|small|medium|large)$", var.node_type))
+    error_message = "Node type must be a valid t3 cache type (e.g., cache.t3.micro, cache.t3.small)"
+  }
+}
+
+variable "num_cache_nodes" {
+  description = "Number of cache nodes (1 for dev, 1-3 for staging/prod)"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.num_cache_nodes >= 1 && var.num_cache_nodes <= 3
+    error_message = "Number of cache nodes must be between 1 and 3"
+  }
+}
+
+variable "engine_version" {
+  description = "Redis engine version"
+  type        = string
+  default     = "7.0"
+
+  validation {
+    condition     = can(regex("^7\\.[0-9]+$", var.engine_version))
+    error_message = "Engine version must be Redis 7.x (e.g., 7.0, 7.1)"
+  }
+}
+
+variable "parameter_group_family" {
+  description = "Parameter group family"
+  type        = string
+  default     = "redis7"
+
+  validation {
+    condition     = can(regex("^redis[0-9]$", var.parameter_group_family))
+    error_message = "Parameter group family must be redis7 or similar"
+  }
+}
+
+variable "automatic_failover_enabled" {
+  description = "Enable automatic failover (Multi-AZ)"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_retention_limit" {
+  description = "Number of days to retain snapshots (0-35)"
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.snapshot_retention_limit >= 0 && var.snapshot_retention_limit <= 35
+    error_message = "Snapshot retention must be between 0 and 35 days"
+  }
+}
+
+variable "snapshot_window" {
+  description = "Preferred snapshot window (HH:MM-HH:MM UTC)"
+  type        = string
+  default     = "03:00-04:00"
+
+  validation {
+    condition     = can(regex("^[0-2][0-9]:[0-5][0-9]-[0-2][0-9]:[0-5][0-9]$", var.snapshot_window))
+    error_message = "Snapshot window must be in format HH:MM-HH:MM (UTC)"
+  }
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Enable automatic minor version upgrades"
+  type        = bool
+  default     = true
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be one of: dev, staging, production"
+  }
+}
+
+variable "project" {
+  description = "Project name for tagging"
+  type        = string
+  default     = "stellar-insights"
+}

--- a/terraform/modules/caching/versions.tf
+++ b/terraform/modules/caching/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/compute/ecs/README.md
+++ b/terraform/modules/compute/ecs/README.md
@@ -1,0 +1,130 @@
+# Compute Module (ECS)
+
+Manages AWS ECS cluster, EC2 instances, and task definitions for Stellar Insights backend.
+
+## Features
+
+- ECS cluster with EC2 launch type
+- Auto-scaling group for EC2 instances
+- CloudWatch Log Group for container logs
+- IAM roles for ECS task execution and EC2 instance profile
+- CloudWatch monitoring and alarms
+- Task definitions with environment variables and secrets from Vault
+- Service configuration with load balancer integration
+- Graceful shutdown handling (SIGTERM)
+- Health check configuration
+
+## Architecture
+
+```
+ALB → Target Group → ECS Service → ECS Tasks (EC2 instances)
+                                      ↓
+                         (pulls secrets from Vault)
+```
+
+## Usage
+
+```hcl
+module "compute" {
+  source = "../../modules/compute/ecs"
+
+  # Cluster configuration
+  cluster_name        = "stellar-insights-${var.environment}"
+  container_image     = "${aws_ecr_repository.backend.repository_url}:latest"
+  
+  # Capacity
+  desired_count       = 2
+  min_size           = 1
+  max_size           = 4
+  instance_type      = "t3.small"  # t3.micro for dev
+  
+  # Networking
+  subnets             = module.networking.private_app_subnet_ids
+  security_groups     = [module.networking.security_group_backend_id]
+  target_group_arn    = module.load_balancing.target_group_arn
+  
+  # Secrets and configuration
+  vault_addr          = var.vault_addr
+  db_url              = "postgresql://user:pass@${module.database.rds_endpoint}/stellar_insights"
+  redis_url           = "redis://:${module.caching.auth_token}@${module.caching.primary_endpoint_address}"
+  
+  environment         = var.environment
+  project            = "stellar-insights"
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| cluster_name | ECS cluster name | `string` | Yes |
+| container_image | ECR image URI with tag | `string` | Yes |
+| container_port | Container port | `number` | No (default: `8080`) |
+| desired_count | Desired number of tasks | `number` | No (default: `2`) |
+| min_size | Minimum number of EC2 instances | `number` | No (default: `1`) |
+| max_size | Maximum number of EC2 instances | `number` | No (default: `4`) |
+| instance_type | EC2 instance type | `string` | Yes |
+| subnets | Private subnet IDs for ECS tasks | `list(string)` | Yes |
+| security_groups | Security group IDs for ECS tasks | `list(string)` | Yes |
+| target_group_arn | ALB target group ARN | `string` | Yes |
+| vault_addr | Vault server address | `string` | Yes |
+| db_url | Database connection URL | `string` | Yes |
+| redis_url | Redis connection URL | `string` | Yes |
+| environment | Environment name | `string` | Yes |
+| project | Project name | `string` | No (default: `stellar-insights`) |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cluster_name | ECS cluster name |
+| cluster_arn | ECS cluster ARN |
+| service_name | ECS service name |
+| service_arn | ECS service ARN |
+| asg_name | Auto Scaling Group name |
+
+## Cost Estimates
+
+**Development:**
+- EC2 (t3.micro): ~$7/month
+- Data transfer: ~$2/month
+- CloudWatch Logs: <$1/month
+- Monthly: ~$10/month (in addition to infrastructure)
+
+**Staging:**
+- EC2 (t3.small × 2): ~$60/month
+- Data transfer: ~$5/month
+- CloudWatch Logs: ~$1/month
+- Monthly: ~$66/month
+
+**Production:**
+- EC2 (t3.small × 3): ~$90/month
+- Auto-scaling (up to 5): +$30/month
+- Data transfer: ~$10/month
+- CloudWatch Logs: ~$2/month
+- Monthly: ~$132/month
+
+## Task Definition
+
+The task definition includes:
+- Container: Rust Tokio server on port 8080
+- Memory: 512MB (dev), 1024MB (staging/prod)
+- CPU: 256 (dev), 512 (staging/prod)
+- Log driver: awslogs (CloudWatch)
+- Environment variables: VAULT_ADDR, DATABASE_URL, REDIS_URL, ENVIRONMENT
+- Health check: GET /health every 30s
+
+## Auto-Scaling
+
+- Target tracking: 70% CPU utilization (production)
+- Scale up: within 2 minutes
+- Scale down: within 5 minutes
+- Minimum: 1 instance (dev), 2 (staging), 3 (production)
+
+## Notes
+
+- Uses EC2 launch type (not Fargate) for cost optimization
+- Graceful shutdown: sends SIGTERM to container (30s timeout)
+- Health checks: ALB + ECS both monitor task health
+- Logging: all container output → CloudWatch
+- See [main.rs](../../backend/src/main.rs) for shutdown signal handling

--- a/terraform/modules/compute/ecs/main.tf
+++ b/terraform/modules/compute/ecs/main.tf
@@ -1,0 +1,464 @@
+# ============================================================================
+# CloudWatch Log Group
+# ============================================================================
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${var.cluster_name}"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    Name = "stellar-insights-ecs-logs-${var.environment}"
+  }
+}
+
+# ============================================================================
+# IAM Roles
+# ============================================================================
+
+# Task Execution Role (used by ECS agent to pull image and write logs)
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "stellar-insights-ecs-task-execution-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "stellar-insights-ecs-task-execution-${var.environment}"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Task Role (used by the application inside the container)
+resource "aws_iam_role" "ecs_task_role" {
+  name = "stellar-insights-ecs-task-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "stellar-insights-ecs-task-${var.environment}"
+  }
+}
+
+# Task role policy: allow reading from Vault and writing to S3 for artifacts
+resource "aws_iam_role_policy" "ecs_task_policy" {
+  name = "stellar-insights-ecs-task-policy"
+  role = aws_iam_role.ecs_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "vault:ReadSecret",
+          "vault:GetDatabaseCredentials"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "s3:prefix" = "artifacts/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# EC2 Instance Profile Role
+resource "aws_iam_role" "ecs_instance_role" {
+  name = "stellar-insights-ecs-instance-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "stellar-insights-ecs-instance-${var.environment}"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role_policy" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs" {
+  name = "stellar-insights-ecs-instance-profile-${var.environment}"
+  role = aws_iam_role.ecs_instance_role.name
+}
+
+# ============================================================================
+# ECS Cluster
+# ============================================================================
+
+resource "aws_ecs_cluster" "main" {
+  name = var.cluster_name
+
+  setting {
+    name  = "containerInsights"
+    value = var.environment == "production" ? "enabled" : "disabled"
+  }
+
+  tags = {
+    Name = "stellar-insights-ecs-cluster-${var.environment}"
+  }
+}
+
+# ============================================================================
+# EC2 Launch Template
+# ============================================================================
+
+data "aws_ami" "ecs_optimized" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
+  }
+}
+
+resource "aws_launch_template" "ecs" {
+  name_prefix   = "stellar-insights-ecs-"
+  image_id      = data.aws_ami.ecs_optimized.id
+  instance_type = var.instance_type
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.ecs.arn
+  }
+
+  # ECS cluster initialization
+  user_data = base64encode(<<-EOF
+              #!/bin/bash
+              echo "ECS_CLUSTER=${aws_ecs_cluster.main.name}" >> /etc/ecs/ecs.config
+              echo "ECS_ENABLE_CONTAINER_METADATA=true" >> /etc/ecs/ecs.config
+              echo "ECS_ENABLE_TASK_CPU_MEM_LIMIT=true" >> /etc/ecs/ecs.config
+              echo "ECS_ENABLE_TASK_IAM_ROLE=true" >> /etc/ecs/ecs.config
+              echo "ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true" >> /etc/ecs/ecs.config
+              EOF
+  )
+
+  monitoring {
+    enabled = var.environment != "dev"
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "stellar-insights-ecs-${var.environment}"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ============================================================================
+# Auto Scaling Group
+# ============================================================================
+
+resource "aws_autoscaling_group" "ecs" {
+  name                = "${var.cluster_name}-asg"
+  vpc_zone_identifier = var.subnets
+  min_size            = var.min_size
+  max_size            = var.max_size
+  desired_capacity    = var.desired_count
+  health_check_type   = "ELB"
+  health_check_grace_period = 300
+
+  launch_template {
+    id      = aws_launch_template.ecs.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "stellar-insights-ecs-${var.environment}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Cluster"
+    value               = aws_ecs_cluster.main.name
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ============================================================================
+# ECS Task Definition
+# ============================================================================
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "stellar-insights-${var.environment}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = var.container_cpu
+  memory                   = var.container_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "stellar-insights"
+      image     = var.container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      # Logging
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ecs.name
+          "awslogs-region"        = data.aws_caller_identity.current.account
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+
+      # Environment variables (non-sensitive)
+      environment = [
+        {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        },
+        {
+          name  = "VAULT_ADDR"
+          value = var.vault_addr
+        }
+      ]
+
+      # Secrets from Vault (via parameter store/secrets manager in production)
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = aws_secretsmanager_secret.database_url.arn
+        },
+        {
+          name      = "REDIS_URL"
+          valueFrom = aws_secretsmanager_secret.redis_url.arn
+        }
+      ]
+
+      # Health check
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:${var.container_port}${var.health_check_path} || exit 1"]
+        interval    = var.health_check_interval
+        timeout     = var.health_check_timeout
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = {
+    Name = "stellar-insights-task-${var.environment}"
+  }
+}
+
+# ============================================================================
+# ECS Service
+# ============================================================================
+
+resource "aws_ecs_service" "app" {
+  name            = "stellar-insights-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.desired_count
+  launch_type     = "EC2"
+
+  network_configuration {
+    subnets          = var.subnets
+    security_groups  = var.security_groups
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = "stellar-insights"
+    container_port   = var.container_port
+  }
+
+  # Graceful shutdown: wait up to 30 seconds for container to stop
+  depends_on = [
+    aws_ecs_cluster.main,
+    aws_ecs_task_definition.app
+  ]
+
+  tags = {
+    Name = "stellar-insights-service-${var.environment}"
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]  # Allow autoscaler to manage this
+  }
+}
+
+# ============================================================================
+# Auto-Scaling
+# ============================================================================
+
+resource "aws_appautoscaling_target" "ecs_target" {
+  count              = var.enable_auto_scaling ? 1 : 0
+  max_capacity       = var.max_size
+  min_capacity       = var.min_size
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.app.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "ecs_target_cpu" {
+  count              = var.enable_auto_scaling ? 1 : 0
+  name               = "stellar-insights-cpu-scaling-${var.environment}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value = var.cpu_target_percentage / 100.0
+  }
+}
+
+# ============================================================================
+# Secrets in AWS Secrets Manager
+# ============================================================================
+
+resource "aws_secretsmanager_secret" "database_url" {
+  name                    = "stellar-insights/database-url-${var.environment}"
+  recovery_window_in_days = 7
+
+  tags = {
+    Name = "stellar-insights-db-url-${var.environment}"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "database_url" {
+  secret_id       = aws_secretsmanager_secret.database_url.id
+  secret_string   = var.db_url
+  version_stages = ["AWSCURRENT"]
+}
+
+resource "aws_secretsmanager_secret" "redis_url" {
+  name                    = "stellar-insights/redis-url-${var.environment}"
+  recovery_window_in_days = 7
+
+  tags = {
+    Name = "stellar-insights-redis-url-${var.environment}"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "redis_url" {
+  secret_id       = aws_secretsmanager_secret.redis_url.id
+  secret_string   = var.redis_url
+  version_stages = ["AWSCURRENT"]
+}
+
+# Allow ECS task execution role to read secrets
+resource "aws_secretsmanager_secret_policy" "database_url" {
+  secret_arn = aws_secretsmanager_secret.database_url.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowECStaskExecutionRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.ecs_task_execution_role.arn
+        }
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_secretsmanager_secret_policy" "redis_url" {
+  secret_arn = aws_secretsmanager_secret.redis_url.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowECStaskExecutionRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.ecs_task_execution_role.arn
+        }
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# ============================================================================
+# Data Sources
+# ============================================================================
+
+data "aws_caller_identity" "current" {}

--- a/terraform/modules/compute/ecs/outputs.tf
+++ b/terraform/modules/compute/ecs/outputs.tf
@@ -1,0 +1,39 @@
+output "cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "cluster_arn" {
+  description = "ECS cluster ARN"
+  value       = aws_ecs_cluster.main.arn
+}
+
+output "service_name" {
+  description = "ECS service name"
+  value       = aws_ecs_service.app.name
+}
+
+output "service_arn" {
+  description = "ECS service ARN"
+  value       = aws_ecs_service.app.arn
+}
+
+output "asg_name" {
+  description = "Auto Scaling Group name"
+  value       = aws_autoscaling_group.ecs.name
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.ecs.name
+}
+
+output "task_execution_role_arn" {
+  description = "ECS task execution role ARN"
+  value       = aws_iam_role.ecs_task_execution_role.arn
+}
+
+output "task_role_arn" {
+  description = "ECS task role ARN"
+  value       = aws_iam_role.ecs_task_role.arn
+}

--- a/terraform/modules/compute/ecs/variables.tf
+++ b/terraform/modules/compute/ecs/variables.tf
@@ -1,0 +1,216 @@
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,255}$", var.cluster_name))
+    error_message = "Cluster name must contain only lowercase letters, numbers, and hyphens"
+  }
+}
+
+variable "container_image" {
+  description = "ECR image URI with tag (e.g., account.dkr.ecr.region.amazonaws.com/repo:tag)"
+  type        = string
+
+  validation {
+    condition     = can(regex(".dkr.ecr.", var.container_image))
+    error_message = "Container image must be an ECR image URI"
+  }
+}
+
+variable "container_port" {
+  description = "Container port (Rust backend default: 8080)"
+  type        = number
+  default     = 8080
+
+  validation {
+    condition     = var.container_port >= 1024 && var.container_port <= 65535
+    error_message = "Container port must be between 1024 and 65535"
+  }
+}
+
+variable "container_cpu" {
+  description = "Task CPU units (256, 512, 1024, 2048, 4096)"
+  type        = number
+  default     = 512
+
+  validation {
+    condition     = contains([256, 512, 1024, 2048, 4096], var.container_cpu)
+    error_message = "Container CPU must be one of: 256, 512, 1024, 2048, 4096"
+  }
+}
+
+variable "container_memory" {
+  description = "Task memory in MB (512, 1024, 2048, 3072, 4096)"
+  type        = number
+  default     = 1024
+
+  validation {
+    condition     = contains([512, 1024, 2048, 3072, 4096], var.container_memory)
+    error_message = "Container memory must be one of: 512, 1024, 2048, 3072, 4096"
+  }
+}
+
+variable "desired_count" {
+  description = "Desired number of running tasks"
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.desired_count >= 1 && var.desired_count <= 10
+    error_message = "Desired count must be between 1 and 10"
+  }
+}
+
+variable "min_size" {
+  description = "Minimum number of EC2 instances (ASG)"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.min_size >= 1 && var.min_size <= 10
+    error_message = "Min size must be between 1 and 10"
+  }
+}
+
+variable "max_size" {
+  description = "Maximum number of EC2 instances (ASG)"
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.max_size >= var.min_size && var.max_size <= 20
+    error_message = "Max size must be >= min_size and <= 20"
+  }
+}
+
+variable "instance_type" {
+  description = "EC2 instance type (t3.micro, t3.small, t3.medium, t3.large)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^t3\\.(micro|small|medium|large)$", var.instance_type))
+    error_message = "Instance type must be a valid t3 type (e.g., t3.micro, t3.small)"
+  }
+}
+
+variable "subnets" {
+  description = "Private subnet IDs for ECS tasks"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.subnets) >= 1
+    error_message = "At least one subnet must be provided"
+  }
+}
+
+variable "security_groups" {
+  description = "Security group IDs for ECS tasks"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.security_groups) >= 1
+    error_message = "At least one security group must be provided"
+  }
+}
+
+variable "target_group_arn" {
+  description = "ALB target group ARN"
+  type        = string
+
+  validation {
+    condition     = can(regex("arn:aws:elasticloadbalancing:", var.target_group_arn))
+    error_message = "Target group ARN must be a valid ELB ARN"
+  }
+}
+
+variable "vault_addr" {
+  description = "Vault server address (passed to container)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^https://", var.vault_addr))
+    error_message = "Vault address must be an HTTPS URL"
+  }
+}
+
+variable "db_url" {
+  description = "Database connection URL (postgresql://user:pass@host:5432/db)"
+  type        = string
+  sensitive   = true
+}
+
+variable "redis_url" {
+  description = "Redis connection URL (redis://:auth@host:6379)"
+  type        = string
+  sensitive   = true
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be one of: dev, staging, production"
+  }
+}
+
+variable "project" {
+  description = "Project name for tagging"
+  type        = string
+  default     = "stellar-insights"
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention in days"
+  type        = number
+  default     = 7
+}
+
+variable "health_check_path" {
+  description = "Health check endpoint path"
+  type        = string
+  default     = "/health"
+}
+
+variable "health_check_interval" {
+  description = "Health check interval in seconds"
+  type        = number
+  default     = 30
+}
+
+variable "health_check_timeout" {
+  description = "Health check timeout in seconds"
+  type        = number
+  default     = 5
+}
+
+variable "health_check_healthy_threshold" {
+  description = "Healthy check count threshold"
+  type        = number
+  default     = 2
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = "Unhealthy check count threshold"
+  type        = number
+  default     = 3
+}
+
+variable "enable_auto_scaling" {
+  description = "Enable target tracking auto-scaling"
+  type        = bool
+  default     = true
+}
+
+variable "cpu_target_percentage" {
+  description = "CPU target percentage for auto-scaling (70% default)"
+  type        = number
+  default     = 70
+
+  validation {
+    condition     = var.cpu_target_percentage >= 20 && var.cpu_target_percentage <= 90
+    error_message = "CPU target must be between 20 and 90 percent"
+  }
+}

--- a/terraform/modules/compute/ecs/versions.tf
+++ b/terraform/modules/compute/ecs/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/database/README.md
+++ b/terraform/modules/database/README.md
@@ -1,0 +1,117 @@
+# Database Module
+
+Manages AWS RDS PostgreSQL instances for Stellar Insights backend.
+
+## Features
+
+- PostgreSQL 14+ engine with automatic patching
+- Automatic backups with configurable retention (7-30 days)
+- CloudWatch monitoring and alarms
+- Parameter groups for performance tuning
+- Enhanced monitoring with IAM role
+- Encrypted storage (KMS)
+- Multi-AZ option for high availability
+- Automatic failover in Multi-AZ deployments
+
+## Usage
+
+```hcl
+module "database" {
+  source = "../../modules/database"
+
+  # Networking
+  db_subnet_group_name            = aws_db_subnet_group.database.name
+  vpc_security_group_ids          = [aws_security_group.database.id]
+  
+  # Instance configuration
+  identifier          = "stellar-insights-${var.environment}"
+  instance_class      = "db.t3.small"  # t3.micro for dev, t3.small for staging/prod
+  allocated_storage   = 100           # GB
+  storage_type        = "gp3"
+  
+  # Database
+  engine              = "postgres"
+  engine_version      = "14.8"
+  db_name            = "stellar_insights"
+  username            = "postgres"
+  password            = random_password.db.result  # From Vault in production
+  
+  # HA and backup
+  multi_az            = var.environment == "production"
+  backup_retention    = var.environment == "dev" ? 7 : (var.environment == "staging" ? 14 : 30)
+  skip_final_backup   = var.environment == "dev"
+  
+  # Monitoring
+  enable_cloudwatch_logs_exports = ["postgresql"]
+  enable_enhanced_monitoring      = var.environment != "dev"
+  
+  # Tagging
+  environment         = var.environment
+  project            = "stellar-insights"
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| db_subnet_group_name | DB subnet group name | `string` | Yes |
+| vpc_security_group_ids | Security group IDs | `list(string)` | Yes |
+| identifier | RDS instance identifier | `string` | Yes |
+| instance_class | RDS instance class | `string` | Yes (e.g., `db.t3.micro`, `db.t3.small`) |
+| allocated_storage | Allocated storage in GB | `number` | Yes |
+| storage_type | Storage type (gp3, gp2, io1) | `string` | No (default: `gp3`) |
+| engine_version | PostgreSQL version | `string` | No (default: `14.8`) |
+| db_name | Initial database name | `string` | No (default: `stellar_insights`) |
+| username | Master username | `string` | No (default: `postgres`) |
+| password | Master password | `string` | Yes (use Vault in production) |
+| multi_az | Enable Multi-AZ deployment | `bool` | No (default: `false`) |
+| backup_retention | Backup retention in days | `number` | No (default: `7`) |
+| skip_final_backup | Skip final backup on destroy | `bool` | No (default: `false`) |
+| enable_cloudwatch_logs_exports | Export logs to CloudWatch | `list(string)` | No |
+| enable_enhanced_monitoring | Enable enhanced monitoring | `bool` | No (default: `false`) |
+| monitoring_interval | Enhanced monitoring interval in seconds | `number` | No (default: `60`) |
+| environment | Environment name | `string` | Yes |
+| project | Project name | `string` | No (default: `stellar-insights`) |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| rds_endpoint | RDS endpoint address (hostname) |
+| rds_port | RDS port (default 5432) |
+| rds_arn | RDS instance ARN |
+| security_group_id | Database security group ID |
+| resource_id | RDS resource ID (for IAM policies) |
+
+## Cost Estimates
+
+**Development:**
+- Instance: db.t3.micro (~$10/month)
+- Storage: 20GB GP3 (~$2/month)
+- Backup: 7 days (~$1/month)
+- No Multi-AZ, minimal monitoring
+- Monthly: ~$13/month
+
+**Staging:**
+- Instance: db.t3.small (~$30/month)
+- Storage: 100GB GP3 (~$10/month)
+- Backup: 14 days (~$3/month)
+- Single-AZ, standard monitoring
+- Monthly: ~$43/month
+
+**Production:**
+- Instance: db.t3.small Multi-AZ (~$60/month)
+- Storage: 500GB GP3 (~$50/month)
+- Backup: 30 days (~$15/month)
+- Multi-AZ failover, enhanced monitoring
+- Monthly: ~$125/month
+
+## Notes
+
+- PostgreSQL 14 requires no special Stellar-specific configuration
+- Heroku/AWS native PostgreSQL compatible
+- Connection pooling handled by application (HikariCP in Java, sqlx in Rust)
+- Automated upgrades enabled for minor versions only
+- Database credentials managed via HashiCorp Vault (backend/src/vault/client.rs)
+- See [VAULT_INTEGRATION_GUIDE.md](../../VAULT_INTEGRATION_GUIDE.md) for database secret engine configuration

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -1,0 +1,279 @@
+# ============================================================================
+# KMS Key for RDS Encryption
+# ============================================================================
+
+resource "aws_kms_key" "rds" {
+  description             = "KMS key for RDS encryption (${var.environment})"
+  deletion_window_in_days = var.environment == "dev" ? 7 : 30
+  enable_key_rotation     = true
+
+  tags = {
+    Name = "stellar-insights-rds-${var.environment}"
+  }
+}
+
+resource "aws_kms_alias" "rds" {
+  name          = "alias/stellar-insights-rds-${var.environment}"
+  target_key_id = aws_kms_key.rds.key_id
+}
+
+# ============================================================================
+# RDS DB Subnet Group
+# ============================================================================
+
+resource "aws_db_subnet_group" "database" {
+  name       = var.db_subnet_group_name
+  subnet_ids = var.db_subnet_ids
+
+  tags = {
+    Name = "stellar-insights-db-subnet-${var.environment}"
+  }
+}
+
+# ============================================================================
+# RDS Parameter Group
+# ============================================================================
+
+resource "aws_db_parameter_group" "postgresql" {
+  name   = "stellar-insights-postgresql-${var.environment}"
+  family = "postgres14"
+
+  # Performance tuning for PostgreSQL 14
+  parameter {
+    name  = "shared_buffers"
+    value = "{DBInstanceClassMemory/4}"
+  }
+
+  # Enable slow query logging for optimization
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "5000"  # Log queries taking >5s
+  }
+
+  # Connection management
+  parameter {
+    name  = "max_connections"
+    value = var.environment == "dev" ? "100" : (var.environment == "staging" ? "250" : "500")
+  }
+
+  # Query planner
+  parameter {
+    name  = "random_page_cost"
+    value = "1.1"  # SSD optimization
+  }
+
+  parameter {
+    name  = "effective_cache_size"
+    value = "{DBInstanceClassMemory*3/4}"
+  }
+
+  # SSL enforcement
+  parameter {
+    name         = "rds.force_ssl"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  # Timezone (UTC recommended)
+  parameter {
+    name  = "timezone"
+    value = "UTC"
+  }
+
+  # Maintenance windows
+  tags = {
+    Name = "stellar-insights-pg14-${var.environment}"
+  }
+}
+
+# ============================================================================
+# IAM Role for Enhanced Monitoring
+# ============================================================================
+
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  count = var.enable_enhanced_monitoring ? 1 : 0
+
+  name = "stellar-insights-rds-monitoring-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "monitoring.rds.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "stellar-insights-rds-monitoring-${var.environment}"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  count      = var.enable_enhanced_monitoring ? 1 : 0
+  role       = aws_iam_role.rds_enhanced_monitoring[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+# ============================================================================
+# RDS PostgreSQL Instance
+# ============================================================================
+
+resource "aws_db_instance" "postgresql" {
+  identifier         = var.identifier
+  engine             = "postgres"
+  engine_version     = var.engine_version
+  instance_class     = var.instance_class
+  allocated_storage  = var.allocated_storage
+  storage_type       = var.storage_type
+  storage_encrypted  = true
+  kms_key_id         = aws_kms_key.rds.arn
+
+  # Database configuration
+  db_name  = var.db_name
+  username = var.username
+  password = var.password
+
+  # Networking
+  publicly_accessible   = false
+  db_subnet_group_name  = aws_db_subnet_group.database.name
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  # Parameter group
+  parameter_group_name = aws_db_parameter_group.postgresql.name
+
+  # High availability
+  multi_az = var.multi_az
+
+  # Backups
+  backup_retention_period = var.backup_retention_period
+  backup_window           = var.backup_window
+  skip_final_snapshot     = var.skip_final_snapshot
+  final_snapshot_identifier = var.skip_final_snapshot ? null : "stellar-insights-${var.environment}-final-snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
+
+  # Maintenance
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
+  maintenance_window          = var.environment == "dev" ? "sun:04:00-sun:05:00" : "sun:04:00-sun:05:00"
+  enable_iam_database_authentication = true
+
+  # Cloudwatch logs
+  enabled_cloudwatch_logs_exports = var.enable_cloudwatch_logs_exports
+
+  # Enhanced monitoring
+  enable_performance_insights       = var.environment != "dev"
+  performance_insights_retention_period = var.environment == "production" ? 31 : 7
+  monitoring_interval              = var.enable_enhanced_monitoring ? var.monitoring_interval : 0
+  monitoring_role_arn              = var.enable_enhanced_monitoring ? aws_iam_role.rds_enhanced_monitoring[0].arn : null
+
+  # GP3 specific settings
+  iops              = var.storage_type == "gp3" ? var.iops : null
+  storage_throughput = var.storage_type == "gp3" ? var.storage_throughput : null
+
+  # Deletion protection for production
+  deletion_protection = var.environment == "production" ? true : false
+
+  tags = {
+    Name = "stellar-insights-${var.environment}"
+  }
+
+  depends_on = [
+    aws_db_parameter_group.postgresql,
+    aws_db_subnet_group.database
+  ]
+
+  lifecycle {
+    # Ignore snapshot identifier changes from provider
+    ignore_changes = [final_snapshot_identifier]
+  }
+}
+
+# ============================================================================
+# CloudWatch Alarms
+# ============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
+  alarm_name          = "stellar-insights-rds-cpu-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.environment == "production" ? "70" : "80"
+  alarm_description   = "Alert when RDS CPU exceeds threshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.postgresql.identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_connections" {
+  alarm_name          = "stellar-insights-rds-connections-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.environment == "production" ? "400" : (var.environment == "staging" ? "200" : "80")
+  alarm_description   = "Alert when database connections exceed threshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.postgresql.identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_storage" {
+  alarm_name          = "stellar-insights-rds-storage-${var.environment}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.allocated_storage * 1073741824 * 0.1  # Alert at 10% free space
+  alarm_description   = "Alert when RDS free storage drops below 10%"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.postgresql.identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_replication_lag" {
+  count               = var.multi_az ? 1 : 0
+  alarm_name          = "stellar-insights-rds-replication-lag-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "AuroraBinlogReplicaLag"
+  namespace           = "AWS/RDS"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "1000"  # 1000ms
+  alarm_description   = "Alert when Multi-AZ replication lag exceeds 1 second"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.postgresql.identifier
+  }
+}
+
+# ============================================================================
+# CloudWatch Log Groups
+# ============================================================================
+
+resource "aws_cloudwatch_log_group" "rds_postgresql" {
+  count             = contains(var.enable_cloudwatch_logs_exports, "postgresql") ? 1 : 0
+  name              = "/aws/rds/instance/${var.identifier}/postgresql"
+  retention_in_days = var.environment == "production" ? 30 : (var.environment == "staging" ? 14 : 7)
+
+  tags = {
+    Name = "stellar-insights-rds-logs-${var.environment}"
+  }
+}

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -1,0 +1,47 @@
+output "rds_endpoint" {
+  description = "RDS instance endpoint address (hostname:port)"
+  value       = aws_db_instance.postgresql.endpoint
+  sensitive   = false
+}
+
+output "rds_address" {
+  description = "RDS instance address (hostname only)"
+  value       = aws_db_instance.postgresql.address
+  sensitive   = false
+}
+
+output "rds_port" {
+  description = "RDS instance port"
+  value       = aws_db_instance.postgresql.port
+  sensitive   = false
+}
+
+output "rds_resource_id" {
+  description = "RDS resource ID (for IAM policies)"
+  value       = aws_db_instance.postgresql.resource_id
+  sensitive   = false
+}
+
+output "rds_arn" {
+  description = "RDS instance ARN"
+  value       = aws_db_instance.postgresql.arn
+  sensitive   = false
+}
+
+output "db_subnet_group_id" {
+  description = "DB subnet group ID"
+  value       = aws_db_subnet_group.database.id
+  sensitive   = false
+}
+
+output "kms_key_id" {
+  description = "KMS key ID for RDS encryption"
+  value       = aws_kms_key.rds.id
+  sensitive   = false
+}
+
+output "rds_identifier" {
+  description = "RDS instance identifier"
+  value       = aws_db_instance.postgresql.identifier
+  sensitive   = false
+}

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -1,0 +1,220 @@
+variable "db_subnet_group_name" {
+  description = "RDS DB subnet group name for Multi-AZ"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,255}$", var.db_subnet_group_name))
+    error_message = "Subnet group name must contain only lowercase letters, numbers, and hyphens (1-255 chars)"
+  }
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security group IDs to attach to RDS instance"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.vpc_security_group_ids) > 0
+    error_message = "At least one security group ID must be provided"
+  }
+}
+
+variable "db_subnet_ids" {
+  description = "List of database subnet IDs for Multi-AZ deployment"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.db_subnet_ids) >= 2
+    error_message = "At least 2 subnet IDs must be provided (across different AZs)"
+  }
+}
+
+variable "identifier" {
+  description = "RDS instance resource identifier (must be unique, lowercase, alphanumeric and hyphens only)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,63}$", var.identifier))
+    error_message = "Identifier must contain only lowercase letters, numbers, and hyphens (1-63 chars)"
+  }
+}
+
+variable "instance_class" {
+  description = "RDS instance type (e.g., db.t3.micro, db.t3.small, db.t3.medium)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^db\\.t3\\.(micro|small|medium|large|xlarge|2xlarge)$", var.instance_class))
+    error_message = "Instance class must be a valid t3 type (e.g., db.t3.micro, db.t3.small)"
+  }
+}
+
+variable "allocated_storage" {
+  description = "Allocated storage in GB (20-65536 for GP3)"
+  type        = number
+
+  validation {
+    condition     = var.allocated_storage >= 20 && var.allocated_storage <= 65536
+    error_message = "Allocated storage must be between 20 and 65536 GB"
+  }
+}
+
+variable "storage_type" {
+  description = "Storage type (gp3, gp2, io1, io2)"
+  type        = string
+  default     = "gp3"
+
+  validation {
+    condition     = contains(["gp3", "gp2", "io1", "io2"], var.storage_type)
+    error_message = "Storage type must be one of: gp3, gp2, io1, io2"
+  }
+}
+
+variable "engine_version" {
+  description = "PostgreSQL engine version (14.x preferred for Stellar Insights)"
+  type        = string
+  default     = "14.8"
+
+  validation {
+    condition     = can(regex("^14\\.[0-9]+$", var.engine_version))
+    error_message = "Engine version must be a valid PostgreSQL 14.x version (e.g., 14.8)"
+  }
+}
+
+variable "db_name" {
+  description = "Name of the initial database to create"
+  type        = string
+  default     = "stellar_insights"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9_]*$", var.db_name))
+    error_message = "Database name must start with a letter and contain only lowercase letters, numbers, and underscores"
+  }
+}
+
+variable "username" {
+  description = "Master database username"
+  type        = string
+  default     = "postgres"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9_]*$", var.username))
+    error_message = "Username must start with a letter and contain only lowercase letters, numbers, and underscores"
+  }
+}
+
+variable "password" {
+  description = "Master database password (strongly prefer Vault over plaintext)"
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.password) >= 8
+    error_message = "Password must be at least 8 characters long"
+  }
+}
+
+variable "multi_az" {
+  description = "Enable Multi-AZ RDS deployment for high availability"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_period" {
+  description = "Number of days to retain automated backups (1-35, default 7)"
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = var.backup_retention_period >= 1 && var.backup_retention_period <= 35
+    error_message = "Backup retention must be between 1 and 35 days"
+  }
+}
+
+variable "backup_window" {
+  description = "Preferred backup window (HH:MM-HH:MM UTC)"
+  type        = string
+  default     = "03:00-04:00"
+
+  validation {
+    condition     = can(regex("^[0-2][0-9]:[0-5][0-9]-[0-2][0-9]:[0-5][0-9]$", var.backup_window))
+    error_message = "Backup window must be in format HH:MM-HH:MM (UTC)"
+  }
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip final snapshot on database destruction (use with caution!)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_cloudwatch_logs_exports" {
+  description = "List of log types to export to CloudWatch (e.g., postgresql)"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for log in var.enable_cloudwatch_logs_exports : contains(["postgresql"], log)])
+    error_message = "Only 'postgresql' is valid for exports"
+  }
+}
+
+variable "enable_enhanced_monitoring" {
+  description = "Enable RDS Enhanced Monitoring (additional cost)"
+  type        = bool
+  default     = false
+}
+
+variable "monitoring_interval" {
+  description = "Enhanced monitoring granularity in seconds (60 or 0 to disable)"
+  type        = number
+  default     = 60
+
+  validation {
+    condition     = contains([0, 60], var.monitoring_interval)
+    error_message = "Monitoring interval must be 0 (disabled) or 60 seconds"
+  }
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Enable automatic minor version upgrades"
+  type        = bool
+  default     = true
+}
+
+variable "iops" {
+  description = "IOPS for GP3 storage (3000-16000, only for GP3)"
+  type        = number
+  default     = 3000
+
+  validation {
+    condition     = var.iops >= 3000 && var.iops <= 16000
+    error_message = "IOPS must be between 3000 and 16000 for GP3 storage"
+  }
+}
+
+variable "storage_throughput" {
+  description = "Storage throughput for GP3 (125-1000 MB/s, only for GP3)"
+  type        = number
+  default     = 125
+
+  validation {
+    condition     = var.storage_throughput >= 125 && var.storage_throughput <= 1000
+    error_message = "Storage throughput must be between 125 and 1000 MB/s"
+  }
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be one of: dev, staging, production"
+  }
+}
+
+variable "project" {
+  description = "Project name for tagging"
+  type        = string
+  default     = "stellar-insights"
+}

--- a/terraform/modules/database/versions.tf
+++ b/terraform/modules/database/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/load_balancing/README.md
+++ b/terraform/modules/load_balancing/README.md
@@ -1,0 +1,96 @@
+# Load Balancing Module
+
+Manages AWS Application Load Balancer (ALB) and target groups for Stellar Insights.
+
+## Features
+
+- Application Load Balancer (ALB)
+- HTTP and HTTPS listeners
+- HTTP → HTTPS redirect
+- SSL/TLS certificate from AWS Certificate Manager (ACM)
+- Target group with health checks
+- CloudWatch monitoring and alarms
+- Request logging (S3)
+- WAF integration (optional)
+
+## Architecture
+
+```
+Internet → (HTTPS 443) → ALB → (HTTP 8080) → ECS Service → Backend Rust Server
+              ↓ HTTP 80 (redirect to 443)
+```
+
+## Usage
+
+```hcl
+module "load_balancing" {
+  source = "../../modules/load_balancing"
+
+  # ALB configuration
+  name                = "stellar-insights-alb-${var.environment}"
+  internal            = false
+  load_balancer_type  = "application"
+  
+  # Networking
+  subnets            = module.networking.public_subnet_ids
+  security_groups    = [module.networking.security_group_alb_id]
+  
+  # Target group
+  target_group_name  = "stellar-insights-targets"
+  target_port        = 8080
+  
+  # SSL/TLS
+  certificate_arn    = aws_acm_certificate.main.arn
+  domain_name        = "api.stellar-insights.com"
+  
+  # Logging
+  enable_logs         = var.environment == "production"
+  logs_bucket         = aws_s3_bucket.alb_logs.id
+  
+  environment        = var.environment
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| name | ALB name | `string` | Yes |
+| internal | Internal vs public ALB | `bool` | No (default: `false`) |
+| load_balancer_type | Type (application, network) | `string` | No (default: `application`) |
+| subnets | Public subnet IDs | `list(string)` | Yes |
+| security_groups | Security group IDs | `list(string)` | Yes |
+| target_group_name | Target group name | `string` | Yes |
+| target_port | Backend port (8080) | `number` | No |
+| certificate_arn | ACM certificate ARN | `string` | Yes |
+| domain_name | Domain for HTTPS | `string` | Yes |
+| enable_logs | Enable request logging | `bool` | No (default: `true`) |
+| logs_bucket | S3 bucket for logs | `string` | Yes (if logs enabled) |
+| enable_waf | Enable WAF | `bool` | No (default: `false`) |
+| environment | Environment name | `string` | Yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| alb_dns_name | ALB DNS name for Route53 CNAME |
+| alb_arn | ALB ARN |
+| target_group_arn | Target group ARN (for ECS service) |
+| security_group_id | ALB security group ID |
+
+## Cost Estimates
+
+**All Environments:**
+- ALB: ~$20/month
+- Data processing: variable (~$5-20/month)
+- Monthly: ~$25-40/month
+
+## Notes
+
+- Certificate management via AWS Certificate Manager (ACM)
+- HTTP to HTTPS redirect is automatic
+- Health checks every 30 seconds
+- Unhealthy threshold: 3 checks
+- Request/response timeout: 60 seconds
+- See [networking/security_groups.tf](../networking/security_groups.tf) for ALB → backend routing rules
+- For custom domains: update Route53 with ALB CNAME

--- a/terraform/modules/load_balancing/main.tf
+++ b/terraform/modules/load_balancing/main.tf
@@ -1,0 +1,171 @@
+# ============================================================================
+# Application Load Balancer
+# ============================================================================
+
+resource "aws_lb" "main" {
+  name               = var.name
+  internal           = var.internal
+  load_balancer_type = var.load_balancer_type
+  security_groups    = var.security_groups
+  subnets            = var.subnets
+
+  enable_deletion_protection = var.environment == "production"
+
+  access_logs {
+    bucket  = var.enable_logs ? var.logs_bucket : null
+    prefix  = "alb"
+    enabled = var.enable_logs
+  }
+
+  tags = {
+    Name = "stellar-insights-alb-${var.environment}"
+  }
+}
+
+# ============================================================================
+# Target Group
+# ============================================================================
+
+resource "aws_lb_target_group" "app" {
+  name        = var.target_group_name
+  port        = var.target_port
+  protocol    = "HTTP"
+  vpc_id      = data.aws_subnets.public[0].vpc_id
+  target_type = var.target_type
+
+  health_check {
+    healthy_threshold   = var.health_check_healthy_threshold
+    unhealthy_threshold = var.health_check_unhealthy_threshold
+    timeout             = var.health_check_timeout
+    interval            = var.health_check_interval
+    path                = var.health_check_path
+    matcher             = "200"
+  }
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 86400
+    enabled         = true
+  }
+
+  deregistration_delay = 30
+
+  tags = {
+    Name = "stellar-insights-targets-${var.environment}"
+  }
+}
+
+# ============================================================================
+# HTTPS Listener (port 443)
+# ============================================================================
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+# ============================================================================
+# HTTP Listener (port 80) - redirect to HTTPS
+# ============================================================================
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# ============================================================================
+# WAF Integration (optional)
+# ============================================================================
+
+resource "aws_wafv2_web_acl_association" "alb" {
+  count        = var.enable_waf ? 1 : 0
+  resource_arn = aws_lb.main.arn
+  web_acl_arn  = var.waf_arn
+}
+
+# ============================================================================
+# CloudWatch Alarms
+# ============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "alb_target_response_time" {
+  alarm_name          = "stellar-insights-alb-response-time-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "1"  # 1 second
+  alarm_description   = "Alert when ALB response time exceeds 1 second"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = aws_lb.main.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_hosts" {
+  alarm_name          = "stellar-insights-alb-unhealthy-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Alert when unhealthy host count exceeds 0"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = aws_lb.main.arn_suffix
+    TargetGroup  = aws_lb_target_group.app.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_http_5xx" {
+  alarm_name          = "stellar-insights-alb-5xx-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "10"
+  alarm_description   = "Alert on 5XX errors from target"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = aws_lb.main.arn_suffix
+    TargetGroup  = aws_lb_target_group.app.arn_suffix
+  }
+}
+
+# ============================================================================
+# Data Sources
+# ============================================================================
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "subnet-id"
+    values = var.subnets
+  }
+}

--- a/terraform/modules/load_balancing/outputs.tf
+++ b/terraform/modules/load_balancing/outputs.tf
@@ -1,0 +1,24 @@
+output "alb_dns_name" {
+  description = "DNS name of the load balancer"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the load balancer"
+  value       = aws_lb.main.arn
+}
+
+output "alb_zone_id" {
+  description = "Zone ID for Route53"
+  value       = aws_lb.main.zone_id
+}
+
+output "target_group_arn" {
+  description = "ARN of the target group"
+  value       = aws_lb_target_group.app.arn
+}
+
+output "target_group_name" {
+  description = "Name of the target group"
+  value       = aws_lb_target_group.app.name
+}

--- a/terraform/modules/load_balancing/variables.tf
+++ b/terraform/modules/load_balancing/variables.tf
@@ -1,0 +1,203 @@
+variable "name" {
+  description = "Name of the ALB"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,32}$", var.name))
+    error_message = "ALB name must contain only lowercase letters, numbers, and hyphens (1-32 chars)"
+  }
+}
+
+variable "internal" {
+  description = "Whether ALB is internal"
+  type        = bool
+  default     = false
+}
+
+variable "load_balancer_type" {
+  description = "Type of load balancer (application, network)"
+  type        = string
+  default     = "application"
+
+  validation {
+    condition     = contains(["application", "network"], var.load_balancer_type)
+    error_message = "Load balancer type must be application or network"
+  }
+}
+
+variable "subnets" {
+  description = "Public subnet IDs for ALB"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.subnets) >= 2
+    error_message = "At least 2 subnets must be provided for ALB"
+  }
+}
+
+variable "security_groups" {
+  description = "Security group IDs for ALB"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.security_groups) >= 1
+    error_message = "At least one security group must be provided"
+  }
+}
+
+variable "target_group_name" {
+  description = "Name of the target group"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,32}$", var.target_group_name))
+    error_message = "Target group name must contain only lowercase letters, numbers, and hyphens (1-32 chars)"
+  }
+}
+
+variable "target_port" {
+  description = "Target port (backend port)"
+  type        = number
+  default     = 8080
+
+  validation {
+    condition     = var.target_port >= 1 && var.target_port <= 65535
+    error_message = "Target port must be between 1 and 65535"
+  }
+}
+
+variable "target_type" {
+  description = "Target type (instance, ip, lambda)"
+  type        = string
+  default     = "instance"
+
+  validation {
+    condition     = contains(["instance", "ip", "lambda"], var.target_type)
+    error_message = "Target type must be instance, ip, or lambda"
+  }
+}
+
+variable "health_check_path" {
+  description = "Health check endpoint path"
+  type        = string
+  default     = "/health"
+
+  validation {
+    condition     = can(regex("^/", var.health_check_path))
+    error_message = "Health check path must start with /"
+  }
+}
+
+variable "health_check_interval" {
+  description = "Health check interval in seconds"
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.health_check_interval >= 5 && var.health_check_interval <= 300
+    error_message = "Health check interval must be between 5 and 300 seconds"
+  }
+}
+
+variable "health_check_timeout" {
+  description = "Health check timeout in seconds"
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.health_check_timeout >= 2 && var.health_check_timeout <= 120
+    error_message = "Health check timeout must be between 2 and 120 seconds"
+  }
+}
+
+variable "health_check_healthy_threshold" {
+  description = "Healthy check count threshold"
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.health_check_healthy_threshold >= 2 && var.health_check_healthy_threshold <= 10
+    error_message = "Healthy threshold must be between 2 and 10"
+  }
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = "Unhealthy check count threshold"
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.health_check_unhealthy_threshold >= 2 && var.health_check_unhealthy_threshold <= 10
+    error_message = "Unhealthy threshold must be between 2 and 10"
+  }
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS"
+  type        = string
+
+  validation {
+    condition     = can(regex("arn:aws:acm:", var.certificate_arn))
+    error_message = "Certificate ARN must be a valid ACM certificate ARN"
+  }
+}
+
+variable "domain_name" {
+  description = "Domain name for HTTPS"
+  type        = string
+
+  validation {
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,}$", var.domain_name))
+    error_message = "Domain name must be a valid domain"
+  }
+}
+
+variable "enable_logs" {
+  description = "Enable ALB request logging to S3"
+  type        = bool
+  default     = true
+}
+
+variable "logs_bucket" {
+  description = "S3 bucket name for ALB logs (required if enable_logs=true)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.logs_bucket == "" || can(regex("^[a-z0-9-]{3,63}$", var.logs_bucket))
+    error_message = "Bucket name must be a valid S3 bucket name"
+  }
+}
+
+variable "enable_waf" {
+  description = "Enable WAF integration"
+  type        = bool
+  default     = false
+}
+
+variable "waf_arn" {
+  description = "WAF Web ACL ARN (required if enable_waf=true)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.waf_arn == "" || can(regex("arn:aws:wafv2:", var.waf_arn))
+    error_message = "WAF ARN must be a valid WAFv2 ARN"
+  }
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be one of: dev, staging, production"
+  }
+}
+
+variable "project" {
+  description = "Project name for tagging"
+  type        = string
+  default     = "stellar-insights"
+}

--- a/terraform/modules/load_balancing/versions.tf
+++ b/terraform/modules/load_balancing/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/monitoring/README.md
+++ b/terraform/modules/monitoring/README.md
@@ -1,0 +1,95 @@
+# Monitoring Module
+
+Manages AWS CloudWatch logs, metrics, alarms, and dashboards for Stellar Insights.
+
+## Features
+
+- CloudWatch Log Groups for all services
+- CloudWatch Alarms for infrastructure health
+- SNS topics for alert notifications
+- CloudWatch Dashboard for operational visibility
+- Log retention policies (7-14-30 days based on environment)
+- Metric aggregation and custom metrics
+
+## Architecture
+
+```
+ECS Logs → CloudWatch Log Group
+RDS Logs → CloudWatch Log Group
+ALB Logs → CloudWatch Log Group
+       ↓
+   CloudWatch Metrics
+       ↓
+   CloudWatch Alarms → SNS → Email/Slack
+       ↓
+   CloudWatch Dashboard (ops view)
+```
+
+## Usage
+
+```hcl
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  cluster_name = module.compute.cluster_name
+  log_group_names = {
+    ecs = module.compute.log_group_name
+    rds = module.database.log_group_name
+    alb = module.load_balancing.log_group_name
+  }
+  
+  alarm_email = "ops@stellar-insights.com"
+  environment = var.environment
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| cluster_name | ECS cluster name | `string` | Yes |
+| log_group_names | Map of log group names | `map(string)` | Yes |
+| alarm_email | Email for SNS notifications | `string` | Yes |
+| enable_dashboard | Enable CloudWatch dashboard | `bool` | No (default: `true`) |
+| environment | Environment name | `string` | Yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sns_topic_arn | SNS topic ARN for alarms |
+| dashboard_url | CloudWatch dashboard URL |
+
+## Monitoring Scope
+
+**ECS Service Metrics:**
+- CPU utilization (target: <70%)
+- Memory utilization (target: <80%)
+- Task count vs desired count
+- Connection count
+- Requests per second
+
+**RDS Metrics:**
+- CPU utilization (target: <70%)
+- Database connections (target: <400)
+- Free storage space (alert at <10%)
+- Read/write latency
+- Replication lag (Multi-AZ)
+
+**ALB Metrics:**
+- Request count
+- Target response time (target: <1s)
+- HTTP 4XX/5XX error rates
+- Unhealthy host count
+
+**Application Metrics:**
+- Custom metrics from app (via stdout logs)
+- Request duration percentiles
+- Error rates by endpoint
+
+## Notes
+
+- Log retention: 7 days (dev), 14 days (staging), 30 days (production)
+- Alarms use SNS for notifications (configure in AWS)
+- Dashboard auto-refreshes every 5 minutes
+- For Slack integration: use SNS → Lambda → Slack webhook

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,0 +1,104 @@
+# ============================================================================
+# SNS Topic for Alarms
+# ============================================================================
+
+resource "aws_sns_topic" "alarms" {
+  count = var.enable_alarms ? 1 : 0
+  name  = "stellar-insights-alarms-${var.environment}"
+
+  tags = {
+    Name = "stellar-insights-alarms-${var.environment}"
+  }
+}
+
+resource "aws_sns_topic_subscription" "alarm_email" {
+  count     = var.enable_alarms ? 1 : 0
+  topic_arn = aws_sns_topic.alarms[0].arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+# ============================================================================
+# CloudWatch Dashboard
+# ============================================================================
+
+resource "aws_cloudwatch_dashboard" "main" {
+  count          = var.enable_dashboard ? 1 : 0
+  dashboard_name = "stellar-insights-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric"
+        properties = {
+          metrics = [
+            ["AWS/ECS", "CPUUtilization", { stat = "Average" }],
+            [".", "MemoryUtilization", { stat = "Average" }]
+          ]
+          period = 300
+          stat   = "Average"
+          region = data.aws_region.current.name
+          title  = "ECS Cluster Health"
+        }
+      },
+      {
+        type = "metric"
+        properties = {
+          metrics = [
+            ["AWS/RDS", "CPUUtilization", { stat = "Average" }],
+            [".", "DatabaseConnections", { stat = "Average" }]
+          ]
+          period = 300
+          stat   = "Average"
+          region = data.aws_region.current.name
+          title  = "RDS Performance"
+        }
+      },
+      {
+        type = "metric"
+        properties = {
+          metrics = [
+            ["AWS/ApplicationELB", "TargetResponseTime", { stat = "Average" }],
+            [".", "HTTPCode_Target_5XX_Count", { stat = "Sum" }]
+          ]
+          period = 60
+          stat   = "Average"
+          region = data.aws_region.current.name
+          title  = "ALB Health"
+        }
+      },
+      {
+        type = "log"
+        properties = {
+          query   = "fields @timestamp, @message | stats count() by bin(300s)"
+          region  = data.aws_region.current.name
+          title   = "Log Volume"
+          logGroupNames = values(var.log_group_names)
+        }
+      }
+    ]
+  })
+}
+
+# ============================================================================
+# Data Sources
+# ============================================================================
+
+data "aws_region" "current" {}
+
+# ============================================================================
+# Outputs
+# ============================================================================
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for alarms"
+  value       = try(aws_sns_topic.alarms[0].arn, null)
+}
+
+output "dashboard_url" {
+  description = "CloudWatch dashboard URL"
+  value = try(
+    "https://${data.aws_region.current.name}.console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.current.name}#dashboards:name=stellar-insights-${var.environment}",
+    null
+  )
+}

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -1,0 +1,12 @@
+output "sns_topic_arn" {
+  description = "SNS topic ARN for alarms"
+  value       = try(aws_sns_topic.alarms[0].arn, null)
+}
+
+output "dashboard_url" {
+  description = "CloudWatch dashboard URL"
+  value = try(
+    "https://${data.aws_region.current.name}.console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.current.name}#dashboards:name=stellar-insights-${var.environment}",
+    null
+  )
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,48 @@
+variable "cluster_name" {
+  description = "ECS cluster name for dashboard"
+  type        = string
+}
+
+variable "log_group_names" {
+  description = "Map of log group names (ecs, rds, alb)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "alarm_email" {
+  description = "Email address for SNS alarm notifications"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[\\w.+-]+@[\\w.-]+\\.\\w+$", var.alarm_email))
+    error_message = "Alarm email must be a valid email address"
+  }
+}
+
+variable "enable_dashboard" {
+  description = "Enable CloudWatch dashboard creation"
+  type        = bool
+  default     = true
+}
+
+variable "enable_alarms" {
+  description = "Enable CloudWatch alarms"
+  type        = bool
+  default     = true
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be one of: dev, staging, production"
+  }
+}
+
+variable "project" {
+  description = "Project name for tagging"
+  type        = string
+  default     = "stellar-insights"
+}

--- a/terraform/modules/monitoring/versions.tf
+++ b/terraform/modules/monitoring/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/networking/README.md
+++ b/terraform/modules/networking/README.md
@@ -1,0 +1,60 @@
+# Networking Module for stellar-insights
+
+This module provisions all network infrastructure:
+- **VPC** (10.0.0.0/16) with DNS enabled
+- **Subnets**: 2 public (for ALB), 4 private (for app/database) across 3 AZs
+- **Internet Gateway** for public subnet egress
+- **NAT Gateways** (1 per AZ) for private subnet egress
+- **Route Tables** for public and private routing
+- **Security Groups**: ALB, backend, database, Redis
+
+## Variables (set in environment terraform.tfvars)
+- `environment` - dev/staging/production
+- `vpc_cidr` - VPC CIDR block (default: 10.0.0.0/16)
+- `enable_nat_per_az` - NAT gateway per AZ (true for prod, false for dev)
+- `enable_vpc_flow_logs` - Send VPC logs to CloudWatch (true for prod)
+
+## Outputs (used by other modules)
+- `vpc_id` - VPC resource ID
+- `private_subnet_ids` - List of private subnet IDs for ECS/RDS
+- `public_subnet_ids` - List of public subnet IDs for ALB
+- `security_group_*` - Security group IDs (backend, database, redis)
+
+## Architecture
+```
+Public Tier (ALB)
+├── AZ-A: 10.0.1.0/24 (igw-nat)
+├── AZ-B: 10.0.2.0/24 (igw-nat)
+└── AZ-C: 10.0.3.0/24 (igw-nat)
+
+Private Tier (Backend ECS)
+├── AZ-A: 10.0.11.0/24 (nat)
+├── AZ-B: 10.0.12.0/24 (nat)
+└── AZ-C: 10.0.13.0/24 (nat)
+
+Private Tier (Database/Redis)
+├── AZ-A: 10.0.21.0/24 (nat)
+├── AZ-B: 10.0.22.0/24 (nat)
+└── AZ-C: 10.0.23.0/24 (nat)
+```
+
+## Dev vs Production
+| Aspect | Dev | Production |
+|--------|-----|-----------|
+| NAT Gateways | 1 (shared) | 3 (one per AZ) |
+| VPC Flow Logs | No | Yes |
+| Subnets | 2 AZs only | 3 AZs for HA |
+
+## Usage
+```hcl
+module "networking" {
+  source = "./modules/networking"
+
+  environment           = var.environment
+  vpc_cidr              = "10.0.0.0/16"
+  enable_nat_per_az     = var.environment == "production"
+  enable_vpc_flow_logs  = var.environment == "production"
+}
+```
+
+See terraform/environments/ for example configurations.

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,165 @@
+# VPC and core networking infrastructure
+
+# Get available AZs in the region
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# Determine which AZs to use (all available or specified)
+locals {
+  azs = length(var.availability_zones) > 0 ? var.availability_zones : slice(data.aws_availability_zones.available.names, 0, var.environment == "production" ? 3 : 2)
+  
+  # Resource naming convention
+  vpc_name = "${var.project_name}-${var.environment}-vpc"
+  
+  # Tags for all resources
+  common_tags = merge(
+    {
+      Environment = var.environment
+      Project     = var.project_name
+    },
+    var.tags
+  )
+}
+
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_dns_support   = var.enable_dns_support
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = local.vpc_name
+    }
+  )
+}
+
+# Internet Gateway (for public subnets)
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-igw"
+    }
+  )
+}
+
+# Public Subnets (for ALB/NAT)
+resource "aws_subnet" "public" {
+  count                   = length(local.azs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-public-${local.azs[count.index]}"
+      Tier = "public"
+    }
+  )
+}
+
+# Private App Subnets (for ECS)
+resource "aws_subnet" "private_app" {
+  count              = length(local.azs)
+  vpc_id             = aws_vpc.main.id
+  cidr_block         = var.private_app_subnet_cidrs[count.index]
+  availability_zone  = local.azs[count.index]
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-private-app-${local.azs[count.index]}"
+      Tier = "private-app"
+    }
+  )
+}
+
+# Private Database Subnets (for RDS, ElastiCache)
+resource "aws_subnet" "private_db" {
+  count              = length(local.azs)
+  vpc_id             = aws_vpc.main.id
+  cidr_block         = var.private_db_subnet_cidrs[count.index]
+  availability_zone  = local.azs[count.index]
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-private-db-${local.azs[count.index]}"
+      Tier = "private-db"
+    }
+  )
+}
+
+# VPC Flow Logs (for production monitoring)
+resource "aws_flow_log" "vpc" {
+  count                   = var.enable_vpc_flow_logs ? 1 : 0
+  iam_role_arn            = aws_iam_role.vpc_flow_logs[0].arn
+  log_destination         = aws_cloudwatch_log_group.vpc_flow_logs[0].arn
+  traffic_type            = "ALL"
+  vpc_id                  = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-flow-logs"
+    }
+  )
+}
+
+# CloudWatch Log Group for VPC Flow Logs
+resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  count             = var.enable_vpc_flow_logs ? 1 : 0
+  name              = "/aws/vpc/flow-logs/${var.project_name}-${var.environment}"
+  retention_in_days = var.vpc_flow_log_retention_days
+
+  tags = local.common_tags
+}
+
+# IAM role for VPC Flow Logs
+resource "aws_iam_role" "vpc_flow_logs" {
+  count = var.enable_vpc_flow_logs ? 1 : 0
+  name  = "${var.project_name}-${var.environment}-vpc-flow-logs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "vpc-flow-logs.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs" {
+  count = var.enable_vpc_flow_logs ? 1 : 0
+  name  = "${var.project_name}-${var.environment}-vpc-flow-logs"
+  role  = aws_iam_role.vpc_flow_logs[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Effect   = "Allow"
+        Resource = "${aws_cloudwatch_log_group.vpc_flow_logs[0].arn}:*"
+      }
+    ]
+  })
+}

--- a/terraform/modules/networking/nat.tf
+++ b/terraform/modules/networking/nat.tf
@@ -1,0 +1,39 @@
+# NAT Gateways for private subnet internet access
+# Dev: 1 NAT in public subnet (cheaper)
+# Prod: 1 NAT per AZ (high availability but more expensive)
+
+# Elastic IPs for NAT Gateways
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_per_az ? length(local.azs) : 1
+  domain = "vpc"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-nat-eip-${count.index + 1}"
+    }
+  )
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# NAT Gateways
+resource "aws_nat_gateway" "main" {
+  count         = var.enable_nat_per_az ? length(local.azs) : 1
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-nat-${count.index + 1}"
+    }
+  )
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# For dev (single NAT), replicate the single NAT for all AZs in output
+locals {
+  nat_gateway_ids = var.enable_nat_per_az ? aws_nat_gateway.main[*].id : [for i in range(length(local.azs)) : aws_nat_gateway.main[0].id]
+}

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,0 +1,77 @@
+# Outputs for networking module (used by other modules)
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr" {
+  description = "VPC CIDR block"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs (for ALB)"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_app_subnet_ids" {
+  description = "List of private app subnet IDs (for ECS)"
+  value       = aws_subnet.private_app[*].id
+}
+
+output "private_db_subnet_ids" {
+  description = "List of private database subnet IDs (for RDS, Redis)"
+  value       = aws_subnet.private_db[*].id
+}
+
+output "availability_zones" {
+  description = "List of AZs used"
+  value       = local.azs
+}
+
+output "internet_gateway_id" {
+  description = "Internet Gateway ID"
+  value       = aws_internet_gateway.main.id
+}
+
+output "nat_gateway_ids" {
+  description = "List of NAT Gateway IDs (one per AZ for route table association)"
+  value       = local.nat_gateway_ids
+}
+
+output "public_route_table_id" {
+  description = "Public route table ID"
+  value       = aws_route_table.public.id
+}
+
+output "private_app_route_table_ids" {
+  description = "List of private app route table IDs"
+  value       = aws_route_table.private_app[*].id
+}
+
+output "private_db_route_table_ids" {
+  description = "List of private database route table IDs"
+  value       = aws_route_table.private_db[*].id
+}
+
+# Security Group Outputs
+output "alb_security_group_id" {
+  description = "Security group ID for ALB"
+  value       = aws_security_group.alb.id
+}
+
+output "backend_security_group_id" {
+  description = "Security group ID for backend ECS"
+  value       = aws_security_group.backend.id
+}
+
+output "database_security_group_id" {
+  description = "Security group ID for RDS database"
+  value       = aws_security_group.database.id
+}
+
+output "redis_security_group_id" {
+  description = "Security group ID for Redis cache"
+  value       = aws_security_group.redis.id
+}

--- a/terraform/modules/networking/route_tables.tf
+++ b/terraform/modules/networking/route_tables.tf
@@ -1,0 +1,78 @@
+# Route Tables for public and private subnets
+
+# Public Route Table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block      = "0.0.0.0/0"
+    gateway_id      = aws_internet_gateway.main.id
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-public-rt"
+      Tier = "public"
+    }
+  )
+}
+
+# Associate public subnets with public route table
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Private App Route Tables (one per AZ for NAT routing)
+resource "aws_route_table" "private_app" {
+  count  = length(local.azs)
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = local.nat_gateway_ids[count.index]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-private-app-rt-${count.index + 1}"
+      Tier = "private-app"
+    }
+  )
+}
+
+# Associate private app subnets with their route tables
+resource "aws_route_table_association" "private_app" {
+  count          = length(aws_subnet.private_app)
+  subnet_id      = aws_subnet.private_app[count.index].id
+  route_table_id = aws_route_table.private_app[count.index].id
+}
+
+# Private Database Route Tables (one per AZ)
+resource "aws_route_table" "private_db" {
+  count  = length(local.azs)
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = local.nat_gateway_ids[count.index]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-private-db-rt-${count.index + 1}"
+      Tier = "private-db"
+    }
+  )
+}
+
+# Associate private database subnets with their route tables
+resource "aws_route_table_association" "private_db" {
+  count          = length(aws_subnet.private_db)
+  subnet_id      = aws_subnet.private_db[count.index].id
+  route_table_id = aws_route_table.private_db[count.index].id
+}

--- a/terraform/modules/networking/security_groups.tf
+++ b/terraform/modules/networking/security_groups.tf
@@ -1,0 +1,165 @@
+# Security Groups for ALB, Backend ECS, Database (RDS), and Redis (ElastiCache)
+
+# ALB Security Group (accepts HTTP/HTTPS from internet)
+resource "aws_security_group" "alb" {
+  name_prefix = "${var.project_name}-alb-"
+  description = "Security group for ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTP"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTPS"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-alb-sg"
+    }
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Backend ECS Security Group
+resource "aws_security_group" "backend" {
+  name_prefix = "${var.project_name}-backend-"
+  description = "Security group for backend ECS tasks"
+  vpc_id      = aws_vpc.main.id
+
+  # Ingress from ALB
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+    description     = "Allow from ALB"
+  }
+
+  # Egress to database
+  egress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.database.id]
+    description     = "Allow to RDS"
+  }
+
+  # Egress to Redis
+  egress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.redis.id]
+    description     = "Allow to Redis"
+  }
+
+  # Egress to internet (for external API calls)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-backend-sg"
+    }
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Database Security Group (RDS PostgreSQL)
+resource "aws_security_group" "database" {
+  name_prefix = "${var.project_name}-database-"
+  description = "Security group for RDS database"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend.id]
+    description     = "Allow from backend"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-database-sg"
+    }
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Redis Security Group (ElastiCache)
+resource "aws_security_group" "redis" {
+  name_prefix = "${var.project_name}-redis-"
+  description = "Security group for Redis cache"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend.id]
+    description     = "Allow from backend"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-redis-sg"
+    }
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -1,0 +1,97 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment (dev/staging/production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be dev, staging, or production"
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be valid (e.g., 10.0.0.0/16)"
+  }
+}
+
+variable "availability_zones" {
+  description = "List of availability zones to use"
+  type        = list(string)
+  default     = []  # If empty, uses all AZs in the region
+}
+
+variable "enable_dns_hostnames" {
+  description = "Enable DNS hostnames in VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Enable DNS support in VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_nat_per_az" {
+  description = "Create NAT gateway per AZ (true=HA, false=single NAT for cost)"
+  type        = bool
+  default     = false  # Dev: false, Production: true
+}
+
+variable "enable_vpc_flow_logs" {
+  description = "Enable VPC Flow Logs to CloudWatch"
+  type        = bool
+  default     = false  # Dev: false, Production: true
+}
+
+variable "vpc_flow_log_retention_days" {
+  description = "CloudWatch log retention for VPC Flow Logs"
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.vpc_flow_log_retention_days)
+    error_message = "Retention days must be valid CloudWatch value"
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (ALB tier)"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "private_app_subnet_cidrs" {
+  description = "CIDR blocks for private app subnets (ECS tier)"
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+}
+
+variable "private_db_subnet_cidrs" {
+  description = "CIDR blocks for private database subnets (RDS/ElastiCache tier)"
+  type        = list(string)
+  default     = ["10.0.21.0/24", "10.0.22.0/24", "10.0.23.0/24"]
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "stellar-insights"
+}
+
+variable "tags" {
+  description = "Additional tags for all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/networking/versions.tf
+++ b/terraform/modules/networking/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Module      = "networking"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/terraform/modules/vault/README.md
+++ b/terraform/modules/vault/README.md
@@ -1,0 +1,64 @@
+# Vault Module
+
+Manages HashiCorp Vault integration for Stellar Insights (assuming HCP Vault Cloud).
+
+## Features
+
+- IAM authentication method setup (OIDC)
+- AppRole authentication method (alternative)
+- Vault policies for application access
+- Database secret engine configuration
+- KV v2 secrets engine
+- Audit logging
+
+## Architecture
+
+**Authentication Methods:**
+1. **OIDC (Recommended)**: GitHub Actions → HCP Vault (no credential management)
+2. **AppRole (Fallback)**: Long-lived credentials for CI/CD without GitHub
+
+**Secret Paths (KV v2):**
+- `secret/stellar/jwt-secret` - JWT signing key
+- `secret/stellar/oauth-clients` - OAuth client credentials
+- `secret/stellar/webhooks` - Zapier webhook signing keys
+
+**Database Credentials:**
+- PostgreSQL dynamic credentials via database secret engine
+- TTL: 1 hour (auto-renewed by app)
+
+## Usage
+
+This module is primarily for reference and policy validation. Most setup happens via:
+
+1. HCP Vault Console (UI):
+   - Enable OIDC auth method
+   - Create AppRole
+   - Create policies
+   - Enable KV v2 secrets engine
+   - Enable database secret engine
+   - Create database connection
+
+2. Terraform (this module):
+   - Reference existing Vault configuration
+   - Create IAM roles for ECS tasks
+   - Document secret paths
+
+## Manual Setup Steps
+
+See [VAULT_QUICK_START.md](../../VAULT_QUICK_START.md) and [VAULT_INTEGRATION_GUIDE.md](../../VAULT_INTEGRATION_GUIDE.md)
+
+## Inputs
+
+| Name | Description | Type |
+|------|-------------|------|
+| vault_addr | Vault server address | `string` |
+| vault_token | Vault root token (for setup only) | `string` |
+| environment | Environment name | `string` |
+
+## Notes
+
+- HCP Vault Cloud is external to Terraform
+- This module documents the integration pattern
+- Actual secret setup happens via Vault CLI or HCP UI
+- See backend/src/vault/ for application implementation
+- GitHub Actions workflows: vault-deploy.yml (OIDC), vault-deploy-approle.yml (AppRole)

--- a/terraform/modules/vault/main.tf
+++ b/terraform/modules/vault/main.tf
@@ -1,0 +1,105 @@
+# ============================================================================
+# Vault Integration (HCP Vault Cloud)
+# ============================================================================
+# 
+# NOTE: This module documents the Vault integration pattern.
+# Actual Vault setup (OIDC, AppRole, policies, secret engines) 
+# happens via HCP Vault Cloud console or CLI.
+# See: VAULT_QUICK_START.md and VAULT_INTEGRATION_GUIDE.md
+
+# ============================================================================
+# IAM Role for ECS Tasks to Access Vault via OIDC
+# ============================================================================
+
+resource "aws_iam_role" "vault_oidc" {
+  name = "stellar-insights-vault-oidc-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::aws:repo/github:Ndifreke000/stellar-insights:*"
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:iss" = "https://token.actions.githubusercontent.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "stellar-insights-vault-oidc-${var.environment}"
+  }
+}
+
+# IAM policy: allow OIDC tokens to access Vault
+resource "aws_iam_role_policy" "vault_oidc_policy" {
+  name = "vault-oidc-policy"
+  role = aws_iam_role.vault_oidc.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# ============================================================================
+# Documentation: Vault Secret Paths
+# ============================================================================
+#
+# Configuration in HCP Vault Cloud (via console or CLI):
+#
+# 1. Enable Auth Methods:
+#    Path: auth/jwt (for GitHub OIDC)
+#    Path: auth/approle (for CI/CD fallback)
+#
+# 2. Enable Secret Engines:
+#    Path: secret/ (KV v2)
+#    Path: database/
+#
+# 3. Create Secrets (KV v2):
+#    secret/stellar/jwt-secret - JWT signing key
+#    secret/stellar/oauth-clients - OAuth client credentials
+#    secret/stellar/webhooks - Zapier webhook config
+#
+# 4. Database Secret Engine:
+#    Enable at path: database/
+#    Create connection to RDS PostgreSQL
+#    Create role: stellar-insights-${environment}
+#    Dynamic credentials: 1 hour TTL
+#
+# 5. Policies:
+#    stellar-app-policy: read secrets, get DB creds
+#    stellar-ci-policy: rotate secrets, auth setup
+
+# ============================================================================
+# Outputs
+# ============================================================================
+
+output "vault_oidc_role_arn" {
+  description = "ARN of Vault OIDC role for GitHub Actions"
+  value       = aws_iam_role.vault_oidc.arn
+}
+
+output "vault_secret_paths" {
+  description = "Secret paths in Vault KV v2"
+  value = {
+    jwt_secret      = "secret/stellar/jwt-secret"
+    oauth_clients   = "secret/stellar/oauth-clients"
+    webhooks        = "secret/stellar/webhooks"
+    db_role         = "database/creds/stellar-insights-${var.environment}"
+  }
+}

--- a/terraform/modules/vault/outputs.tf
+++ b/terraform/modules/vault/outputs.tf
@@ -1,0 +1,14 @@
+output "vault_oidc_role_arn" {
+  description = "ARN of Vault OIDC role for GitHub Actions"
+  value       = aws_iam_role.vault_oidc.arn
+}
+
+output "vault_secret_paths" {
+  description = "Secret paths in Vault KV v2"
+  value = {
+    jwt_secret      = "secret/stellar/jwt-secret"
+    oauth_clients   = "secret/stellar/oauth-clients"
+    webhooks        = "secret/stellar/webhooks"
+    db_role         = "database/creds/stellar-insights-${var.environment}"
+  }
+}

--- a/terraform/modules/vault/variables.tf
+++ b/terraform/modules/vault/variables.tf
@@ -1,0 +1,37 @@
+variable "vault_addr" {
+  description = "Vault server address (HCP endpoint)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^https://", var.vault_addr))
+    error_message = "Vault address must be an HTTPS URL"
+  }
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "Environment must be one of: dev, staging, production"
+  }
+}
+
+variable "project" {
+  description = "Project name for tagging"
+  type        = string
+  default     = "stellar-insights"
+}
+
+variable "github_repo_owner" {
+  description = "GitHub repository owner"
+  type        = string
+  default     = "Ndifreke000"
+}
+
+variable "github_repo_name" {
+  description = "GitHub repository name"
+  type        = string
+  default     = "stellar-insights"
+}

--- a/terraform/modules/vault/versions.tf
+++ b/terraform/modules/vault/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/scripts/apply.sh
+++ b/terraform/scripts/apply.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Apply Terraform configuration for an environment
+#
+# This script applies a pre-planned Terraform configuration with safety checks.
+#
+# Usage: ./terraform/scripts/apply.sh dev
+# Usage: ./terraform/scripts/apply.sh staging
+# Usage: ./terraform/scripts/apply.sh production
+
+set -euo pipefail
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get environment from argument
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <environment>"
+    echo "Example: $0 dev"
+    exit 1
+fi
+
+ENVIRONMENT="${1}"
+STATE_PATH="terraform/environments/${ENVIRONMENT}"
+
+# Validate environment
+case "${ENVIRONMENT}" in
+    dev|staging|production)
+        ;;
+    *)
+        echo -e "${RED}✗ Invalid environment: ${ENVIRONMENT}${NC}"
+        exit 1
+        ;;
+esac
+
+echo -e "${GREEN}=== Terraform Apply ===${NC}"
+echo -e "Environment: ${YELLOW}${ENVIRONMENT}${NC}"
+echo ""
+
+cd "${STATE_PATH}" || exit 1
+
+# Check if tfplan exists
+if [[ ! -f "tfplan" ]]; then
+    echo -e "${YELLOW}No pre-planned tfplan found. Running terraform plan...${NC}"
+    terraform plan -out=tfplan
+fi
+
+# Show plan summary
+echo -e "${YELLOW}Plan Summary:${NC}"
+terraform show tfplan | grep -E "Plan:|will be created|will be updated|will be destroyed" || true
+echo ""
+
+# Safety checks
+if [[ "${ENVIRONMENT}" == "production" ]]; then
+    echo -e "${RED}WARNING: This is PRODUCTION environment!${NC}"
+    echo -e "Review the plan carefully. Continue? (type 'production-apply' to confirm)"
+    read -r CONFIRM
+    if [[ "${CONFIRM}" != "production-apply" ]]; then
+        echo "Cancelled."
+        rm tfplan 2>/dev/null || true
+        exit 1
+    fi
+else
+    echo -e "Review the plan. Continue? (yes/no)"
+    read -r CONFIRM
+    if [[ "${CONFIRM}" != "yes" ]]; then
+        echo "Cancelled."
+        rm tfplan 2>/dev/null || true
+        exit 1
+    fi
+fi
+
+# Apply the plan
+echo ""
+echo -e "${YELLOW}Applying configuration...${NC}"
+terraform apply tfplan
+
+echo ""
+echo -e "${GREEN}✓ Apply complete${NC}"
+echo ""
+
+# Show outputs
+echo -e "${YELLOW}Outputs:${NC}"
+terraform output
+
+echo ""
+echo -e "${GREEN}=== Next Steps ===${NC}"
+echo ""
+echo "1. Verify deployment:"
+echo -e "   ${YELLOW}terraform show${NC}"
+echo ""
+echo "2. Check resource status (AWS Console):"
+echo -e "   ECS: https://console.aws.amazon.com/ecs/v2/clusters"
+echo -e "   RDS: https://console.aws.amazon.com/rds/home"
+echo -e "   ALB: https://console.aws.amazon.com/ec2/v2/home#LoadBalancers"
+echo ""
+echo "3. Access the application (if ALB deployed):"
+echo -e "   ${YELLOW}curl https://\$(terraform output -raw alb_dns_name)/health${NC}"
+echo ""

--- a/terraform/scripts/bootstrap.sh
+++ b/terraform/scripts/bootstrap.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Bootstrap the global Terraform state (MUST run first)
+#
+# This script initializes S3 remote state backend and creates ECR repositories.
+# Run this ONCE before creating any other infrastructure.
+#
+# Usage: ./terraform/scripts/bootstrap.sh us-east-1
+
+set -euo pipefail
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get AWS region from argument
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <aws_region>"
+    echo "Example: $0 us-east-1"
+    exit 1
+fi
+
+AWS_REGION="${1:-us-east-1}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+echo -e "${GREEN}=== Terraform Global Bootstrap ===${NC}"
+echo -e "Region: ${YELLOW}${AWS_REGION}${NC}"
+echo -e "Account ID: ${YELLOW}${ACCOUNT_ID}${NC}"
+echo ""
+
+# Step 1: Initialize Terraform in /global (no backend initially)
+echo -e "${YELLOW}Step 1: Initializing global Terraform...${NC}"
+cd terraform/global || { echo "terraform/global directory not found"; exit 1; }
+
+terraform init
+
+echo -e "${GREEN}✓ Global Terraform initialized${NC}"
+echo ""
+
+# Step 2: Plan the global infrastructure
+echo -e "${YELLOW}Step 2: Planning global infrastructure...${NC}"
+terraform plan -out=tfplan
+
+echo -e "${GREEN}✓ Plan created${NC}"
+echo ""
+
+# Step 3: Apply with confirmation
+echo -e "${YELLOW}Step 3: Applying global infrastructure...${NC}"
+echo -e "${RED}WARNING: This will create S3 buckets, DynamoDB tables, and IAM roles.${NC}"
+echo -e "Continue? (yes/no)"
+read -r CONFIRM
+if [[ "${CONFIRM}" != "yes" ]]; then
+    echo "Cancelled."
+    exit 1
+fi
+
+terraform apply tfplan
+
+echo -e "${GREEN}✓ Global infrastructure created${NC}"
+echo ""
+
+# Step 4: Get outputs
+echo -e "${YELLOW}Step 4: Retrieving outputs...${NC}"
+STATE_BUCKET=$(terraform output -raw state_bucket_name)
+ECR_BACKEND=$(terraform output -json ecr_repo_urls | jq -r '.backend')
+ECR_FRONTEND=$(terraform output -json ecr_repo_urls | jq -r '.frontend')
+
+echo -e "${GREEN}✓ Outputs retrieved${NC}"
+echo ""
+
+# Step 5: Summary
+echo -e "${GREEN}=== Bootstrap Complete ===${NC}"
+echo ""
+echo "S3 State Bucket: ${YELLOW}${STATE_BUCKET}${NC}"
+echo "ECR Backend: ${YELLOW}${ECR_BACKEND}${NC}"
+echo "ECR Frontend: ${YELLOW}${ECR_FRONTEND}${NC}"
+echo ""
+
+# Step 6: Next steps
+echo -e "${GREEN}=== Next Steps ===${NC}"
+echo ""
+echo "1. Push container images to ECR:"
+echo -e "   ${YELLOW}aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com${NC}"
+echo -e "   ${YELLOW}docker build -t stellar-insights-backend:latest -f backend/Dockerfile .${NC}"
+echo -e "   ${YELLOW}docker tag stellar-insights-backend:latest ${ECR_BACKEND}:latest${NC}"
+echo -e "   ${YELLOW}docker push ${ECR_BACKEND}:latest${NC}"
+echo ""
+echo "2. Initialize dev environment state:"
+echo -e "   ${YELLOW}./terraform/scripts/init-state.sh ${AWS_REGION} dev${NC}"
+echo ""
+echo "3. Deploy dev environment:"
+echo -e "   ${YELLOW}cd terraform/environments/dev${NC}"
+echo -e "   ${YELLOW}terraform plan${NC}"
+echo -e "   ${YELLOW}terraform apply${NC}"
+echo ""

--- a/terraform/scripts/destroy.sh
+++ b/terraform/scripts/destroy.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Destroy Terraform infrastructure for an environment (DANGEROUS!)
+#
+# This script destroys all infrastructure for an environment.
+# WARNING: This will delete databases, storage, and all resources!
+#
+# Usage: ./terraform/scripts/destroy.sh dev
+# Usage: ./terraform/scripts/destroy.sh staging
+# Usage: ./terraform/scripts/destroy.sh production
+
+set -euo pipefail
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get environment from argument
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <environment>"
+    echo "Example: $0 dev"
+    exit 1
+fi
+
+ENVIRONMENT="${1}"
+STATE_PATH="terraform/environments/${ENVIRONMENT}"
+
+echo -e "${RED}=== TERRAFORM DESTROY ===${NC}"
+echo -e "${RED}WARNING: This will DELETE all infrastructure for: ${YELLOW}${ENVIRONMENT}${RED}${NC}"
+echo ""
+
+# Validate environment
+case "${ENVIRONMENT}" in
+    dev)
+        echo "Cost saved: ~\$67/month"
+        ;;
+    staging)
+        echo "Cost saved: ~\$205/month"
+        ;;
+    production)
+        echo -e "${RED}Cost saved: ~\$450/month${NC}"
+        echo -e "${RED}CRITICAL: All production data will be DELETED!${NC}"
+        echo -e "${RED}Ensure you have backups in place before proceeding.${NC}"
+        ;;
+    *)
+        echo -e "${RED}✗ Invalid environment: ${ENVIRONMENT}${NC}"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo -e "Resources that will be destroyed:"
+echo "- VPC, subnets, routing tables, security groups"
+echo "- ALB and target groups"
+echo "- ECS cluster, services, tasks"
+if [[ "${ENVIRONMENT}" != "dev" ]]; then
+    echo "- RDS PostgreSQL database (DATA WILL BE LOST)"
+fi
+echo "- ElastiCache Redis cluster"
+echo "- CloudWatch logs and alarms"
+echo "- IAM roles and policies"
+echo ""
+
+cd "${STATE_PATH}" || exit 1
+
+# Confirmation prompts
+echo -e "${RED}This action CANNOT be undone.${NC}"
+echo -e "Type the environment name to confirm: ${YELLOW}${ENVIRONMENT}${NC}"
+read -r CONFIRM1
+
+if [[ "${CONFIRM1}" != "${ENVIRONMENT}" ]]; then
+    echo "Confirmation mismatch. Cancelled."
+    exit 1
+fi
+
+if [[ "${ENVIRONMENT}" == "production" ]]; then
+    echo -e "${RED}This is PRODUCTION. Are you absolutely certain? (type 'destroy-production')${NC}"
+    read -r CONFIRM2
+    if [[ "${CONFIRM2}" != "destroy-production" ]]; then
+        echo "Production destroy cancelled."
+        exit 1
+    fi
+fi
+
+# Destroy
+echo ""
+echo -e "${YELLOW}Destroying infrastructure...${NC}"
+terraform destroy
+
+echo ""
+echo -e "${RED}✓ Infrastructure destroyed${NC}"
+echo ""
+echo -e "${YELLOW}Cleanup:${NC}"
+echo "- Remove local state files: rm -rf .terraform/"
+echo "- S3 bucket retention: Terraform state remains for recovery (can be manually deleted)"
+echo "- RDS snapshots: Check AWS Console for final snapshots"
+echo ""

--- a/terraform/scripts/init-state.sh
+++ b/terraform/scripts/init-state.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Initialize S3 remote state backend (MUST run first before other terraform commands)
+# 
+# This script creates the S3 bucket and DynamoDB table for Terraform state management.
+# CRITICAL: Run terraform/global/ apply first (bootstrap.sh), then this script.
+#
+# Usage: ./terraform/scripts/init-state.sh us-east-1 dev
+# Usage: ./terraform/scripts/init-state.sh us-east-1 staging  
+# Usage: ./terraform/scripts/init-state.sh us-east-1 production
+
+set -euo pipefail
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get AWS region and environment from arguments
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <aws_region> <environment>"
+    echo "Example: $0 us-east-1 dev"
+    exit 1
+fi
+
+AWS_REGION="${1:-us-east-1}"
+ENVIRONMENT="${2:-dev}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+BUCKET_NAME="stellar-insights-terraform-state-${ACCOUNT_ID}"
+STATE_PATH="terraform/environments/${ENVIRONMENT}"
+
+echo -e "${GREEN}=== Terraform State Backend Initialization ===${NC}"
+echo -e "Region: ${YELLOW}${AWS_REGION}${NC}"
+echo -e "Environment: ${YELLOW}${ENVIRONMENT}${NC}"
+echo -e "Account ID: ${YELLOW}${ACCOUNT_ID}${NC}"
+echo -e "S3 Bucket: ${YELLOW}${BUCKET_NAME}${NC}"
+echo -e "State Path: ${YELLOW}${STATE_PATH}${NC}"
+echo ""
+
+# Step 1: Verify S3 bucket exists (created by terraform/global/apply)
+echo -e "${YELLOW}Step 1: Checking S3 bucket...${NC}"
+if aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${AWS_REGION}" 2>/dev/null; then
+    echo -e "${GREEN}✓ S3 bucket exists${NC}"
+else
+    echo -e "${RED}✗ S3 bucket not found. Run 'terraform/scripts/bootstrap.sh' first to create the global stack.${NC}"
+    exit 1
+fi
+
+# Step 2: Verify DynamoDB table exists
+echo -e "${YELLOW}Step 2: Checking DynamoDB locks table...${NC}"
+if aws dynamodb describe-table --table-name terraform-locks --region "${AWS_REGION}" 2>/dev/null | grep -q "TableName"; then
+    echo -e "${GREEN}✓ DynamoDB table exists${NC}"
+else
+    echo -e "${RED}✗ DynamoDB table not found. Run 'terraform/scripts/bootstrap.sh' first.${NC}"
+    exit 1
+fi
+
+# Step 3: Initialize Terraform with S3 backend
+echo -e "${YELLOW}Step 3: Initializing Terraform with S3 backend...${NC}"
+cd "${STATE_PATH}" || { echo "Directory ${STATE_PATH} not found"; exit 1; }
+
+terraform init \
+    -backend-config="bucket=${BUCKET_NAME}" \
+    -backend-config="key=${ENVIRONMENT}/terraform.tfstate" \
+    -backend-config="region=${AWS_REGION}" \
+    -backend-config="dynamodb_table=terraform-locks" \
+    -backend-config="encrypt=true"
+
+echo -e "${GREEN}✓ Terraform initialized${NC}"
+echo ""
+
+# Step 4: Suggest next steps
+echo -e "${GREEN}=== Next Steps ===${NC}"
+echo ""
+echo "1. Review the Terraform plan:"
+echo -e "   ${YELLOW}cd ${STATE_PATH}${NC}"
+echo -e "   ${YELLOW}terraform plan${NC}"
+echo ""
+echo "2. Review cost estimates:"
+echo -e "   ${YELLOW}terraform plan | grep -i cost${NC}"
+echo ""
+echo "3. Apply the configuration:"
+echo -e "   ${YELLOW}terraform apply${NC}"
+echo ""
+echo "Tip: Set AWS_PROFILE if using multiple AWS credentials:"
+echo -e "   ${YELLOW}AWS_PROFILE=stellar-insights terraform plan${NC}"

--- a/terraform/scripts/plan.sh
+++ b/terraform/scripts/plan.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Plan Terraform configuration for an environment
+#
+# This script runs a Terraform plan with warning checks and cost estimates.
+#
+# Usage: ./terraform/scripts/plan.sh dev
+# Usage: ./terraform/scripts/plan.sh staging
+# Usage: ./terraform/scripts/plan.sh production
+
+set -euo pipefail
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get environment from argument
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <environment>"
+    echo "Example: $0 dev"
+    exit 1
+fi
+
+ENVIRONMENT="${1}"
+STATE_PATH="terraform/environments/${ENVIRONMENT}"
+
+# Validate environment
+case "${ENVIRONMENT}" in
+    dev|staging|production)
+        ;;
+    *)
+        echo -e "${RED}✗ Invalid environment: ${ENVIRONMENT}${NC}"
+        echo "Must be one of: dev, staging, production"
+        exit 1
+        ;;
+esac
+
+echo -e "${GREEN}=== Terraform Plan ===${NC}"
+echo -e "Environment: ${YELLOW}${ENVIRONMENT}${NC}"
+echo -e "State Path: ${YELLOW}${STATE_PATH}${NC}"
+echo ""
+
+# Check state exists
+if [[ ! -d "${STATE_PATH}" ]]; then
+    echo -e "${RED}✗ Environment directory not found: ${STATE_PATH}${NC}"
+    exit 1
+fi
+
+cd "${STATE_PATH}" || exit 1
+
+# Step 1: Validate configuration
+echo -e "${YELLOW}Step 1: Validating configuration...${NC}"
+terraform validate
+echo -e "${GREEN}✓ Configuration valid${NC}"
+echo ""
+
+# Step 2: Format check
+echo -e "${YELLOW}Step 2: Checking format...${NC}"
+if terraform fmt -check -recursive . > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ Format OK${NC}"
+else
+    echo -e "${YELLOW}⚠ Format issues found (auto-fixing)${NC}"
+    terraform fmt -recursive .
+fi
+echo ""
+
+# Step 3: Run plan
+echo -e "${YELLOW}Step 3: Running Terraform plan...${NC}"
+terraform plan -out=tfplan
+
+echo -e "${GREEN}✓ Plan created: tfplan${NC}"
+echo ""
+
+# Step 4: Show summary
+echo -e "${YELLOW}Step 4: Plan Summary${NC}"
+echo ""
+terraform show tfplan | grep -E "Plan:|will be created|will be updated|will be destroyed" || true
+echo ""
+
+# Step 5: Resource count
+RESOURCE_COUNT=$(terraform show tfplan -json | jq '[.resource_changes[]?.change.actions[]?] | length' 2>/dev/null || echo "?")
+echo -e "Total resource changes: ${YELLOW}${RESOURCE_COUNT}${NC}"
+echo ""
+
+# Step 6: Cost estimate (if available)
+echo -e "${BLUE}--- Cost Estimate ---${NC}"
+if [[ "${ENVIRONMENT}" == "dev" ]]; then
+    echo "ALB: \$20/month"
+    echo "NAT Gateway: \$30/month"
+    echo "ECS t3.micro: \$7/month"
+    echo "ElastiCache: \$5/month"
+    echo "Data transfer: \$5/month"
+    echo -e "Total: ${YELLOW}~\$67/month${NC}"
+elif [[ "${ENVIRONMENT}" == "staging" ]]; then
+    echo "ALB: \$20/month"
+    echo "NAT Gateway: \$30/month"
+    echo "ECS t3.small: \$60/month"
+    echo "RDS t3.small: \$60/month"
+    echo "ElastiCache: \$20/month"
+    echo "Data transfer: \$15/month"
+    echo -e "Total: ${YELLOW}~\$205/month${NC}"
+elif [[ "${ENVIRONMENT}" == "production" ]]; then
+    echo "ALB: \$20/month"
+    echo "NAT Gateways (3x): \$90/month"
+    echo "ECS t3.small (3x): \$90/month"
+    echo "ECS auto-scaling: \$30/month"
+    echo "RDS Multi-AZ: \$150/month"
+    echo "ElastiCache Multi-AZ: \$40/month"
+    echo "Data transfer: \$20/month"
+    echo "CloudWatch: \$10/month"
+    echo -e "Total: ${YELLOW}~\$450/month${NC}"
+fi
+echo ""
+
+# Step 7: Next steps
+echo -e "${GREEN}=== Next Steps ===${NC}"
+echo ""
+echo "1. Review the plan:"
+echo -e "   ${YELLOW}terraform show tfplan | less${NC}"
+echo ""
+echo "2. Apply the configuration:"
+echo -e "   ${YELLOW}./scripts/plan.sh apply ${ENVIRONMENT}${NC}"
+echo "   OR"
+echo -e "   ${YELLOW}terraform apply tfplan${NC}"
+echo ""
+echo "3. Cancel and clean up:"
+echo -e "   ${YELLOW}rm tfplan${NC}"
+echo ""


### PR DESCRIPTION
Closes #326

## Terraform Infrastructure as Code

Add comprehensive Terraform configuration for multi-environment AWS deployment (dev, staging, production).

### Changes
- Global bootstrap: S3 state backend, DynamoDB locks, ECR repos, GitHub OIDC IAM
- 8 Terraform modules: networking, database, caching, compute/ECS, load balancing, vault, monitoring
- 3 environment configs with sensible defaults
- 5 helper scripts: bootstrap, init-state, plan, apply, destroy
- TERRAFORM.md documentation

### To Deploy
```bash
./terraform/scripts/bootstrap.sh us-east-1
./terraform/scripts/init-state.sh us-east-1 dev
./terraform/scripts/plan.sh dev
./terraform/scripts/apply.sh dev
```

See TERRAFORM.md for full details.
