### PR TITLE
Add emergency withdrawal mechanism to analytics contract 

### DIFF
--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -1,9 +1,10 @@
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map, String, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Map, String,
+    Vec,
 };
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -125,6 +126,23 @@ pub struct TimelockAction {
 const TIMELOCK_DELAY: u64 = 172800; // 48 hours in seconds
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiSigConfig {
+    pub admins: Vec<Address>,
+    pub threshold: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingAction {
+    pub action_id: u64,
+    pub action_type: String,
+    pub signatures: Vec<Address>,
+    pub created_at: u64,
+    pub expires_at: u64,
+}
+
+#[contracttype]
 pub enum DataKey {
     Admin,
     Snapshots,
@@ -139,6 +157,8 @@ pub enum DataKey {
     /// Per-caller rate limit tracking
     RateLimit(Address),
     Version,
+    MultiSigConfig,
+    PendingAction(u64),
 }
 
 fn check_rate_limit(env: &Env, caller: &Address) {
@@ -895,29 +915,23 @@ impl AnalyticsContract {
         caller: Address,
         admins: Vec<Address>,
         threshold: u32,
-    ) -> Result<(), u32> {
+    ) {
         caller.require_auth();
 
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("Contract not initialized: admin not set");
+        let admin = require_admin(&env);
 
         if caller != admin {
             panic!("Unauthorized: only the admin can initialize multisig");
         }
 
-        if threshold == 0 || threshold > admins.len() as u32 {
-            return Err(1); // InvalidThreshold
+        if threshold == 0 || threshold > admins.len() {
+            panic!("Invalid threshold: must be > 0 and <= number of admins");
         }
 
         let config = MultiSigConfig { admins, threshold };
         env.storage()
             .instance()
             .set(&DataKey::MultiSigConfig, &config);
-
-        Ok(())
     }
 
     /// Get the current multi-sig configuration.
@@ -939,7 +953,7 @@ impl AnalyticsContract {
             .storage()
             .instance()
             .get(&DataKey::MultiSigConfig)
-            .expect("MultiSig not initialized");
+            .unwrap_or_else(|| panic!("MultiSig not initialized"));
 
         if !config.admins.contains(&proposer) {
             panic!("Unauthorized: proposer is not a multisig admin");
@@ -981,7 +995,7 @@ impl AnalyticsContract {
             .storage()
             .instance()
             .get(&DataKey::MultiSigConfig)
-            .expect("MultiSig not initialized");
+            .unwrap_or_else(|| panic!("MultiSig not initialized"));
 
         if !config.admins.contains(&signer) {
             panic!("Unauthorized: signer is not a multisig admin");
@@ -991,7 +1005,7 @@ impl AnalyticsContract {
             .storage()
             .persistent()
             .get(&DataKey::PendingAction(action_id))
-            .expect("Action not found");
+            .unwrap_or_else(|| panic!("Action not found"));
 
         if env.ledger().timestamp() > pending.expires_at {
             panic!("Action expired");
@@ -1012,6 +1026,39 @@ impl AnalyticsContract {
         env.storage()
             .persistent()
             .get(&DataKey::PendingAction(action_id))
+    }
+
+    /// Emergency withdrawal of tokens from the contract.
+    /// Only the admin can call this, and the contract must be paused.
+    pub fn emergency_withdraw(
+        env: Env,
+        admin: Address,
+        token_addr: Address,
+        amount: i128,
+        recipient: Address,
+    ) {
+        admin.require_auth();
+        let stored_admin = require_admin(&env);
+        if admin != stored_admin {
+            panic!("Unauthorized: only the admin can perform emergency withdrawal");
+        }
+
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if !paused {
+            panic!("Contract must be paused for emergency withdrawal");
+        }
+
+        let token_client = token::Client::new(&env, &token_addr);
+        token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+
+        env.events().publish(
+            (symbol_short!("emergency"), admin),
+            (token_addr, amount, recipient),
+        );
     }
 }
 

--- a/contracts/analytics/src/tests.rs
+++ b/contracts/analytics/src/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient},
     vec, Address, BytesN, Env, Vec,
 };
 
@@ -62,7 +63,7 @@ fn test_version_stored_on_init() {
     let version = client.getversion();
     assert!(!version.is_empty());
     // Version should be stored and retrievable
-    assert_eq!(version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(version, soroban_sdk::String::from_str(&env, env!("CARGO_PKG_VERSION")));
 }
 
 #[test]
@@ -1274,4 +1275,90 @@ fn test_prune_old_snapshots() {
     // Verify recent snapshots still exist
     assert!(client.get_snapshot(&91).is_some());
     assert!(client.get_snapshot(&100).is_some());
+}
+
+// ============================================================================
+// Emergency Withdrawal Tests - Issue #597
+// ============================================================================
+
+#[test]
+fn test_emergency_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Set up a token
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_addr = token_contract.address();
+    let sac_client = StellarAssetClient::new(&env, &token_addr);
+    let token_client = TokenClient::new(&env, &token_addr);
+
+    // Mint tokens to the analytics contract
+    sac_client.mint(&contract_id, &1000_i128);
+    assert_eq!(token_client.balance(&contract_id), 1000);
+
+    // Pause the contract first (required for emergency withdrawal)
+    let reason = soroban_sdk::String::from_str(&env, "emergency");
+    client.pause(&admin, &reason);
+
+    // Perform emergency withdrawal
+    let recipient = Address::generate(&env);
+    client.emergency_withdraw(&admin, &token_addr, &500_i128, &recipient);
+
+    // Verify balances
+    assert_eq!(token_client.balance(&contract_id), 500);
+    assert_eq!(token_client.balance(&recipient), 500);
+}
+
+#[test]
+#[should_panic(expected = "Contract must be paused")]
+fn test_emergency_withdrawal_requires_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_addr = token_contract.address();
+
+    let recipient = Address::generate(&env);
+    // Should fail because contract is not paused
+    client.emergency_withdraw(&admin, &token_addr, &500_i128, &recipient);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_emergency_withdrawal_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_addr = token_contract.address();
+
+    // Pause the contract
+    let reason = soroban_sdk::String::from_str(&env, "emergency");
+    client.pause(&admin, &reason);
+
+    // Non-admin should fail
+    let attacker = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.emergency_withdraw(&attacker, &token_addr, &500_i128, &recipient);
 }


### PR DESCRIPTION
Summary                                                                                                                                   
  
  Closes [#597     ](https://github.com/Ndifreke000/stellar-insights/issues/597)                                                                                                                          
                                                                                                                                          
  - Adds emergency_withdraw(admin, token_addr, amount, recipient) function that allows the admin to recover stuck funds from the contract,  
  only when the contract is paused
  - Enforces admin auth check and pause requirement before transferring tokens via the Stellar Asset Contract token client                  
  - Emits an emergency event with token address, amount, and recipient                                                                      
  - Also fixes pre-existing merge-conflict damage in lib.rs and tests.rs that prevented compilation                                         
