### PR TITLE
Missing Cache Invalidation Strategy

### DIFF
--- a/backend/src/api/corridors.rs
+++ b/backend/src/api/corridors.rs
@@ -1016,6 +1016,10 @@ pub async fn update_corridor_metrics_from_transactions(
 
     let metrics = compute_corridor_metrics(&txs, None, 1.0);
     let corridor = app_state.db.update_corridor_metrics(id, metrics).await?;
+    app_state
+        .cache
+        .invalidate_corridor(&corridor.to_string_key())
+        .await?;
 
     // Broadcast the corridor update to WebSocket clients
     broadcast_corridor_update(&app_state.ws_state, &corridor);

--- a/backend/src/cache.rs
+++ b/backend/src/cache.rs
@@ -261,6 +261,33 @@ impl CacheManager {
         self.delete_pattern(pattern).await
     }
 
+    /// Invalidate all corridor-related cache entries.
+    pub async fn invalidate_corridors(&self) -> anyhow::Result<usize> {
+        let pattern = keys::corridor_pattern();
+        let deleted = self.invalidate_pattern(&pattern).await?;
+        tracing::info!(
+            "Invalidated {} corridor cache entries matching pattern: {}",
+            deleted,
+            pattern
+        );
+        Ok(deleted)
+    }
+
+    /// Invalidate cache entries for a specific corridor and related list views.
+    pub async fn invalidate_corridor(&self, corridor_key: &str) -> anyhow::Result<()> {
+        let detail_key = keys::corridor_detail(corridor_key);
+        self.delete(&detail_key).await?;
+
+        // Corridor list endpoints can include this corridor, so clear list/detail variants.
+        let invalidated = self.invalidate_corridors().await?;
+        tracing::info!(
+            "Invalidated corridor cache for key: {} ({} related entries removed)",
+            corridor_key,
+            invalidated
+        );
+        Ok(())
+    }
+
     /// Clean up expired entries (Redis handles this automatically, but useful for monitoring)
     pub async fn cleanup_expired(&self) -> anyhow::Result<()> {
         tracing::debug!("Cache cleanup triggered (Redis auto-expires keys)");
@@ -389,6 +416,11 @@ mod tests {
         assert_eq!(keys::anchor_list(50, 0), "anchor:list:50:0");
         assert_eq!(keys::anchor_detail("123"), "anchor:detail:123");
         assert_eq!(keys::anchor_by_account("GA123"), "anchor:account:GA123");
+        assert_eq!(
+            keys::corridor_detail("USDC:issuer->XLM:native"),
+            "corridor:detail:USDC:issuer->XLM:native"
+        );
+        assert_eq!(keys::corridor_pattern(), "corridor:*");
         assert_eq!(keys::dashboard_stats(), "dashboard:stats");
         assert_eq!(keys::anchor_pattern(), "anchor:*");
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
     let ws_state = Arc::new(WsState::new());
     let ingestion = Arc::new(DataIngestionService::new(rpc_client.clone(), db.clone()));
 
-    let app_state = AppState::new(db.clone(), ws_state, ingestion);
+    let app_state = AppState::new(db.clone(), cache.clone(), ws_state, ingestion);
     let cached_state = (
         db.clone(),
         cache.clone(),

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,3 +1,4 @@
+use crate::cache::CacheManager;
 use crate::database::Database;
 use crate::ingestion::DataIngestionService;
 use crate::websocket::WsState;
@@ -7,6 +8,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<Database>,
+    pub cache: Arc<CacheManager>,
     pub ws_state: Arc<WsState>,
     pub ingestion: Arc<DataIngestionService>,
 }
@@ -15,11 +17,13 @@ impl AppState {
     #[must_use]
     pub const fn new(
         db: Arc<Database>,
+        cache: Arc<CacheManager>,
         ws_state: Arc<WsState>,
         ingestion: Arc<DataIngestionService>,
     ) -> Self {
         Self {
             db,
+            cache,
             ws_state,
             ingestion,
         }


### PR DESCRIPTION
Close: #668
Implemented the cache invalidation fix for corridor updates.

What changed

Added corridor-specific invalidation helpers to [cache.rs] and [cache.rs].
Extended shared app state to carry the cache manager in [state.rs] and [state.rs].
Wired cache into app state creation in [main.rs]
Invalidated the relevant corridor cache immediately after the DB update in [corridors.rs]
Added a small key-builder assertion update in [cache.rs]

Behavior
CacheManager::invalidate_pattern remains backed by SCAN, so we avoid the Redis KEYS anti-pattern.

invalidate_corridor clears the specific detail key and then clears corridor-related cached views so list responses do not stay stale after updates.