### PR TITLE
refactor: standardize inconsistent error handling patterns (#499)

### DIFF
--- a/backend/docs/ERROR_HANDLING_GUIDE.md
+++ b/backend/docs/ERROR_HANDLING_GUIDE.md
@@ -1,0 +1,25 @@
+# Error Handling Guide
+
+## Hierarchy
+
+- `DomainError`: business/domain validation and rule violations.
+- `ApiError`: HTTP-facing error envelope used by handlers.
+- `anyhow::Result<T>`: internal service/repository fallible operations where flexibility is needed.
+
+## Recommended Usage
+
+- Domain logic and validators should return `Result<T, DomainError>`.
+- API handlers should return `ApiResult<T>` and rely on `From` conversions.
+- Infrastructure-heavy internals can use `anyhow::Result<T>` and convert at API boundaries.
+
+## Conversion Rules
+
+- `DomainError` -> `ApiError`: via `impl From<DomainError> for ApiError`.
+- `sqlx::Error` -> `ApiError`: via existing conversion impl.
+- `crate::rpc::error::RpcError` -> `ApiError`: via conversion impl.
+
+## Anti-Patterns To Avoid
+
+- `Result<T, String>` in new domain or API code.
+- Manual string mapping at every API boundary.
+- Mixing ad-hoc custom response errors when `ApiError` can represent the failure.

--- a/backend/src/replay/config.rs
+++ b/backend/src/replay/config.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::DomainError;
+
 use super::EventFilter;
 
 /// Configuration for a replay operation
@@ -92,32 +94,45 @@ impl ReplayConfig {
     }
 
     /// Validate configuration
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> Result<(), DomainError> {
         if self.batch_size == 0 {
-            return Err("Batch size must be greater than 0".to_string());
+            return Err(DomainError::InvalidConfiguration(
+                "Batch size must be greater than 0".to_string(),
+            ));
         }
 
         if self.max_workers == 0 {
-            return Err("Max workers must be greater than 0".to_string());
+            return Err(DomainError::InvalidConfiguration(
+                "Max workers must be greater than 0".to_string(),
+            ));
         }
 
         if self.checkpoint_interval == 0 {
-            return Err("Checkpoint interval must be greater than 0".to_string());
+            return Err(DomainError::InvalidConfiguration(
+                "Checkpoint interval must be greater than 0".to_string(),
+            ));
         }
 
         if self.event_timeout_secs == 0 {
-            return Err("Event timeout must be greater than 0".to_string());
+            return Err(DomainError::InvalidConfiguration(
+                "Event timeout must be greater than 0".to_string(),
+            ));
         }
 
         match &self.range {
             ReplayRange::FromTo { start, end } => {
                 if start > end {
-                    return Err(format!("Invalid range: start ({}) > end ({})", start, end));
+                    return Err(DomainError::InvalidTimeRange {
+                        start: start.to_string(),
+                        end: end.to_string(),
+                    });
                 }
             }
             ReplayRange::FromCheckpoint { checkpoint_id } => {
                 if checkpoint_id.is_empty() {
-                    return Err("Checkpoint ID cannot be empty".to_string());
+                    return Err(DomainError::InvalidConfiguration(
+                        "Checkpoint ID cannot be empty".to_string(),
+                    ));
                 }
             }
             _ => {}

--- a/backend/src/replay/engine.rs
+++ b/backend/src/replay/engine.rs
@@ -41,7 +41,9 @@ impl ReplayEngine {
         state_builder: Arc<RwLock<StateBuilder>>,
     ) -> Result<Self> {
         // Validate configuration
-        config.validate().map_err(|e| ReplayError::ConfigError(e))?;
+        config
+            .validate()
+            .map_err(|e| ReplayError::ConfigError(e.to_string()))?;
 
         let session_id = uuid::Uuid::new_v4().to_string();
 


### PR DESCRIPTION
## Description
Standardizes error handling patterns by introducing a domain-level error type and explicit conversion boundaries into API errors. This removes stringly-typed domain failures in key paths and makes propagation more predictable.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Related Issue
Closes #499

## Changes Made
- Added `DomainError` in `backend/src/error.rs` to represent business/domain failures consistently.
- Added `From<DomainError> for ApiError` so API handlers can convert domain failures without ad-hoc mapping.
- Added `From<crate::rpc::error::RpcError> for ApiError` to unify RPC -> API boundary behavior.
- Migrated replay config validation to domain errors:
  - `ReplayConfig::validate()` now returns `Result<(), DomainError>`.
  - Replaced `String` validation failures with structured `DomainError` variants.
  - Updated replay engine to preserve existing replay error contract via `.to_string()` conversion.
- Migrated cost calculator helper from string errors to domain errors:
  - `resolve_usd_rate()` now returns `Result<f64, DomainError>`.
  - Callers now use `error.to_string()` when returning bad-request responses.
- Added `backend/docs/ERROR_HANDLING_GUIDE.md` with hierarchy and usage conventions (`DomainError`, `ApiError`, `anyhow::Result`).

## Testing
### Backend
```bash
cd backend
cargo check -q
```

### Frontend
```bash
Not run (backend-only refactor)
```

### Contracts
```bash
Not run
```

## Additional Notes
- `cargo check -q` still reports pre-existing compile issues unrelated to this PR (e.g., SQLx macro validation and `tracing_logstash::Layer` visibility).
- There is one unstaged local whitespace-only change in `backend/src/elk_health.rs` intentionally excluded from this PR.
