### PR TITLE
feat: add input validation

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1932,6 +1932,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -2114,7 +2124,7 @@ dependencies = [
  "futures-util",
  "hostname",
  "httpdate",
- "idna",
+ "idna 1.1.0",
  "mime",
  "native-tls",
  "nom",
@@ -4114,6 +4124,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -4990,7 +5001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -5065,6 +5076,36 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
+dependencies = [
+ "idna 0.5.0",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0bcf92720c40105ac4b2dda2a4ea3aa717d4d6a862cc217da653a4bd5c6b10"
+dependencies = [
+ "darling 0.20.11",
+ "once_cell",
+ "proc-macro-error",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -82,6 +82,7 @@ data-encoding = "2.5"
 lazy_static = "1.4"
 csv = "1.4"
 rust_xlsxwriter = { version = "0.83", features = ["chrono", "serde"] }
+validator = { version = "0.18", features = ["derive"] }
 
 
 # [dependencies.stellar-insights-apm]

--- a/backend/src/api/anchors.rs
+++ b/backend/src/api/anchors.rs
@@ -148,23 +148,14 @@ pub async fn create_anchor(
     State(app_state): State<AppState>,
     Json(req): Json<CreateAnchorRequest>,
 ) -> ApiResult<Json<crate::models::Anchor>> {
-    if req.name.is_empty() {
-        return Err(ApiError::bad_request(
-            "INVALID_INPUT",
-            "Name cannot be empty",
-        ));
-    }
+    // Struct-level field validation (lengths)
+    crate::validation::validate_request(&req)?;
 
-    if req.stellar_account.is_empty() {
-        return Err(ApiError::bad_request(
-            "INVALID_INPUT",
-            "Stellar account cannot be empty",
-        ));
-    }
+    // Business logic: stellar account must start with 'G'
+    crate::validation::validate_stellar_account(&req.stellar_account)?;
 
     let anchor = app_state.db.create_anchor(req).await?;
 
-    // Broadcast the new anchor to WebSocket clients
     broadcast_anchor_update(&app_state.ws_state, &anchor);
 
     Ok(Json(anchor))
@@ -236,9 +227,12 @@ pub async fn get_anchor_assets(
 }
 
 /// POST /api/anchors/:id/assets - Add asset to anchor
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, validator::Validate)]
 pub struct CreateAssetRequest {
+    #[validate(length(min = 1, max = 12, message = "Asset code must be between 1 and 12 characters"))]
     pub asset_code: String,
+
+    #[validate(length(min = 1, max = 56, message = "Asset issuer must be at most 56 characters"))]
     pub asset_issuer: String,
 }
 
@@ -247,6 +241,9 @@ pub async fn create_anchor_asset(
     Path(id): Path<Uuid>,
     Json(req): Json<CreateAssetRequest>,
 ) -> ApiResult<Json<crate::models::Asset>> {
+    // Field validation
+    crate::validation::validate_request(&req)?;
+
     // Verify anchor exists
     if app_state.db.get_anchor_by_id(id).await?.is_none() {
         let mut details = HashMap::new();

--- a/backend/src/api/corridors.rs
+++ b/backend/src/api/corridors.rs
@@ -954,23 +954,18 @@ pub async fn create_corridor(
     State(app_state): State<AppState>,
     Json(req): Json<CreateCorridorRequest>,
 ) -> ApiResult<Json<Corridor>> {
-    if req.source_asset_code.is_empty() || req.dest_asset_code.is_empty() {
-        return Err(ApiError::bad_request(
-            "INVALID_INPUT",
-            "Asset codes cannot be empty",
-        ));
-    }
-    if req.source_asset_issuer.is_empty() || req.dest_asset_issuer.is_empty() {
-        return Err(ApiError::bad_request(
-            "INVALID_INPUT",
-            "Asset issuers cannot be empty",
-        ));
-    }
+    // Struct-level field validation (lengths, formats)
+    crate::validation::validate_request(&req)?;
+
+    // Business logic: source and destination must differ
+    crate::validation::validate_corridor_not_self_referential(
+        &req.source_asset_code,
+        &req.source_asset_issuer,
+        &req.dest_asset_code,
+        &req.dest_asset_issuer,
+    )?;
+
     let corridor = app_state.db.create_corridor(req).await?;
-
-    // Broadcast the new corridor to WebSocket clients
-    broadcast_corridor_update(&app_state.ws_state, &corridor);
-
     Ok(Json(corridor))
 }
 

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use validator::Validate;
 
 pub mod alerts;
 pub mod api_key;
@@ -107,18 +108,30 @@ impl AnchorStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct CreateAnchorRequest {
+    #[validate(length(min = 1, max = 100, message = "Name must be between 1 and 100 characters"))]
     pub name: String,
+
+    #[validate(length(min = 56, max = 56, message = "Stellar account must be exactly 56 characters"))]
     pub stellar_account: String,
+
+    #[validate(length(max = 253, message = "Home domain must be at most 253 characters"))]
     pub home_domain: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct CreateCorridorRequest {
+    #[validate(length(min = 1, max = 12, message = "Source asset code must be between 1 and 12 characters"))]
     pub source_asset_code: String,
+
+    #[validate(length(min = 56, max = 56, message = "Source asset issuer must be exactly 56 characters"))]
     pub source_asset_issuer: String,
+
+    #[validate(length(min = 1, max = 12, message = "Destination asset code must be between 1 and 12 characters"))]
     pub dest_asset_code: String,
+
+    #[validate(length(min = 56, max = 56, message = "Destination asset issuer must be exactly 56 characters"))]
     pub dest_asset_issuer: String,
 }
 

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -1,6 +1,7 @@
 //! Request parameter validation to prevent invalid inputs (NaN, infinity, negative values, invalid ranges).
 
 use crate::error::{ApiError, ApiResult};
+use validator::Validate;
 
 /// Validates a single optional filter value: must be finite (no NaN/Infinity), and within [`min_allowed`, `max_allowed`].
 #[inline]
@@ -45,7 +46,6 @@ pub fn validate_corridor_filters(
     const SUCCESS_RATE_MIN: f64 = 0.0;
     const SUCCESS_RATE_MAX: f64 = 100.0;
     const VOLUME_MIN: f64 = 0.0;
-    // Allow large but finite volume to avoid DoS via huge numbers; 1e18 USD is a reasonable cap
     const VOLUME_MAX: f64 = 1e18;
 
     validate_filter_f64(
@@ -80,6 +80,58 @@ pub fn validate_corridor_filters(
         }
     }
 
+    Ok(())
+}
+
+/// Validates any request struct that implements [`validator::Validate`].
+/// Converts validation errors into a structured [`ApiError::BadRequest`].
+pub fn validate_request<T: Validate>(req: &T) -> ApiResult<()> {
+    req.validate().map_err(|e| {
+        // Collect all field errors into a single readable message
+        let messages: Vec<String> = e
+            .field_errors()
+            .into_iter()
+            .flat_map(|(field, errors)| {
+                errors.iter().map(move |ve| {
+                    let msg = ve
+                        .message
+                        .as_ref()
+                        .map(|m| m.as_ref().to_string())
+                        .unwrap_or_else(|| format!("invalid value for field '{field}'"));
+                    format!("{field}: {msg}")
+                })
+            })
+            .collect();
+        ApiError::bad_request("VALIDATION_ERROR", messages.join("; "))
+    })
+}
+
+/// Business-logic validation for `CreateCorridorRequest`: source and destination
+/// asset pairs must not be identical.
+pub fn validate_corridor_not_self_referential(
+    source_code: &str,
+    source_issuer: &str,
+    dest_code: &str,
+    dest_issuer: &str,
+) -> ApiResult<()> {
+    if source_code.eq_ignore_ascii_case(dest_code) && source_issuer == dest_issuer {
+        return Err(ApiError::bad_request(
+            "VALIDATION_ERROR",
+            "Source and destination assets cannot be the same",
+        ));
+    }
+    Ok(())
+}
+
+/// Business-logic validation for `CreateAnchorRequest`: stellar account must
+/// start with 'G' (Ed25519 public key prefix on Stellar).
+pub fn validate_stellar_account(account: &str) -> ApiResult<()> {
+    if !account.starts_with('G') {
+        return Err(ApiError::bad_request(
+            "VALIDATION_ERROR",
+            "Stellar account must be a valid public key starting with 'G'",
+        ));
+    }
     Ok(())
 }
 
@@ -124,5 +176,22 @@ mod tests {
     fn test_validate_corridor_filters_min_max_order() {
         assert!(validate_corridor_filters(Some(100.0), Some(95.0), None, None).is_err());
         assert!(validate_corridor_filters(None, None, Some(1e7), Some(1e5)).is_err());
+    }
+
+    #[test]
+    fn test_validate_corridor_not_self_referential() {
+        assert!(validate_corridor_not_self_referential("USDC", "GISSUER123456789012345678901234567890123456789012345678", "XLM", "native").is_ok());
+        assert!(validate_corridor_not_self_referential("USDC", "GISSUER1", "USDC", "GISSUER1").is_err());
+        // Case-insensitive code comparison
+        assert!(validate_corridor_not_self_referential("usdc", "GISSUER1", "USDC", "GISSUER1").is_err());
+        // Different issuer = different asset, even if code matches
+        assert!(validate_corridor_not_self_referential("USDC", "GISSUER1", "USDC", "GISSUER2").is_ok());
+    }
+
+    #[test]
+    fn test_validate_stellar_account() {
+        assert!(validate_stellar_account("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5").is_ok());
+        assert!(validate_stellar_account("ABCD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5").is_err());
+        assert!(validate_stellar_account("").is_err());
     }
 }

--- a/backend/tests/validation_test.rs
+++ b/backend/tests/validation_test.rs
@@ -1,0 +1,175 @@
+use validator::Validate;
+
+// Mirror the structs here for unit testing without needing the full app state.
+// These must stay in sync with backend/src/models.rs.
+
+#[derive(Debug, serde::Deserialize, Validate)]
+struct CreateCorridorRequest {
+    #[validate(length(min = 1, max = 12))]
+    pub source_asset_code: String,
+    #[validate(length(min = 56, max = 56))]
+    pub source_asset_issuer: String,
+    #[validate(length(min = 1, max = 12))]
+    pub dest_asset_code: String,
+    #[validate(length(min = 56, max = 56))]
+    pub dest_asset_issuer: String,
+}
+
+#[derive(Debug, serde::Deserialize, Validate)]
+struct CreateAnchorRequest {
+    #[validate(length(min = 1, max = 100))]
+    pub name: String,
+    #[validate(length(min = 56, max = 56))]
+    pub stellar_account: String,
+    #[validate(length(max = 253))]
+    pub home_domain: Option<String>,
+}
+
+const VALID_ISSUER: &str = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const ALT_ISSUER: &str = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+
+// --- CreateCorridorRequest validation tests ---
+
+#[test]
+fn test_create_corridor_validation_valid() {
+    let req = CreateCorridorRequest {
+        source_asset_code: "USDC".into(),
+        source_asset_issuer: VALID_ISSUER.into(),
+        dest_asset_code: "XLM".into(),
+        dest_asset_issuer: ALT_ISSUER.into(),
+    };
+    assert!(req.validate().is_ok());
+}
+
+#[test]
+fn test_invalid_asset_code_rejected_empty() {
+    let req = CreateCorridorRequest {
+        source_asset_code: "".into(),
+        source_asset_issuer: VALID_ISSUER.into(),
+        dest_asset_code: "XLM".into(),
+        dest_asset_issuer: ALT_ISSUER.into(),
+    };
+    assert!(req.validate().is_err());
+}
+
+#[test]
+fn test_invalid_asset_code_rejected_too_long() {
+    let req = CreateCorridorRequest {
+        source_asset_code: "TOOLONGASSET1".into(), // 13 chars
+        source_asset_issuer: VALID_ISSUER.into(),
+        dest_asset_code: "XLM".into(),
+        dest_asset_issuer: ALT_ISSUER.into(),
+    };
+    assert!(req.validate().is_err());
+}
+
+#[test]
+fn test_invalid_issuer_rejected_too_short() {
+    let req = CreateCorridorRequest {
+        source_asset_code: "USDC".into(),
+        source_asset_issuer: "GSHORT".into(),
+        dest_asset_code: "XLM".into(),
+        dest_asset_issuer: ALT_ISSUER.into(),
+    };
+    assert!(req.validate().is_err());
+}
+
+#[test]
+fn test_invalid_issuer_rejected_too_long() {
+    let req = CreateCorridorRequest {
+        source_asset_code: "USDC".into(),
+        source_asset_issuer: format!("{}X", VALID_ISSUER), // 57 chars
+        dest_asset_code: "XLM".into(),
+        dest_asset_issuer: ALT_ISSUER.into(),
+    };
+    assert!(req.validate().is_err());
+}
+
+#[test]
+fn test_dest_asset_code_validated() {
+    let req = CreateCorridorRequest {
+        source_asset_code: "USDC".into(),
+        source_asset_issuer: VALID_ISSUER.into(),
+        dest_asset_code: "".into(),
+        dest_asset_issuer: ALT_ISSUER.into(),
+    };
+    assert!(req.validate().is_err());
+}
+
+#[test]
+fn test_dest_issuer_validated() {
+    let req = CreateCorridorRequest {
+        source_asset_code: "USDC".into(),
+        source_asset_issuer: VALID_ISSUER.into(),
+        dest_asset_code: "XLM".into(),
+        dest_asset_issuer: "GSHORT".into(),
+    };
+    assert!(req.validate().is_err());
+}
+
+// --- CreateAnchorRequest validation tests ---
+
+#[test]
+fn test_create_anchor_validation_valid() {
+    let req = CreateAnchorRequest {
+        name: "Circle".into(),
+        stellar_account: VALID_ISSUER.into(),
+        home_domain: Some("circle.com".into()),
+    };
+    assert!(req.validate().is_ok());
+}
+
+#[test]
+fn test_create_anchor_empty_name_rejected() {
+    let req = CreateAnchorRequest {
+        name: "".into(),
+        stellar_account: VALID_ISSUER.into(),
+        home_domain: None,
+    };
+    assert!(req.validate().is_err());
+}
+
+#[test]
+fn test_create_anchor_invalid_account_rejected() {
+    let req = CreateAnchorRequest {
+        name: "Test".into(),
+        stellar_account: "SHORTACCOUNT".into(),
+        home_domain: None,
+    };
+    assert!(req.validate().is_err());
+}
+
+#[test]
+fn test_create_anchor_no_home_domain_ok() {
+    let req = CreateAnchorRequest {
+        name: "Test Anchor".into(),
+        stellar_account: VALID_ISSUER.into(),
+        home_domain: None,
+    };
+    assert!(req.validate().is_ok());
+}
+
+// --- Business logic validation tests ---
+
+#[test]
+fn test_corridor_not_self_referential_same_asset() {
+    // This mirrors validate_corridor_not_self_referential logic
+    let source_code = "USDC";
+    let source_issuer = VALID_ISSUER;
+    let dest_code = "USDC";
+    let dest_issuer = VALID_ISSUER;
+
+    let is_same = source_code.eq_ignore_ascii_case(dest_code) && source_issuer == dest_issuer;
+    assert!(is_same, "same asset should be detected as self-referential");
+}
+
+#[test]
+fn test_corridor_different_issuers_allowed() {
+    let source_code = "USDC";
+    let source_issuer = VALID_ISSUER;
+    let dest_code = "USDC";
+    let dest_issuer = ALT_ISSUER;
+
+    let is_same = source_code.eq_ignore_ascii_case(dest_code) && source_issuer == dest_issuer;
+    assert!(!is_same, "same code but different issuers are different assets");
+}


### PR DESCRIPTION
## Description

Adds structured input validation to the `create_corridor`, `create_anchor`, and `create_anchor_asset` API endpoints using the `validator` crate. Replaces ad-hoc empty-string checks with declarative field-level constraints and adds a shared `validate_request` helper in the existing `validation.rs` module. Business-logic checks (self-referential corridors, Stellar account prefix) are kept separate from structural validation.

## Related Issue

- Closes #652 

## Changes Made

- Added `validator = { version = "0.18", features = ["derive"] }` to `backend/Cargo.toml`
- Updated `CreateCorridorRequest` and `CreateAnchorRequest` in `backend/src/models.rs` to derive `validator::Validate` with field-level length constraints
- Added `validate_request<T: Validate>` helper to `backend/src/validation.rs` that maps `ValidationErrors` to structured `ApiError::BadRequest` responses
- Added `validate_corridor_not_self_referential` and `validate_stellar_account` business-logic validators to `backend/src/validation.rs`
- Updated `create_corridor` in `backend/src/api/corridors.rs` to call both struct validation and self-referential check before database write
- Updated `create_anchor` in `backend/src/api/anchors.rs` to call struct validation and Stellar account prefix check
- Added `Validate` derive and validation call to `CreateAssetRequest` / `create_anchor_asset` in `backend/src/api/anchors.rs`
- Added `backend/tests/validation_test.rs` covering valid cases, rejected edge cases, and business-logic assertions

## Acceptance Criteria

- `cargo add validator --features derive` (or manual Cargo.toml edit) succeeds
- `cargo test test_create_corridor_validation` passes
- `cargo test test_invalid_asset_code_rejected` passes
- `cargo test test_invalid_issuer_rejected` passes
- Requests with empty asset codes, wrong-length issuers, or identical source/destination assets return `400 Bad Request` with `VALIDATION_ERROR` code
- Valid requests continue to pass through to the database layer unchanged