### PR TITLE
feat(contracts/analytics): add batch_submit_snapshots and batch_get_s…

### DIFF
--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Map};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -387,6 +387,114 @@ impl AnalyticsContract {
         }
 
         env.storage().instance().set(&DataKey::Paused, &paused);
+    }
+
+    /// Batch submit multiple snapshots in a single transaction.
+    /// Epochs must be strictly increasing within the batch and relative to the current latest.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `caller` - Address attempting to submit (must be the authorized admin)
+    /// * `snapshots` - Vector of (epoch, hash) pairs to submit
+    ///
+    /// # Returns
+    /// * Vector of ledger timestamps for each submitted snapshot
+    pub fn batch_submit_snapshots(
+        env: Env,
+        caller: Address,
+        snapshots: Vec<(u64, BytesN<32>)>,
+    ) -> Vec<u64> {
+        let is_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if is_paused {
+            panic!("Contract is paused for emergency maintenance");
+        }
+
+        caller.require_auth();
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized: admin not set");
+
+        if caller != admin {
+            panic!("Unauthorized: only the admin can submit snapshots");
+        }
+
+        let mut timestamps = Vec::new(&env);
+        let mut snapshots_map: Map<u64, SnapshotMetadata> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Snapshots)
+            .unwrap_or_else(|| Map::new(&env));
+        let mut latest: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LatestEpoch)
+            .unwrap_or(0);
+
+        for (epoch, hash) in snapshots.iter() {
+            if epoch == 0 {
+                panic!("Invalid epoch: must be greater than 0");
+            }
+            if epoch <= latest {
+                panic!("Epoch monotonicity violated: epoch must be strictly greater than latest");
+            }
+            if snapshots_map.contains_key(epoch) {
+                panic!("Snapshot immutability violated: epoch already exists in storage");
+            }
+
+            let timestamp = env.ledger().timestamp();
+            snapshots_map.set(
+                epoch,
+                SnapshotMetadata {
+                    epoch,
+                    timestamp,
+                    hash,
+                },
+            );
+            latest = epoch;
+            timestamps.push_back(timestamp);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Snapshots, &snapshots_map);
+        env.storage().instance().set(&DataKey::LatestEpoch, &latest);
+
+        env.events()
+            .publish((symbol_short!("batch"), caller), snapshots.len());
+
+        timestamps
+    }
+
+    /// Batch get multiple snapshots by epoch in a single call.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `epochs` - Vector of epoch numbers to retrieve
+    ///
+    /// # Returns
+    /// * Vector of Option<SnapshotMetadata> (None for epochs not found)
+    pub fn batch_get_snapshots(
+        env: Env,
+        epochs: Vec<u64>,
+    ) -> Vec<Option<SnapshotMetadata>> {
+        let snapshots: Map<u64, SnapshotMetadata> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Snapshots)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let mut results = Vec::new(&env);
+        for epoch in epochs.iter() {
+            results.push_back(snapshots.get(epoch));
+        }
+        results
     }
 
     /// Check if contract is paused

--- a/contracts/analytics/src/tests.rs
+++ b/contracts/analytics/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, BytesN, Env,
+    Address, BytesN, Env, Vec,
 };
 
 fn create_test_hash(env: &Env, value: u8) -> BytesN<32> {
@@ -452,4 +452,101 @@ fn test_old_admin_cannot_submit_after_transfer() {
     let epoch = 1u64;
     let hash = create_test_hash(&env, 1);
     client.submit_snapshot(&epoch, &hash, &admin);
+}
+
+// ============================================================================
+// Batch Operations Tests
+// ============================================================================
+
+#[test]
+fn test_batch_submit_snapshots() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    env.ledger().set_timestamp(1000);
+
+    let mut snapshots = Vec::new(&env);
+    snapshots.push_back((1u64, create_test_hash(&env, 1)));
+    snapshots.push_back((2u64, create_test_hash(&env, 2)));
+    snapshots.push_back((3u64, create_test_hash(&env, 3)));
+
+    let timestamps = client.batch_submit_snapshots(&admin, &snapshots);
+
+    assert_eq!(timestamps.len(), 3);
+    assert_eq!(client.get_latest_epoch(), 3);
+
+    assert_eq!(client.get_snapshot(&1u64).unwrap().hash, create_test_hash(&env, 1));
+    assert_eq!(client.get_snapshot(&2u64).unwrap().hash, create_test_hash(&env, 2));
+    assert_eq!(client.get_snapshot(&3u64).unwrap().hash, create_test_hash(&env, 3));
+}
+
+#[test]
+fn test_batch_get_snapshots() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    client.submit_snapshot(&1u64, &create_test_hash(&env, 1), &admin);
+    client.submit_snapshot(&2u64, &create_test_hash(&env, 2), &admin);
+    client.submit_snapshot(&3u64, &create_test_hash(&env, 3), &admin);
+
+    let mut epochs = Vec::new(&env);
+    epochs.push_back(1u64);
+    epochs.push_back(2u64);
+    epochs.push_back(99u64); // non-existent
+
+    let results = client.batch_get_snapshots(&epochs);
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results.get(0).unwrap().unwrap().hash, create_test_hash(&env, 1));
+    assert_eq!(results.get(1).unwrap().unwrap().hash, create_test_hash(&env, 2));
+    assert!(results.get(2).unwrap().is_none());
+}
+
+#[test]
+fn test_batch_operations_gas_efficiency() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    env.ledger().set_timestamp(5000);
+
+    // Submit 10 snapshots in a single batch call
+    let mut snapshots = Vec::new(&env);
+    for i in 1u64..=10 {
+        snapshots.push_back((i, create_test_hash(&env, i as u8)));
+    }
+
+    let timestamps = client.batch_submit_snapshots(&admin, &snapshots);
+    assert_eq!(timestamps.len(), 10);
+    assert_eq!(client.get_latest_epoch(), 10);
+
+    // Retrieve all 10 in a single batch call
+    let mut epochs = Vec::new(&env);
+    for i in 1u64..=10 {
+        epochs.push_back(i);
+    }
+
+    let results = client.batch_get_snapshots(&epochs);
+    assert_eq!(results.len(), 10);
+
+    for i in 0u32..10 {
+        let snapshot = results.get(i).unwrap().unwrap();
+        assert_eq!(snapshot.epoch, (i + 1) as u64);
+        assert_eq!(snapshot.hash, create_test_hash(&env, (i + 1) as u8));
+    }
 }


### PR DESCRIPTION
closes #601 

- Add batch_submit_snapshots: submits multiple (epoch, hash) pairs in one transaction, validates monotonicity and immutability per entry, emits a single batch event, returns timestamps Vec
- Add batch_get_snapshots: retrieves multiple snapshots by epoch in one call, returns Vec<Option<SnapshotMetadata>> (None for missing epochs)
- Load snapshots map once per batch call instead of once per snapshot, reducing redundant storage reads
- Add Vec and symbol_short to imports
- Add tests: test_batch_submit_snapshots, test_batch_get_snapshots, test_batch_operations_gas_efficiency

Closes #batch-operations