### PR TITLE
penetration testing integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"
+
+# Optionally ignore rules can be added here to exclude specific updates

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '0 2 * * *' # nightly at 02:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze (CodeQL)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: javascript,go,python,java,rust
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Run CodeQL analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        output: results/sarif/codeql.sarif
+
+    - name: Upload SARIF
+      if: always()
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: results/sarif/codeql.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,109 @@
+name: "Security: Trivy + tfsec"
+
+on:
+  pull_request:
+    branches: [ "main", "staging" ]
+  schedule:
+    - cron: '0 3 * * *' # nightly at 03:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  trivy-scan:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy (filesystem)
+        uses: aquasecurity/trivy-action@v0.9.1
+        with:
+          scan-type: filesystem
+          format: json
+          output: trivy-report.json
+
+      - name: Upload Trivy artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: trivy-report.json
+
+  tfsec-scan:
+    name: tfsec Terraform scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tfsec
+        uses: aquasecurity/tfsec-action@v1
+        with:
+          format: json
+          output: tfsec-report.json
+
+      - name: Upload tfsec artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfsec-report
+          path: tfsec-report.json
+
+  report:
+    name: Create issue & notify
+    needs: [trivy-scan, tfsec-scan]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Trivy artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: trivy-report
+
+      - name: Download tfsec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tfsec-report
+
+      - name: Summarize results
+        id: summarize
+        run: |
+          TRIVY_COUNT=0
+          TFSec_COUNT=0
+          if [ -f trivy-report.json ]; then
+            TRIVY_COUNT=$(jq '.Results[]?.Vulnerabilities | length' trivy-report.json 2>/dev/null | awk '{s+=$1} END{print s+0}')
+          fi
+          if [ -f tfsec-report.json ]; then
+            TFSec_COUNT=$(jq '.[] | length' tfsec-report.json 2>/dev/null | wc -l || true)
+          fi
+          echo "trivy_count=$TRIVY_COUNT" >> $GITHUB_OUTPUT
+          echo "tfsec_count=$TFSec_COUNT" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub issue for findings
+        if: needs.report.outputs.trivy_count != '0' || needs.report.outputs.tfsec_count != '0'
+        uses: peter-evans/create-issue@v4
+        with:
+          title: "[Security] Vulnerability findings from automated scans"
+          body: |
+            Automated security scans (Trivy, tfsec) found potential issues.
+
+            - Trivy findings: ${{ steps.summarize.outputs.trivy_count }}
+            - tfsec findings: ${{ steps.summarize.outputs.tfsec_count }}
+
+            Artifacts attached to this workflow contain detailed JSON reports.
+
+            Please triage and assign to the relevant owner.
+
+      - name: Send email notification (optional)
+        if: ${{ secrets.MAIL_HOST != '' && (steps.summarize.outputs.trivy_count != '0' || steps.summarize.outputs.tfsec_count != '0') }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.MAIL_HOST }}
+          server_port: ${{ secrets.MAIL_PORT }}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "[Security] Automated scan found issues in repo"
+          body: |
+            Automated security scans found findings.
+
+            Trivy: ${{ steps.summarize.outputs.trivy_count }}
+            tfsec: ${{ steps.summarize.outputs.tfsec_count }}
+          to: ${{ secrets.MAIL_TO }}
+          from: ${{ secrets.MAIL_FROM }}

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -1,0 +1,66 @@
+name: "OWASP ZAP: Staging scan"
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # nightly at 04:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  zap-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run OWASP ZAP baseline (docker)
+        env:
+          TARGET_URL: ${{ secrets.STAGING_URL }}
+        run: |
+          if [ -z "$TARGET_URL" ]; then
+            echo "STAGING_URL secret is not set; aborting ZAP scan.";
+            exit 78;
+          fi
+          docker run --rm -v $(pwd):/zap/wrk/:Z owasp/zap2docker-stable zap-baseline.py -t "$TARGET_URL" -r zap-report.html -J zap-report.json || true
+
+      - name: Upload ZAP artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-report
+          path: |
+            zap-report.html
+            zap-report.json
+
+      - name: Parse ZAP results and create issue
+        id: parse
+        run: |
+          if [ ! -f zap-report.json ]; then
+            echo "no_report=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          ALERTS=$(jq '[.site[].alerts[]?] | length' zap-report.json 2>/dev/null || echo 0)
+          echo "alerts=$ALERTS" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub issue for ZAP findings
+        if: steps.parse.outputs.alerts != '0'
+        uses: peter-evans/create-issue@v4
+        with:
+          title: "[Security][ZAP] Staging scan found vulnerabilities"
+          body: |
+            The nightly OWASP ZAP scan against staging found ${{ steps.parse.outputs.alerts }} alerts.
+
+            Download the scan artifacts from the workflow run for full detail.
+
+            Please triage and assign.
+
+      - name: Optional email notification for ZAP
+        if: ${{ secrets.MAIL_HOST != '' && steps.parse.outputs.alerts != '0' }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.MAIL_HOST }}
+          server_port: ${{ secrets.MAIL_PORT }}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "[Security][ZAP] Staging scan found ${{ steps.parse.outputs.alerts }} alerts"
+          body: "OWASP ZAP scan against staging found ${{ steps.parse.outputs.alerts }} alerts. See workflow artifacts for details."
+          to: ${{ secrets.MAIL_TO }}
+          from: ${{ secrets.MAIL_FROM }}

--- a/docs/PENTEST_RUNBOOK.md
+++ b/docs/PENTEST_RUNBOOK.md
@@ -1,0 +1,87 @@
+# Penetration Testing Runbook
+
+This runbook describes the automated penetration testing framework for Stellar Insights. It covers CI jobs, secrets required, triage steps, and manual run instructions.
+
+## Overview
+
+Automated scans added:
+- CodeQL (code analysis)
+- Dependabot (dependency updates)
+- Trivy (filesystem / container image scanning)
+- tfsec (Terraform static checks)
+- OWASP ZAP (dynamic scan against staging)
+
+Workflows added:
+- `.github/workflows/codeql-analysis.yml` (CodeQL on PRs + nightly)
+- `.github/dependabot.yml` (dependency updates)
+- `.github/workflows/security-scan.yml` (Trivy + tfsec on PRs + nightly)
+- `.github/workflows/zap-scan.yml` (OWASP ZAP against staging nightly)
+
+## Required repository secrets
+
+Add the following repository secrets (Actions → Settings → Secrets):
+
+- `STAGING_URL` — full URL of the staging deployment (https://staging.example.com)
+- `MAIL_HOST` — SMTP host (optional, for email alerts)
+- `MAIL_PORT` — SMTP port
+- `MAIL_USERNAME` — SMTP username
+- `MAIL_PASSWORD` — SMTP password
+- `MAIL_FROM` — From address for alerts
+- `MAIL_TO` — Comma-separated recipient list
+
+> If email is not configured, the workflows will still create GitHub issues for findings.
+
+## How to run locally
+
+### Trivy local scan
+
+```bash
+# install trivy
+brew install trivy
+trivy fs --format json -o trivy-report.json .
+jq . trivy-report.json
+```
+
+### tfsec local scan
+
+```bash
+# install tfsec
+brew install tfsec
+tfsec --format json -o tfsec-report.json terraform/
+```
+
+### ZAP local quick run
+
+```bash
+docker run --rm -v $(pwd):/zap/wrk/:Z owasp/zap2docker-stable zap-baseline.py -t "https://staging.example.com" -r zap-report.html -J zap-report.json
+```
+
+## Triage process
+
+1. When a GitHub issue is created by the workflow, add the appropriate label: `security/critical`, `security/high`, `security/medium`, `security/low`.
+2. Assign to the on-call owner or the `security` team.
+3. Reproduce findings locally using the commands above.
+4. For code-level issues, create a PR with a fix and reference the issue number.
+5. For dependency or infra issues, follow the remediation guidance (upgrade, patch, or change configuration).
+6. After remediation, close the GitHub issue and include verification steps.
+
+## False positives
+
+- If a finding is a false positive, document why in the issue and close it with the `security/false-positive` label.
+- Keep a short record in the issue for future reference.
+
+## Escalation
+
+- Critical findings: page on-call and open an incident channel (Slack/email).
+- High findings: triage within 24 hours.
+
+## Maintenance
+
+- Review and update `PENTEST_RUNBOOK.md` quarterly.
+- Update dependencies scanned by Dependabot weekly.
+- Review CodeQL alerts and suppress only with a documented rationale.
+
+## Contacts
+
+- Security owner: @Ndifreke000
+- Infrastructure owner: @Joewizy


### PR DESCRIPTION
Closes #344

Add automated penetration testing and security scanning to the CI pipeline and documentation.

What this PR does:
- Adds CodeQL analysis (PRs + nightly) for code-level vulnerabilities.
- Adds Dependabot configuration for weekly dependency updates.
- Adds Trivy (filesystem/container) and tfsec (Terraform) scans on PRs and nightly runs; uploads JSON reports and auto-creates issues for findings.
- Adds OWASP ZAP nightly dynamic scan against staging (uses `STAGING_URL` secret); uploads artifacts and auto-creates issues for findings.
- Adds PENTEST_RUNBOOK.md with run & triage instructions.
- Adds `issues/ISSUE-90-PENTEST-PLAN.md` with next steps and required repo secrets.

How to test / validate:
1. Add repository secret `STAGING_URL` (required for ZAP scans).
2. (Optional) Add SMTP secrets (`MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM`, `MAIL_TO`) if you want email notifications.
3. Trigger the workflows manually from the Actions UI or via GitHub CLI:
```bash
gh workflow run codeql-analysis.yml
gh workflow run security-scan.yml
gh workflow run zap-scan.yml
```
4. Check Actions run artifacts for JSON reports and created GitHub issues for any findings.

Notes & follow-up:
- Workflows will create GitHub issues for findings; triage and label issues (`security/critical`, `security/high`, etc.) per the runbook.
- Dependabot will open weekly PRs for dependency updates.
- Recommend running an initial manual ZAP scan against staging and triaging results before enabling automated schedules.