### PR TITLE
Add prune_old_snapshots to bound snapshot history growth

### DIFF
--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Map, Vec};
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map, String, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map, String, Vec,
+};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -200,18 +201,15 @@ fn validate_epoch(env: &Env, epoch: u64) -> u64 {
 }
 
 /// Write one snapshot to per-epoch persistent storage and update the shared map + latest epoch.
-/// `snapshots` is the already-loaded shared map (passed in to avoid a redundant read).
 fn write_snapshot(
     env: &Env,
     epoch: u64,
     metadata: &SnapshotMetadata,
     snapshots: &mut Map<u64, SnapshotMetadata>,
 ) {
-    // Per-epoch key — cheap individual read/write, used by get_snapshot
     env.storage()
         .persistent()
         .set(&DataKey::Snapshot(epoch), metadata);
-    // Shared map — kept for get_snapshot_history / get_all_epochs
     snapshots.set(epoch, metadata.clone());
     env.storage()
         .persistent()
@@ -242,12 +240,10 @@ impl AnalyticsContract {
 
     /// Submit a single snapshot. Panics on invalid input or unauthorized caller.
     pub fn submit_snapshot(env: Env, epoch: u64, hash: BytesN<32>, caller: Address) -> u64 {
-        if env
+        let is_paused: bool = env
             .storage()
             .instance()
             .get(&DataKey::Paused)
-            .unwrap_or(false)
-        {
             .unwrap_or(false);
         if is_paused {
             emit_error_event(
@@ -259,18 +255,16 @@ impl AnalyticsContract {
             );
             panic!("Contract is paused for emergency maintenance");
         }
-        caller.require_auth();
-        let admin = require_admin(&env);
 
-        // Enforce rate limit
+        caller.require_auth();
+
         check_rate_limit(&env, &caller);
 
-        // Verify caller is the authorized admin
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Contract not initialized: admin not set");
+            .unwrap_or_else(|| panic!("Contract not initialized: admin not set"));
 
         if caller != admin {
             emit_error_event(
@@ -282,7 +276,6 @@ impl AnalyticsContract {
             );
             panic!("Unauthorized: only the admin can submit snapshots");
         }
-        validate_epoch(&env, epoch);
 
         if epoch == 0 {
             emit_error_event(
@@ -301,29 +294,28 @@ impl AnalyticsContract {
             .get(&DataKey::LatestEpoch)
             .unwrap_or(0);
 
-        if epoch <= latest {
-            if epoch == latest {
-                emit_error_event(
-                    &env,
-                    ContractError::EpochAlreadyExists,
-                    "submit_snapshot",
-                    &caller,
-                    "Snapshot for this epoch already exists",
-                );
-                panic!("Snapshot for epoch {} already exists", epoch);
-            } else {
-                emit_error_event(
-                    &env,
-                    ContractError::EpochMonotonicityViolated,
-                    "submit_snapshot",
-                    &caller,
-                    "Epoch must be strictly greater than the latest epoch",
-                );
-                panic!(
-                    "Epoch monotonicity violated: epoch {} must be strictly greater than latest {}",
-                    epoch, latest
-                );
-            }
+        if epoch == latest {
+            emit_error_event(
+                &env,
+                ContractError::EpochAlreadyExists,
+                "submit_snapshot",
+                &caller,
+                "Snapshot for this epoch already exists",
+            );
+            panic!("Snapshot for epoch {} already exists", epoch);
+        }
+        if epoch < latest {
+            emit_error_event(
+                &env,
+                ContractError::EpochMonotonicityViolated,
+                "submit_snapshot",
+                &caller,
+                "Epoch must be strictly greater than the latest epoch",
+            );
+            panic!(
+                "Epoch monotonicity violated: epoch {} must be strictly greater than latest {}",
+                epoch, latest
+            );
         }
 
         let timestamp = env.ledger().timestamp();
@@ -332,23 +324,36 @@ impl AnalyticsContract {
             epoch,
             timestamp,
             hash: hash.clone(),
-            hash,
-            submitter: caller,
-            ledger_sequence: env.ledger().sequence(),
+            submitter: caller.clone(),
+            ledger_sequence,
             expires_at: None,
         };
+
         let mut snapshots: Map<u64, SnapshotMetadata> = env
             .storage()
             .persistent()
             .get(&DataKey::Snapshots)
             .unwrap_or_else(|| Map::new(&env));
+
         write_snapshot(&env, epoch, &metadata, &mut snapshots);
+
+        env.events().publish(
+            (symbol_short!("snapshot"), caller),
+            SnapshotSubmittedEvent {
+                epoch,
+                hash,
+                submitter: metadata.submitter,
+                timestamp,
+                previous_epoch: latest,
+                ledger_sequence,
+            },
+        );
+
         timestamp
     }
 
     /// Submit a batch of snapshots in a single call (single auth + admin check).
     /// Epochs must be provided in strictly increasing order.
-    /// Returns a Vec of timestamps, one per submitted snapshot.
     pub fn batch_submit(
         env: Env,
         snapshots_input: Vec<(u64, BytesN<32>)>,
@@ -373,32 +378,6 @@ impl AnalyticsContract {
             .persistent()
             .get(&DataKey::Snapshots)
             .unwrap_or_else(|| Map::new(&env));
-        // Defense-in-depth: explicitly prevent overwriting an existing snapshot
-        if snapshots.contains_key(epoch) {
-            emit_error_event(
-                &env,
-                ContractError::SnapshotImmutabilityViolated,
-                "submit_snapshot",
-                &caller,
-                "Epoch already exists in storage",
-            );
-            panic!("Snapshot immutability violated: epoch {} already exists in storage", epoch);
-            panic!(
-                "Snapshot immutability violated: epoch {} already exists in storage",
-                epoch
-            );
-        }
-
-        snapshots.set(epoch, metadata.clone());
-        env.storage()
-            .persistent()
-            .set(&DataKey::Snapshots, &snapshots);
-        env.storage().instance().set(&DataKey::LatestEpoch, &epoch);
-
-        // Also store per-epoch key for TTL management
-        env.storage()
-            .persistent()
-            .set(&DataKey::Snapshot(epoch), &metadata);
 
         let mut results = Vec::new(&env);
         for (epoch, hash) in snapshots_input.iter() {
@@ -429,14 +408,7 @@ impl AnalyticsContract {
         caller.require_auth();
         let admin = require_admin(&env);
 
-        // Enforce rate limit
         check_rate_limit(&env, &caller);
-
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("Contract not initialized: admin not set");
 
         if caller != admin {
             panic!("Unauthorized: only the admin can submit snapshots");
@@ -461,49 +433,23 @@ impl AnalyticsContract {
             .unwrap_or_else(|| Map::new(&env));
         write_snapshot(&env, epoch, &metadata, &mut snapshots);
 
+        // Extend per-epoch key's Soroban storage TTL
         let ledgers_to_live = (ttl / LEDGER_SECONDS) as u32;
-        snapshots.set(epoch, metadata.clone());
-        env.storage()
-            .persistent()
-            .set(&DataKey::Snapshots, &snapshots);
-        env.storage().instance().set(&DataKey::LatestEpoch, &epoch);
-
-        env.events().publish(
-            (symbol_short!("snapshot"), caller.clone()),
-            SnapshotSubmittedEvent {
-                epoch,
-                hash,
-                submitter: caller,
-                timestamp,
-                previous_epoch: latest,
-                ledger_sequence,
-            },
-        // Store per-epoch key and set Soroban storage TTL
-        let ledgers_to_live = (ttl / LEDGER_SECONDS) as u32;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Snapshot(epoch), &metadata);
         env.storage().persistent().extend_ttl(
             &DataKey::Snapshot(epoch),
             ledgers_to_live,
             ledgers_to_live,
         );
+
         timestamp
     }
 
-    /// Get snapshot by epoch — reads the cheap per-epoch key, not the full map.
-    /// Remove expired snapshots from the shared map.
+    /// Remove expired snapshots from storage.
     /// Admin-only. Iterates up to `max_to_clean` epochs and removes those past expiry.
     /// Returns the number of snapshots cleaned.
     pub fn cleanup_expired_snapshots(env: Env, admin: Address, max_to_clean: u32) -> u32 {
         admin.require_auth();
-
-        let stored_admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("Contract not initialized: admin not set");
-
+        let stored_admin = require_admin(&env);
         if admin != stored_admin {
             panic!("Unauthorized: only the admin can clean up snapshots");
         }
@@ -531,7 +477,9 @@ impl AnalyticsContract {
                 if let Some(expires_at) = metadata.expires_at {
                     if now > expires_at {
                         snapshots.remove(epoch);
-                        env.storage().persistent().remove(&DataKey::Snapshot(epoch));
+                        env.storage()
+                            .persistent()
+                            .remove(&DataKey::Snapshot(epoch));
                         cleaned += 1;
                     }
                 }
@@ -546,13 +494,11 @@ impl AnalyticsContract {
 
     /// Check whether a snapshot has expired.
     pub fn is_snapshot_expired(env: Env, epoch: u64) -> bool {
-        let snapshots: Map<u64, SnapshotMetadata> = env
+        match env
             .storage()
             .persistent()
-            .get(&DataKey::Snapshots)
-            .unwrap_or_else(|| Map::new(&env));
-
-        match snapshots.get(epoch) {
+            .get::<DataKey, SnapshotMetadata>(&DataKey::Snapshot(epoch))
+        {
             Some(metadata) => match metadata.expires_at {
                 Some(expires_at) => env.ledger().timestamp() > expires_at,
                 None => false,
@@ -561,14 +507,7 @@ impl AnalyticsContract {
         }
     }
 
-    /// Get snapshot metadata for a specific epoch
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `epoch` - Epoch to retrieve
-    ///
-    /// # Returns
-    /// * Snapshot metadata for the epoch, or None if not found
+    /// Get snapshot metadata for a specific epoch.
     pub fn get_snapshot(env: Env, epoch: u64) -> Option<SnapshotMetadata> {
         env.storage().persistent().get(&DataKey::Snapshot(epoch))
     }
@@ -601,9 +540,9 @@ impl AnalyticsContract {
             .unwrap_or(0)
     }
 
-    pub fn get_all_epochs(env: Env) -> soroban_sdk::Vec<u64> {
+    pub fn get_all_epochs(env: Env) -> Vec<u64> {
         let snapshots = Self::get_snapshot_history(env.clone());
-        let mut epochs = soroban_sdk::Vec::new(&env);
+        let mut epochs = Vec::new(&env);
         for (epoch, _) in snapshots.iter() {
             epochs.push_back(epoch);
         }
@@ -623,77 +562,8 @@ impl AnalyticsContract {
         env.storage().instance().set(&DataKey::Admin, &new_admin);
     }
 
-    pub fn cleanup_expired_snapshots(env: Env, admin: Address, max_to_clean: u32) -> u32 {
-        admin.require_auth();
-        let stored_admin = require_admin(&env);
-        if admin != stored_admin {
-            panic!("Unauthorized: only the admin can clean up snapshots");
-        }
-    /// Emergency pause the contract
-    ///
-    /// Pauses all snapshot submissions. Only the admin can pause the contract.
-    /// Read operations remain available during pause.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `caller` - Address attempting to pause (must be admin)
-    ///
-    /// # Panics
-    /// * If contract is not initialized (admin not set)
-    /// * If caller is not the admin
+    /// Emergency pause the contract.
     pub fn pause(env: Env, caller: Address, reason: String) {
-        caller.require_auth();
-
-        let now = env.ledger().timestamp();
-        let mut cleaned = 0u32;
-        let latest_epoch: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::LatestEpoch)
-            .unwrap_or(0);
-
-        let mut snapshots: Map<u64, SnapshotMetadata> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Snapshots)
-            .unwrap_or_else(|| Map::new(&env));
-
-        for epoch in 1..=latest_epoch {
-            if cleaned >= max_to_clean {
-                break;
-            }
-            if let Some(metadata) = snapshots.get(epoch) {
-                if let Some(expires_at) = metadata.expires_at {
-                    if now > expires_at {
-                        snapshots.remove(epoch);
-                        env.storage().persistent().remove(&DataKey::Snapshot(epoch));
-                        cleaned += 1;
-                    }
-                }
-            }
-        }
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Snapshots, &snapshots);
-        cleaned
-    }
-
-    pub fn is_snapshot_expired(env: Env, epoch: u64) -> bool {
-        match env
-            .storage()
-            .persistent()
-            .get::<DataKey, SnapshotMetadata>(&DataKey::Snapshot(epoch))
-        {
-            Some(metadata) => match metadata.expires_at {
-                Some(expires_at) => env.ledger().timestamp() > expires_at,
-                None => false,
-            },
-            None => false,
-        }
-    }
-
-    pub fn pause(env: Env, caller: Address) {
         caller.require_auth();
         let admin = require_admin(&env);
         if caller != admin {
@@ -712,18 +582,7 @@ impl AnalyticsContract {
         );
     }
 
-    pub fn unpause(env: Env, caller: Address) {
-    /// Unpause the contract
-    ///
-    /// Resumes normal operations. Only the admin can unpause the contract.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `caller` - Address attempting to unpause (must be admin)
-    ///
-    /// # Panics
-    /// * If contract is not initialized (admin not set)
-    /// * If caller is not the admin
+    /// Unpause the contract.
     pub fn unpause(env: Env, caller: Address, reason: String) {
         caller.require_auth();
         let admin = require_admin(&env);
@@ -783,15 +642,6 @@ impl AnalyticsContract {
     }
 
     /// Batch submit multiple snapshots in a single transaction.
-    /// Epochs must be strictly increasing within the batch and relative to the current latest.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `caller` - Address attempting to submit (must be the authorized admin)
-    /// * `snapshots` - Vector of (epoch, hash) pairs to submit
-    ///
-    /// # Returns
-    /// * Vector of ledger timestamps for each submitted snapshot
     pub fn batch_submit_snapshots(
         env: Env,
         caller: Address,
@@ -812,52 +662,34 @@ impl AnalyticsContract {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Contract not initialized: admin not set");
+            .unwrap_or_else(|| panic!("Contract not initialized: admin not set"));
 
         if caller != admin {
             panic!("Unauthorized: only the admin can submit snapshots");
         }
 
-        let mut timestamps = Vec::new(&env);
         let mut snapshots_map: Map<u64, SnapshotMetadata> = env
             .storage()
             .persistent()
             .get(&DataKey::Snapshots)
             .unwrap_or_else(|| Map::new(&env));
-        let mut latest: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::LatestEpoch)
-            .unwrap_or(0);
 
+        let mut timestamps = Vec::new(&env);
         for (epoch, hash) in snapshots.iter() {
-            if epoch == 0 {
-                panic!("Invalid epoch: must be greater than 0");
-            }
-            if epoch <= latest {
-                panic!("Epoch monotonicity violated: epoch must be strictly greater than latest");
-            }
-            if snapshots_map.contains_key(epoch) {
-                panic!("Snapshot immutability violated: epoch already exists in storage");
-            }
+            validate_epoch(&env, epoch);
 
             let timestamp = env.ledger().timestamp();
-            snapshots_map.set(
+            let metadata = SnapshotMetadata {
                 epoch,
-                SnapshotMetadata {
-                    epoch,
-                    timestamp,
-                    hash,
-                },
-            );
-            latest = epoch;
+                timestamp,
+                hash,
+                submitter: caller.clone(),
+                ledger_sequence: env.ledger().sequence(),
+                expires_at: None,
+            };
+            write_snapshot(&env, epoch, &metadata, &mut snapshots_map);
             timestamps.push_back(timestamp);
         }
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Snapshots, &snapshots_map);
-        env.storage().instance().set(&DataKey::LatestEpoch, &latest);
 
         env.events()
             .publish((symbol_short!("batch"), caller), snapshots.len());
@@ -865,18 +697,8 @@ impl AnalyticsContract {
         timestamps
     }
 
-    /// Batch get multiple snapshots by epoch in a single call.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `epochs` - Vector of epoch numbers to retrieve
-    ///
-    /// # Returns
-    /// * Vector of Option<SnapshotMetadata> (None for epochs not found)
-    pub fn batch_get_snapshots(
-        env: Env,
-        epochs: Vec<u64>,
-    ) -> Vec<Option<SnapshotMetadata>> {
+    /// Batch get multiple snapshots by epoch.
+    pub fn batch_get_snapshots(env: Env, epochs: Vec<u64>) -> Vec<Option<SnapshotMetadata>> {
         let snapshots: Map<u64, SnapshotMetadata> = env
             .storage()
             .persistent()
@@ -891,7 +713,6 @@ impl AnalyticsContract {
     }
 
     /// Propose an admin change with a 48-hour timelock.
-    /// Only the current admin can propose. Returns the action ID.
     pub fn propose_admin_change(env: Env, proposer: Address, new_admin: Address) -> u64 {
         proposer.require_auth();
 
@@ -899,7 +720,7 @@ impl AnalyticsContract {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Contract not initialized: admin not set");
+            .unwrap_or_else(|| panic!("Contract not initialized: admin not set"));
 
         if proposer != admin {
             panic!("Unauthorized: only the admin can propose changes");
@@ -944,7 +765,7 @@ impl AnalyticsContract {
             .storage()
             .persistent()
             .get(&DataKey::TimelockAction(action_id))
-            .expect("Action not found");
+            .unwrap_or_else(|| panic!("Action not found"));
 
         if env.ledger().timestamp() < action.executable_at {
             panic!("Timelock not expired: action cannot be executed yet");
@@ -975,7 +796,7 @@ impl AnalyticsContract {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Contract not initialized: admin not set");
+            .unwrap_or_else(|| panic!("Contract not initialized: admin not set"));
 
         if admin != stored_admin {
             panic!("Unauthorized: only the admin can cancel actions");
@@ -996,13 +817,58 @@ impl AnalyticsContract {
             .get(&DataKey::TimelockAction(action_id))
     }
 
-    /// Check if contract is paused
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    ///
-    /// # Returns
-    /// * `true` if contract is paused, `false` otherwise
+    /// Prune old snapshots, keeping only the last N epochs.
+    /// Only admin can call this.
+    /// Returns the number of snapshots removed.
+    pub fn prune_old_snapshots(env: Env, caller: Address, keep_last_n: u32) -> u32 {
+        caller.require_auth();
+        let admin = require_admin(&env);
+        if caller != admin {
+            panic!("Unauthorized: only the admin can prune snapshots");
+        }
+
+        let latest_epoch: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LatestEpoch)
+            .unwrap_or(0);
+
+        if latest_epoch <= keep_last_n as u64 {
+            return 0;
+        }
+
+        let cutoff_epoch = latest_epoch - keep_last_n as u64;
+
+        let mut snapshots: Map<u64, SnapshotMetadata> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Snapshots)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let mut removed = 0u32;
+        for epoch in 1..=cutoff_epoch {
+            if snapshots.contains_key(epoch) {
+                snapshots.remove(epoch);
+                env.storage()
+                    .persistent()
+                    .remove(&DataKey::Snapshot(epoch));
+                removed += 1;
+            }
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Snapshots, &snapshots);
+
+        env.events().publish(
+            (symbol_short!("prune"), caller),
+            (removed, cutoff_epoch),
+        );
+
+        removed
+    }
+
+    /// Check if contract is paused.
     pub fn is_paused(env: Env) -> bool {
         env.storage()
             .instance()

--- a/contracts/analytics/src/tests.rs
+++ b/contracts/analytics/src/tests.rs
@@ -1,13 +1,16 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    vec, Address, BytesN, Env,
-    Address, BytesN, Env, Vec,
+    vec, Address, BytesN, Env, Vec,
 };
 
 fn create_test_hash(env: &Env, value: u8) -> BytesN<32> {
     BytesN::from_array(env, &[value; 32])
 }
+
+// ============================================================================
+// Initialization Tests
+// ============================================================================
 
 #[test]
 fn test_initialization() {
@@ -40,6 +43,10 @@ fn test_initialize_cannot_reinitialize() {
     // Second initialization should fail
     client.initialize(&admin);
 }
+
+// ============================================================================
+// Single Snapshot Tests
+// ============================================================================
 
 #[test]
 fn test_submit_single_snapshot() {
@@ -267,7 +274,6 @@ fn test_bounded_storage_growth_simulation() {
 
     client.initialize(&admin);
 
-    // Use a smaller set to stay within budget limits
     let num_epochs = 20u64;
     for epoch in 1..=num_epochs {
         let hash = create_test_hash(&env, (epoch % 255) as u8);
@@ -284,7 +290,7 @@ fn test_bounded_storage_growth_simulation() {
 }
 
 // ============================================================================
-// Access Control Tests - Tests for Issue #41
+// Access Control Tests
 // ============================================================================
 
 #[test]
@@ -304,7 +310,6 @@ fn test_unauthorized_submission_fails() {
     let epoch = 1u64;
     let hash = create_test_hash(&env, 1);
 
-    // Attempt to submit snapshot with unauthorized address should fail
     client.submit_snapshot(&epoch, &hash, &unauthorized_user);
 }
 
@@ -325,7 +330,6 @@ fn test_authorized_submission_succeeds() {
     let epoch = 1u64;
     let hash = create_test_hash(&env, 1);
 
-    // Authorized admin should be able to submit
     let timestamp = client.submit_snapshot(&epoch, &hash, &admin);
 
     assert_eq!(timestamp, 1000);
@@ -343,13 +347,11 @@ fn test_get_admin() {
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
 
-    // Before initialization, admin should be None
     assert_eq!(client.get_admin(), None);
 
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
-    // After initialization, admin should match
     assert_eq!(client.get_admin(), Some(admin));
 }
 
@@ -367,11 +369,9 @@ fn test_set_admin_by_authorized_admin() {
     client.initialize(&admin);
     assert_eq!(client.get_admin(), Some(admin.clone()));
 
-    // Current admin transfers rights to new admin
     client.set_admin(&admin, &new_admin);
     assert_eq!(client.get_admin(), Some(new_admin.clone()));
 
-    // New admin can now submit snapshots
     let epoch = 1u64;
     let hash = create_test_hash(&env, 1);
     client.submit_snapshot(&epoch, &hash, &new_admin);
@@ -394,7 +394,6 @@ fn test_set_admin_by_unauthorized_user_fails() {
 
     client.initialize(&admin);
 
-    // Unauthorized user attempts to change admin should fail
     client.set_admin(&unauthorized_user, &new_admin);
 }
 
@@ -412,7 +411,6 @@ fn test_snapshot_immutability() {
 
     let epoch = 1u64;
     client.submit_snapshot(&epoch, &create_test_hash(&env, 1), &admin);
-    // Attempting to overwrite an existing snapshot must panic
     client.submit_snapshot(&epoch, &create_test_hash(&env, 2), &admin);
 }
 
@@ -447,10 +445,8 @@ fn test_old_admin_cannot_submit_after_transfer() {
 
     client.initialize(&admin);
 
-    // Transfer admin rights
     client.set_admin(&admin, &new_admin);
 
-    // Old admin should no longer be able to submit
     let epoch = 1u64;
     let hash = create_test_hash(&env, 1);
     client.submit_snapshot(&epoch, &hash, &admin);
@@ -462,11 +458,6 @@ fn test_old_admin_cannot_submit_after_transfer() {
 
 #[test]
 fn test_batch_submit_snapshots() {
-// Snapshot Expiry Tests
-// ============================================================================
-
-#[test]
-fn test_snapshot_expiry() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -487,33 +478,22 @@ fn test_snapshot_expiry() {
     assert_eq!(timestamps.len(), 3);
     assert_eq!(client.get_latest_epoch(), 3);
 
-    assert_eq!(client.get_snapshot(&1u64).unwrap().hash, create_test_hash(&env, 1));
-    assert_eq!(client.get_snapshot(&2u64).unwrap().hash, create_test_hash(&env, 2));
-    assert_eq!(client.get_snapshot(&3u64).unwrap().hash, create_test_hash(&env, 3));
+    assert_eq!(
+        client.get_snapshot(&1u64).unwrap().hash,
+        create_test_hash(&env, 1)
+    );
+    assert_eq!(
+        client.get_snapshot(&2u64).unwrap().hash,
+        create_test_hash(&env, 2)
+    );
+    assert_eq!(
+        client.get_snapshot(&3u64).unwrap().hash,
+        create_test_hash(&env, 3)
+    );
 }
 
 #[test]
 fn test_batch_get_snapshots() {
-
-    // Submit at t=1000 with 500s TTL -> expires at t=1500
-    env.ledger().set_timestamp(1000);
-    let hash = create_test_hash(&env, 1);
-    client.submit_snapshot_with_ttl(&1u64, &hash, &admin, &Some(500u64));
-
-    let snapshot = client.get_snapshot(&1u64).unwrap();
-    assert_eq!(snapshot.expires_at, Some(1500u64));
-
-    // Before expiry: not expired
-    env.ledger().set_timestamp(1499);
-    assert!(!client.is_snapshot_expired(&1u64));
-
-    // After expiry: expired
-    env.ledger().set_timestamp(1501);
-    assert!(client.is_snapshot_expired(&1u64));
-}
-
-#[test]
-fn test_snapshot_default_ttl() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -535,24 +515,19 @@ fn test_snapshot_default_ttl() {
     let results = client.batch_get_snapshots(&epochs);
 
     assert_eq!(results.len(), 3);
-    assert_eq!(results.get(0).unwrap().unwrap().hash, create_test_hash(&env, 1));
-    assert_eq!(results.get(1).unwrap().unwrap().hash, create_test_hash(&env, 2));
+    assert_eq!(
+        results.get(0).unwrap().unwrap().hash,
+        create_test_hash(&env, 1)
+    );
+    assert_eq!(
+        results.get(1).unwrap().unwrap().hash,
+        create_test_hash(&env, 2)
+    );
     assert!(results.get(2).unwrap().is_none());
 }
 
 #[test]
 fn test_batch_operations_gas_efficiency() {
-    env.ledger().set_timestamp(0);
-    let hash = create_test_hash(&env, 1);
-    client.submit_snapshot_with_ttl(&1u64, &hash, &admin, &None);
-
-    let snapshot = client.get_snapshot(&1u64).unwrap();
-    // Default TTL is 90 days = 7_776_000 seconds
-    assert_eq!(snapshot.expires_at, Some(7_776_000u64));
-}
-
-#[test]
-fn test_snapshot_no_expiry_by_default() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -589,12 +564,135 @@ fn test_snapshot_no_expiry_by_default() {
     }
 }
 
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_batch_submit_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    client.initialize(&admin);
+
+    let input = vec![&env, (1u64, create_test_hash(&env, 1))];
+    client.batch_submit(&input, &attacker);
+}
+
+#[test]
+#[should_panic(expected = "Epoch monotonicity violated")]
+fn test_batch_submit_non_monotonic_epochs() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // epoch 5 then epoch 3 — must panic
+    let input = vec![
+        &env,
+        (5u64, create_test_hash(&env, 5)),
+        (3u64, create_test_hash(&env, 3)),
+    ];
+    client.batch_submit(&input, &admin);
+}
+
+#[test]
+fn test_batch_submit_basic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(1000);
+
+    let hash1 = create_test_hash(&env, 1);
+    let hash2 = create_test_hash(&env, 2);
+    let hash3 = create_test_hash(&env, 3);
+
+    let input = vec![
+        &env,
+        (1u64, hash1.clone()),
+        (2u64, hash2.clone()),
+        (3u64, hash3.clone()),
+    ];
+    let timestamps = client.batch_submit(&input, &admin);
+
+    assert_eq!(timestamps.len(), 3);
+    assert_eq!(client.get_latest_epoch(), 3);
+    assert_eq!(client.get_snapshot(&1u64).unwrap().hash, hash1);
+    assert_eq!(client.get_snapshot(&2u64).unwrap().hash, hash2);
+    assert_eq!(client.get_snapshot(&3u64).unwrap().hash, hash3);
+}
+
 // ============================================================================
-// Timelock Tests
+// Snapshot Expiry Tests
 // ============================================================================
 
 #[test]
-fn test_timelock_proposal() {
+fn test_snapshot_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Submit at t=1000 with 500s TTL -> expires at t=1500
+    env.ledger().set_timestamp(1000);
+    let hash = create_test_hash(&env, 1);
+    client.submit_snapshot_with_ttl(&1u64, &hash, &admin, &Some(500u64));
+
+    let snapshot = client.get_snapshot(&1u64).unwrap();
+    assert_eq!(snapshot.expires_at, Some(1500u64));
+
+    // Before expiry: not expired
+    env.ledger().set_timestamp(1499);
+    assert!(!client.is_snapshot_expired(&1u64));
+
+    // After expiry: expired
+    env.ledger().set_timestamp(1501);
+    assert!(client.is_snapshot_expired(&1u64));
+}
+
+#[test]
+fn test_snapshot_default_ttl() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(0);
+    let hash = create_test_hash(&env, 1);
+    client.submit_snapshot_with_ttl(&1u64, &hash, &admin, &None);
+
+    let snapshot = client.get_snapshot(&1u64).unwrap();
+    // Default TTL is 90 days = 7_776_000 seconds
+    assert_eq!(snapshot.expires_at, Some(7_776_000u64));
+}
+
+#[test]
+fn test_snapshot_no_expiry_by_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
 
     // submit_snapshot (no TTL) should have expires_at = None
     env.ledger().set_timestamp(1000);
@@ -611,6 +709,118 @@ fn test_timelock_proposal() {
 
 #[test]
 fn test_cleanup_expired_snapshots() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Submit 3 snapshots with short TTL (100s) and 1 with long TTL (10000s)
+    env.ledger().set_timestamp(1000);
+    for epoch in 1u64..=3 {
+        let hash = create_test_hash(&env, epoch as u8);
+        client.submit_snapshot_with_ttl(&epoch, &hash, &admin, &Some(100u64));
+    }
+    let hash4 = create_test_hash(&env, 4);
+    client.submit_snapshot_with_ttl(&4u64, &hash4, &admin, &Some(10_000u64));
+
+    // Advance past the short TTL expiry
+    env.ledger().set_timestamp(1200);
+
+    // Clean up max 2 at a time
+    let cleaned = client.cleanup_expired_snapshots(&admin, &2u32);
+    assert_eq!(cleaned, 2);
+
+    // Epochs 1 and 2 removed, 3 and 4 still present
+    assert!(client.get_snapshot(&1u64).is_none());
+    assert!(client.get_snapshot(&2u64).is_none());
+    assert!(client.get_snapshot(&3u64).is_some());
+    assert!(client.get_snapshot(&4u64).is_some());
+
+    // Clean remaining expired
+    let cleaned2 = client.cleanup_expired_snapshots(&admin, &10u32);
+    assert_eq!(cleaned2, 1); // epoch 3 expired, epoch 4 not yet
+
+    assert!(client.get_snapshot(&3u64).is_none());
+    assert!(client.get_snapshot(&4u64).is_some());
+}
+
+#[test]
+fn test_cleanup_respects_max_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(0);
+    for epoch in 1u64..=5 {
+        let hash = create_test_hash(&env, epoch as u8);
+        client.submit_snapshot_with_ttl(&epoch, &hash, &admin, &Some(100u64));
+    }
+
+    // All 5 expired
+    env.ledger().set_timestamp(200);
+
+    // Only clean 3
+    let cleaned = client.cleanup_expired_snapshots(&admin, &3u32);
+    assert_eq!(cleaned, 3);
+
+    // 2 still remain
+    let history = client.get_snapshot_history();
+    assert_eq!(history.len(), 2);
+}
+
+#[test]
+fn test_cleanup_no_expired_snapshots() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(0);
+    let hash = create_test_hash(&env, 1);
+    client.submit_snapshot_with_ttl(&1u64, &hash, &admin, &Some(10_000u64));
+
+    // Not yet expired
+    env.ledger().set_timestamp(100);
+    let cleaned = client.cleanup_expired_snapshots(&admin, &10u32);
+    assert_eq!(cleaned, 0);
+    assert!(client.get_snapshot(&1u64).is_some());
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_cleanup_unauthorized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    client.cleanup_expired_snapshots(&attacker, &10u32);
+}
+
+// ============================================================================
+// Timelock Tests
+// ============================================================================
+
+#[test]
+fn test_timelock_proposal() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -657,41 +867,6 @@ fn test_timelock_cannot_execute_early() {
 
 #[test]
 fn test_timelock_execution_after_delay() {
-
-    client.initialize(&admin);
-
-    // Submit 3 snapshots with short TTL (100s) and 1 with long TTL (10000s)
-    env.ledger().set_timestamp(1000);
-    for epoch in 1u64..=3 {
-        let hash = create_test_hash(&env, epoch as u8);
-        client.submit_snapshot_with_ttl(&epoch, &hash, &admin, &Some(100u64));
-    }
-    let hash4 = create_test_hash(&env, 4);
-    client.submit_snapshot_with_ttl(&4u64, &hash4, &admin, &Some(10_000u64));
-
-    // Advance past the short TTL expiry
-    env.ledger().set_timestamp(1200);
-
-    // Clean up max 2 at a time
-    let cleaned = client.cleanup_expired_snapshots(&admin, &2u32);
-    assert_eq!(cleaned, 2);
-
-    // Epochs 1 and 2 removed, 3 and 4 still present
-    assert!(client.get_snapshot(&1u64).is_none());
-    assert!(client.get_snapshot(&2u64).is_none());
-    assert!(client.get_snapshot(&3u64).is_some());
-    assert!(client.get_snapshot(&4u64).is_some());
-
-    // Clean remaining expired
-    let cleaned2 = client.cleanup_expired_snapshots(&admin, &10u32);
-    assert_eq!(cleaned2, 1); // epoch 3 expired, epoch 4 not yet
-
-    assert!(client.get_snapshot(&3u64).is_none());
-    assert!(client.get_snapshot(&4u64).is_some());
-}
-
-#[test]
-fn test_cleanup_respects_max_limit() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -719,29 +894,6 @@ fn test_cleanup_respects_max_limit() {
 
 #[test]
 fn test_timelock_cancellation() {
-
-    client.initialize(&admin);
-
-    env.ledger().set_timestamp(0);
-    for epoch in 1u64..=5 {
-        let hash = create_test_hash(&env, epoch as u8);
-        client.submit_snapshot_with_ttl(&epoch, &hash, &admin, &Some(100u64));
-    }
-
-    // All 5 expired
-    env.ledger().set_timestamp(200);
-
-    // Only clean 3
-    let cleaned = client.cleanup_expired_snapshots(&admin, &3u32);
-    assert_eq!(cleaned, 3);
-
-    // 2 still remain
-    let history = client.get_snapshot_history();
-    assert_eq!(history.len(), 2);
-}
-
-#[test]
-fn test_cleanup_no_expired_snapshots() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -765,28 +917,11 @@ fn test_cleanup_no_expired_snapshots() {
 }
 
 // ============================================================================
-// Rich Event Tests
+// Event Tests
 // ============================================================================
 
 #[test]
 fn test_event_data_completeness() {
-
-    client.initialize(&admin);
-
-    env.ledger().set_timestamp(0);
-    let hash = create_test_hash(&env, 1);
-    client.submit_snapshot_with_ttl(&1u64, &hash, &admin, &Some(10_000u64));
-
-    // Not yet expired
-    env.ledger().set_timestamp(100);
-    let cleaned = client.cleanup_expired_snapshots(&admin, &10u32);
-    assert_eq!(cleaned, 0);
-    assert!(client.get_snapshot(&1u64).is_some());
-}
-
-#[test]
-#[should_panic(expected = "Unauthorized")]
-fn test_cleanup_unauthorized_fails() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -805,14 +940,12 @@ fn test_cleanup_unauthorized_fails() {
     let hash = create_test_hash(&env, 2);
     let timestamp = client.submit_snapshot(&epoch, &hash, &admin);
 
-    // Verify the snapshot was stored with correct data (event payload mirrors storage)
     let snapshot = client.get_snapshot(&epoch).unwrap();
     assert_eq!(snapshot.epoch, epoch);
     assert_eq!(snapshot.hash, hash);
     assert_eq!(snapshot.timestamp, timestamp);
     assert_eq!(timestamp, 1000);
 
-    // Verify previous_epoch tracking: latest before this submit was epoch 1
     assert_eq!(client.get_latest_epoch(), epoch);
 
     // Verify pause event data completeness
@@ -827,11 +960,39 @@ fn test_cleanup_unauthorized_fails() {
 
 #[test]
 fn test_event_emission() {
-    let attacker = Address::generate(&env);
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
     client.initialize(&admin);
+    env.ledger().set_timestamp(2000);
 
-    client.cleanup_expired_snapshots(&attacker, &10u32);
+    let epoch = 1u64;
+    let hash = create_test_hash(&env, 42);
+    let timestamp = client.submit_snapshot(&epoch, &hash, &admin);
+    assert_eq!(timestamp, 2000);
+
+    let snapshot = client.get_snapshot(&epoch).unwrap();
+    assert_eq!(snapshot.epoch, epoch);
+    assert_eq!(snapshot.hash, hash);
+    assert_eq!(snapshot.timestamp, 2000);
+
+    let pause_reason = soroban_sdk::String::from_str(&env, "emergency stop");
+    client.pause(&admin, &pause_reason);
+    assert!(client.is_paused());
+
+    let unpause_reason = soroban_sdk::String::from_str(&env, "issue resolved");
+    client.unpause(&admin, &unpause_reason);
+    assert!(!client.is_paused());
+
+    // Confirm contract is operational again after unpause
+    let epoch2 = 2u64;
+    let hash2 = create_test_hash(&env, 43);
+    client.submit_snapshot(&epoch2, &hash2, &admin);
+    assert_eq!(client.get_latest_epoch(), epoch2);
 }
 
 #[test]
@@ -844,43 +1005,6 @@ fn test_submit_snapshot_with_ttl_stores_submitter_and_ledger() {
     let admin = Address::generate(&env);
 
     client.initialize(&admin);
-    env.ledger().set_timestamp(2000);
-
-    // Emit snapshot event
-    let epoch = 1u64;
-    let hash = create_test_hash(&env, 42);
-    let timestamp = client.submit_snapshot(&epoch, &hash, &admin);
-    assert_eq!(timestamp, 2000);
-
-    // Confirm snapshot stored correctly (event data matches)
-    let snapshot = client.get_snapshot(&epoch).unwrap();
-    assert_eq!(snapshot.epoch, epoch);
-    assert_eq!(snapshot.hash, hash);
-    assert_eq!(snapshot.timestamp, 2000);
-
-    // Emit pause event with reason
-    let pause_reason = soroban_sdk::String::from_str(&env, "emergency stop");
-    client.pause(&admin, &pause_reason);
-    assert!(client.is_paused());
-
-    // Emit unpause event with reason
-    let unpause_reason = soroban_sdk::String::from_str(&env, "issue resolved");
-    client.unpause(&admin, &unpause_reason);
-    assert!(!client.is_paused());
-
-    // Confirm contract is operational again after unpause
-    let epoch2 = 2u64;
-    let hash2 = create_test_hash(&env, 43);
-    client.submit_snapshot(&epoch2, &hash2, &admin);
-    assert_eq!(client.get_latest_epoch(), epoch2);
-}
-
-// ============================================================================
-// Error Event Tests
-// ============================================================================
-
-#[test]
-fn test_error_events() {
 
     env.ledger().set_timestamp(5000);
     let hash = create_test_hash(&env, 42);
@@ -894,43 +1018,17 @@ fn test_error_events() {
 }
 
 // ============================================================================
-// Gas Optimization Tests - Issue #620
+// Error Event Tests
 // ============================================================================
 
 #[test]
-fn test_batch_submit_basic() {
-// Rate Limiting Tests - Tests for Issue #600
-// ============================================================================
-
-#[test]
-fn test_rate_limiting() {
+fn test_error_events() {
     let env = Env::default();
     env.mock_all_auths();
 
     let contract_id = env.register_contract(None, AnalyticsContract);
     let client = AnalyticsContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
-
-    env.ledger().set_timestamp(1000);
-
-    let hash1 = create_test_hash(&env, 1);
-    let hash2 = create_test_hash(&env, 2);
-    let hash3 = create_test_hash(&env, 3);
-
-    let input = vec![
-        &env,
-        (1u64, hash1.clone()),
-        (2u64, hash2.clone()),
-        (3u64, hash3.clone()),
-    ];
-    let timestamps = client.batch_submit(&input, &admin);
-
-    assert_eq!(timestamps.len(), 3);
-    assert_eq!(client.get_latest_epoch(), 3);
-    assert_eq!(client.get_snapshot(&1u64).unwrap().hash, hash1);
-    assert_eq!(client.get_snapshot(&2u64).unwrap().hash, hash2);
-    assert_eq!(client.get_snapshot(&3u64).unwrap().hash, hash3);
 
     client.initialize(&admin);
     env.ledger().set_timestamp(1000);
@@ -941,9 +1039,15 @@ fn test_rate_limiting() {
     assert_eq!(client.get_latest_epoch(), 1);
 
     // Pause and unpause — verifies error events don't break pause/unpause flow
-    client.pause(&admin, &soroban_sdk::String::from_str(&env, "test pause"));
+    client.pause(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "test pause"),
+    );
     assert!(client.is_paused());
-    client.unpause(&admin, &soroban_sdk::String::from_str(&env, "test unpause"));
+    client.unpause(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "test unpause"),
+    );
     assert!(!client.is_paused());
 
     // Submit after unpause — verifies contract is still operational
@@ -961,29 +1065,11 @@ fn test_error_event_invalid_epoch() {
     let client = AnalyticsContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.initialize(&admin);
-    // Triggers ContractError::InvalidEpoch error event then panics
     client.submit_snapshot(&0u64, &create_test_hash(&env, 1), &admin);
 }
 
 #[test]
 #[should_panic(expected = "Unauthorized")]
-fn test_batch_submit_unauthorized() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register_contract(None, AnalyticsContract);
-    let client = AnalyticsContractClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    let attacker = Address::generate(&env);
-    client.initialize(&admin);
-
-    let input = vec![&env, (1u64, create_test_hash(&env, 1))];
-    client.batch_submit(&input, &attacker);
-}
-
-#[test]
-#[should_panic(expected = "Epoch monotonicity violated")]
-fn test_batch_submit_non_monotonic_epochs() {
 fn test_error_event_unauthorized() {
     let env = Env::default();
     env.mock_all_auths();
@@ -992,7 +1078,6 @@ fn test_error_event_unauthorized() {
     let admin = Address::generate(&env);
     let other = Address::generate(&env);
     client.initialize(&admin);
-    // Triggers ContractError::Unauthorized error event then panics
     client.submit_snapshot(&1u64, &create_test_hash(&env, 1), &other);
 }
 
@@ -1006,7 +1091,6 @@ fn test_error_event_monotonicity_violated() {
     let admin = Address::generate(&env);
     client.initialize(&admin);
     client.submit_snapshot(&5u64, &create_test_hash(&env, 5), &admin);
-    // Triggers ContractError::EpochMonotonicityViolated error event then panics
     client.submit_snapshot(&3u64, &create_test_hash(&env, 3), &admin);
 }
 
@@ -1020,7 +1104,6 @@ fn test_error_event_epoch_already_exists() {
     let admin = Address::generate(&env);
     client.initialize(&admin);
     client.submit_snapshot(&1u64, &create_test_hash(&env, 1), &admin);
-    // Triggers ContractError::EpochAlreadyExists error event then panics
     client.submit_snapshot(&1u64, &create_test_hash(&env, 2), &admin);
 }
 
@@ -1033,9 +1116,29 @@ fn test_error_event_contract_paused() {
     let client = AnalyticsContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.initialize(&admin);
-    client.pause(&admin, &soroban_sdk::String::from_str(&env, "test"));
-    // Triggers ContractError::ContractPaused error event then panics
+    client.pause(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "test"),
+    );
     client.submit_snapshot(&1u64, &create_test_hash(&env, 1), &admin);
+}
+
+// ============================================================================
+// Rate Limiting Tests
+// ============================================================================
+
+#[test]
+fn test_rate_limiting() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(1000);
+
     // Submit up to the limit without issue
     for epoch in 1u64..=5 {
         let hash = create_test_hash(&env, epoch as u8);
@@ -1056,21 +1159,6 @@ fn test_rate_limit_exceeded() {
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
-    // epoch 5 then epoch 3 — must panic
-    let input = vec![
-        &env,
-        (5u64, create_test_hash(&env, 5)),
-        (3u64, create_test_hash(&env, 3)),
-    ];
-    client.batch_submit(&input, &admin);
-}
-
-#[test]
-fn test_get_snapshot_uses_per_epoch_key() {
-    // Verifies that get_snapshot works via the per-epoch DataKey::Snapshot(epoch)
-    // path (not the full map), which is cheaper to read.
-
-    client.initialize(&admin);
     env.ledger().set_timestamp(1000);
 
     // Submit MAX_CALLS_PER_WINDOW (100) snapshots to exhaust the limit
@@ -1085,7 +1173,7 @@ fn test_get_snapshot_uses_per_epoch_key() {
 }
 
 #[test]
-fn test_rate_limit_window_reset() {
+fn test_get_snapshot_uses_per_epoch_key() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -1105,8 +1193,18 @@ fn test_rate_limit_window_reset() {
 
     // Non-existent epoch returns None without touching the map
     assert!(client.get_snapshot(&99u64).is_none());
+}
 
+#[test]
+fn test_rate_limit_window_reset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
     client.initialize(&admin);
+
     env.ledger().set_timestamp(1000);
 
     // Exhaust the rate limit
@@ -1123,4 +1221,40 @@ fn test_rate_limit_window_reset() {
     let ts = client.submit_snapshot(&101u64, &hash, &admin);
     assert_eq!(ts, 1000 + 3601);
     assert_eq!(client.get_latest_epoch(), 101);
+}
+
+// ============================================================================
+// Prune Snapshots Tests - Issue #592
+// ============================================================================
+
+#[test]
+fn test_prune_old_snapshots() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Submit 100 snapshots
+    for i in 1u64..=100 {
+        let hash = create_test_hash(&env, (i % 255) as u8);
+        client.submit_snapshot(&i, &hash, &admin);
+    }
+
+    assert_eq!(client.get_latest_epoch(), 100);
+
+    // Prune, keeping last 10
+    let removed = client.prune_old_snapshots(&admin, &10);
+    assert_eq!(removed, 90);
+
+    // Verify old snapshots are gone
+    assert!(client.get_snapshot(&1).is_none());
+    assert!(client.get_snapshot(&90).is_none());
+
+    // Verify recent snapshots still exist
+    assert!(client.get_snapshot(&91).is_some());
+    assert!(client.get_snapshot(&100).is_some());
 }


### PR DESCRIPTION
## Summary

   Closes #592

   - Adds `prune_old_snapshots(caller, keep_last_n)` admin-only function that removes snapshots older than the last N epochs from both
   per-epoch (`DataKey::Snapshot(epoch)`) and shared map (`DataKey::Snapshots`) storage, emitting a `prune` event with the count removed
   and cutoff epoch.
   - Fixes merge-conflict damage in `lib.rs` and `tests.rs` that prevented compilation (duplicate function definitions, interleaved test
   bodies, broken syntax).
   - Adds `test_prune_old_snapshots` test: submits 100 snapshots, prunes keeping last 10, verifies 90 removed and old/new snapshots are
   gone/present.

   ## Test plan

   - [x] `cargo test test_prune_old_snapshots` — passes
   - [x] `cargo test` — all 50 tests pass (0 failures)

   ## Verification

   ```
   cd contracts/analytics
   cargo test test_prune_old_snapshots
   ```