### PR TITLE
feat: add pause reason tracking

### DIFF
--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -72,6 +72,15 @@ pub struct UnpauseEvent {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseInfo {
+    pub paused: bool,
+    pub reason: String,
+    pub paused_at: u64,
+    pub paused_by: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TimelockAction {
     pub action_type: String,
     pub new_admin: Address,
@@ -121,6 +130,7 @@ pub enum DataKey {
     LatestEpoch,
     Snapshot(u64),
     Paused,
+    PauseInfo,
     Governance,
     NextActionId,
     TimelockAction(u64),
@@ -620,13 +630,27 @@ impl AnalyticsContract {
         if caller != admin {
             return Err(Error::Unauthorized.log_context(&env, "pause: caller is not the admin"));
         }
+
+        let timestamp = env.ledger().timestamp();
+
+        // Store structured pause info for transparency
+        let pause_info = PauseInfo {
+            paused: true,
+            reason: reason.clone(),
+            paused_at: timestamp,
+            paused_by: caller.clone(),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseInfo, &pause_info);
         env.storage().instance().set(&DataKey::Paused, &true);
+
         env.events().publish(
             (symbol_short!("pause"), caller.clone()),
             PauseEvent {
                 paused_by: caller,
                 reason,
-                timestamp: env.ledger().timestamp(),
+                timestamp,
                 ledger_sequence: env.ledger().sequence(),
             },
         );
@@ -640,13 +664,27 @@ impl AnalyticsContract {
         if caller != admin {
             return Err(Error::Unauthorized.log_context(&env, "unpause: caller is not the admin"));
         }
+
+        let timestamp = env.ledger().timestamp();
+
+        // Update pause info to reflect the unpaused state
+        let pause_info = PauseInfo {
+            paused: false,
+            reason: reason.clone(),
+            paused_at: timestamp,
+            paused_by: caller.clone(),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseInfo, &pause_info);
         env.storage().instance().set(&DataKey::Paused, &false);
+
         env.events().publish(
             (symbol_short!("unpause"), caller.clone()),
             UnpauseEvent {
                 unpaused_by: caller,
                 reason,
-                timestamp: env.ledger().timestamp(),
+                timestamp,
                 ledger_sequence: env.ledger().sequence(),
             },
         );
@@ -969,6 +1007,12 @@ impl AnalyticsContract {
             .instance()
             .get(&DataKey::Paused)
             .unwrap_or(false)
+    }
+
+    /// Get detailed pause information including reason, timestamp, and who paused.
+    /// Returns `None` if the contract has never been paused.
+    pub fn get_pause_info(env: Env) -> Option<PauseInfo> {
+        env.storage().instance().get(&DataKey::PauseInfo)
     }
 
     // =========================================================================

--- a/contracts/analytics/src/tests.rs
+++ b/contracts/analytics/src/tests.rs
@@ -1198,3 +1198,76 @@ fn test_submit_snapshot_with_ttl_stores_metadata() {
     assert_eq!(snapshot.expires_at, Some(6000u64));
     assert_eq!(snapshot.hash, hash);
 }
+
+#[test]
+fn test_pause_with_reason() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    env.ledger().set_timestamp(12345);
+
+    let reason = soroban_sdk::String::from_str(&env, "Emergency maintenance - fixing critical bug");
+    client.pause(&admin, &reason);
+
+    assert!(client.is_paused());
+
+    let info = client
+        .get_pause_info()
+        .expect("pause info must be set after pause");
+    assert!(info.paused);
+    assert_eq!(info.reason, reason);
+    assert_eq!(info.paused_at, 12345);
+    assert_eq!(info.paused_by, admin);
+}
+
+#[test]
+fn test_get_pause_info_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    env.ledger().set_timestamp(1000);
+
+    client.pause(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "scheduled downtime"),
+    );
+
+    env.ledger().set_timestamp(2000);
+    let unpause_reason = soroban_sdk::String::from_str(&env, "maintenance complete");
+    client.unpause(&admin, &unpause_reason);
+
+    assert!(!client.is_paused());
+
+    let info = client
+        .get_pause_info()
+        .expect("pause info must be set after unpause");
+    assert!(!info.paused);
+    assert_eq!(info.reason, unpause_reason);
+    assert_eq!(info.paused_at, 2000);
+    assert_eq!(info.paused_by, admin);
+}
+
+#[test]
+fn test_get_pause_info_none_when_never_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnalyticsContract);
+    let client = AnalyticsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Contract has never been paused — info should be None
+    assert!(client.get_pause_info().is_none());
+}


### PR DESCRIPTION
## Description

Adds structured pause reason tracking to the `analytics` contract. The `pause` and `unpause` functions now store a `PauseInfo` struct in instance storage alongside the existing boolean `Paused` key, and a new `get_pause_info` function exposes this data on-chain. This gives users and operators full transparency into why the contract was paused, when it happened, and who triggered it.

## Related Issue

- Closes #595 

## Changes Made

- Added `PauseInfo` contracttype struct with fields: `paused`, `reason`, `paused_at`, `paused_by`
- Added `DataKey::PauseInfo` variant to the `DataKey` enum in `contracts/analytics/src/lib.rs`
- Updated `pause` to write a `PauseInfo` entry to instance storage before emitting the existing `PauseEvent`
- Updated `unpause` to overwrite the `PauseInfo` entry with `paused: false` and the unpause reason/timestamp
- Added `get_pause_info(env: Env) -> Option<PauseInfo>` public function
- Added three tests to `contracts/analytics/src/tests.rs`: `test_pause_with_reason`, `test_get_pause_info_after_unpause`, `test_get_pause_info_none_when_never_paused`
