### PR TITLE
feat: add per-connection message rate limiting

### DIFF
--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -11,18 +11,51 @@ use futures::{sink::SinkExt, stream::StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-/// WebSocket connection state
+/// Maximum number of concurrent WebSocket connections the server will accept.
+const MAX_CONNECTIONS: usize = 1000;
+
+/// Number of messages a single connection may send per rate-limit window.
+const MAX_MESSAGES_PER_WINDOW: u32 = 100;
+
+/// Duration of the rate-limit sliding window.
+const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
+// ── Rate limiting ─────────────────────────────────────────────────────────────
+
+/// Per-connection rate-limit tracking.
+struct RateLimitInfo {
+    /// Number of messages received in the current window.
+    message_count: u32,
+    /// When the current window started.
+    window_start: Instant,
+}
+
+impl RateLimitInfo {
+    fn new() -> Self {
+        Self {
+            message_count: 0,
+            window_start: Instant::now(),
+        }
+    }
+}
+
+// ── WebSocket state ───────────────────────────────────────────────────────────
+
+/// WebSocket connection state shared across all handlers.
 pub struct WsState {
-    /// Map of connection ID to broadcast sender
+    /// Map of connection ID to per-connection message sender.
     pub connections: DashMap<Uuid, tokio::sync::mpsc::Sender<WsMessage>>,
-    /// Map of connection ID to subscribed channels
+    /// Map of connection ID to subscribed channels.
     pub subscriptions: DashMap<Uuid, HashSet<String>>,
-    ///Broadcast channel for sending messages to all connections
+    /// Broadcast channel for sending messages to all connections.
     pub tx: broadcast::Sender<WsMessage>,
+    /// Per-connection rate-limit state keyed by connection ID string.
+    rate_limits: DashMap<String, RateLimitInfo>,
 }
 
 impl Default for WsState {
@@ -39,21 +72,52 @@ impl WsState {
             connections: DashMap::new(),
             subscriptions: DashMap::new(),
             tx,
+            rate_limits: DashMap::new(),
         }
     }
 
-    /// Broadcast a message to all connected clients
+    /// Check whether `client_id` is within its rate limit.
+    ///
+    /// Returns `true` if the message should be processed, `false` if the limit
+    /// has been exceeded for the current window.
+    pub fn check_rate_limit(&self, client_id: &str) -> bool {
+        let mut entry = self
+            .rate_limits
+            .entry(client_id.to_string())
+            .or_insert_with(RateLimitInfo::new);
+
+        let now = Instant::now();
+
+        // Reset the window if it has expired.
+        if now.duration_since(entry.window_start) > RATE_LIMIT_WINDOW {
+            entry.message_count = 0;
+            entry.window_start = now;
+        }
+
+        if entry.message_count >= MAX_MESSAGES_PER_WINDOW {
+            return false;
+        }
+
+        entry.message_count += 1;
+        true
+    }
+
+    /// Remove rate-limit tracking for a connection that has disconnected.
+    fn cleanup_rate_limit(&self, client_id: &str) {
+        self.rate_limits.remove(client_id);
+    }
+
+    /// Broadcast a message to all connected clients.
     pub fn broadcast(&self, message: WsMessage) {
         if let Err(e) = self.tx.send(message) {
             warn!("Failed to broadcast message: {}", e);
         }
     }
 
-    /// Broadcast a message to clients subscribed to a specific channel
+    /// Broadcast a message to clients subscribed to a specific channel.
     pub async fn broadcast_to_channel(&self, channel: &str, message: WsMessage) {
         let mut target_connections = Vec::new();
 
-        // Find connections subscribed to this channel
         for entry in &self.subscriptions {
             let (connection_id, channels) = entry.pair();
             if channels.contains(channel) {
@@ -61,7 +125,6 @@ impl WsState {
             }
         }
 
-        // Send to targeted connections
         for connection_id in target_connections {
             if let Some(sender) = self.connections.get(&connection_id) {
                 if let Err(e) = sender.send(message.clone()).await {
@@ -74,7 +137,7 @@ impl WsState {
         }
     }
 
-    /// Subscribe a connection to channels
+    /// Subscribe a connection to channels.
     pub fn subscribe_connection(&self, connection_id: Uuid, channels: Vec<String>) {
         let mut subscription_set = self.subscriptions.entry(connection_id).or_default();
 
@@ -87,7 +150,7 @@ impl WsState {
         }
     }
 
-    /// Unsubscribe a connection from channels
+    /// Unsubscribe a connection from channels.
     pub fn unsubscribe_connection(&self, connection_id: Uuid, channels: Vec<String>) {
         if let Some(mut subscription_set) = self.subscriptions.get_mut(&connection_id) {
             for channel in channels {
@@ -100,13 +163,13 @@ impl WsState {
         }
     }
 
-    /// Get the number of active connections
+    /// Get the number of active connections.
     #[must_use]
     pub fn connection_count(&self) -> usize {
         self.connections.len()
     }
 
-    /// Get subscription count for a channel
+    /// Get the number of connections subscribed to a given channel.
     #[must_use]
     pub fn channel_subscription_count(&self, channel: &str) -> usize {
         self.subscriptions
@@ -115,13 +178,14 @@ impl WsState {
             .count()
     }
 
-    /// Clean up disconnected connections
+    /// Remove all state associated with a disconnected connection.
     pub fn cleanup_connection(&self, connection_id: Uuid) {
         self.connections.remove(&connection_id);
         self.subscriptions.remove(&connection_id);
+        self.cleanup_rate_limit(&connection_id.to_string());
     }
 
-    /// Close all WebSocket connections gracefully
+    /// Close all WebSocket connections gracefully.
     pub async fn close_all_connections(&self) {
         let connection_ids: Vec<Uuid> = self.connections.iter().map(|entry| *entry.key()).collect();
 
@@ -132,6 +196,8 @@ impl WsState {
         info!("All WebSocket connections have been closed");
     }
 }
+
+// ── Message types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -216,19 +282,44 @@ pub enum WsMessage {
     },
 }
 
+// ── Query params ──────────────────────────────────────────────────────────────
+
 #[derive(Debug, Deserialize)]
 pub struct WsQueryParams {
     /// Optional authentication token
     pub token: Option<String>,
 }
 
-/// WebSocket handler endpoint
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// WebSocket upgrade handler.
+///
+/// Rejects the connection with `503 Service Unavailable` when the server has
+/// reached `MAX_CONNECTIONS`, and with `401 Unauthorized` when an invalid
+/// token is supplied.
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
     Query(params): Query<WsQueryParams>,
     State(state): State<Arc<WsState>>,
 ) -> Response {
-    // Validate authentication token if provided
+    // Connection limit check — must happen before the upgrade so we can still
+    // return an HTTP error response.
+    if state.connection_count() >= MAX_CONNECTIONS {
+        warn!(
+            "Connection limit reached ({}/{}), rejecting new WebSocket connection",
+            state.connection_count(),
+            MAX_CONNECTIONS
+        );
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "Server at capacity. Please try again later."
+            })),
+        )
+            .into_response();
+    }
+
+    // Validate authentication token if provided.
     if let Some(token) = params.token {
         if !validate_token(&token) {
             return (
@@ -242,62 +333,73 @@ pub async fn ws_handler(
     ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
-/// Validate authentication token
+/// Validate authentication token.
 fn validate_token(token: &str) -> bool {
-    // For now, implement basic token validation
-    // In production, use JWT or other robust auth mechanism
-
-    // If WS_AUTH_TOKEN env var is set, validate against it
-    // Otherwise, accept all tokens (for development)
     if let Ok(expected_token) = std::env::var("WS_AUTH_TOKEN") {
         token == expected_token
     } else {
-        // No token configured, allow all connections
         warn!("WS_AUTH_TOKEN not configured, allowing all WebSocket connections");
         true
     }
 }
 
-/// Handle individual WebSocket connection
+/// Handle an individual WebSocket connection.
 async fn handle_socket(socket: WebSocket, state: Arc<WsState>) {
     let connection_id = Uuid::new_v4();
+    let client_id = connection_id.to_string();
     info!("New WebSocket connection: {}", connection_id);
 
     let (sender, receiver) = socket.split();
     let sender = Arc::new(tokio::sync::Mutex::new(sender));
 
-    // Create a channel for this specific connection
+    // Per-connection message channel.
     let (tx, mut rx) = tokio::sync::mpsc::channel::<WsMessage>(32);
 
-    // Register the connection
+    // Register the connection.
     state.connections.insert(connection_id, tx);
     crate::observability::metrics::set_active_connections(state.connection_count() as i64);
 
-    // Subscribe to broadcast messages
+    // Subscribe to the broadcast channel.
     let mut broadcast_rx = state.tx.subscribe();
 
-    // Send connection confirmation
+    // Send connection confirmation.
     let connected_msg = WsMessage::Connected {
-        connection_id: connection_id.to_string(),
+        connection_id: client_id.clone(),
     };
     if let Ok(json) = serde_json::to_string(&connected_msg) {
         let mut sender_guard = sender.lock().await;
         let _ = sender_guard.send(Message::Text(json)).await;
     }
 
-    // Clone sender for tasks
     let send_sender = Arc::clone(&sender);
     let recv_sender = Arc::clone(&sender);
     let state_clone = Arc::clone(&state);
 
-    // Task for receiving messages from client
+    // ── Receive task ───────────────────────────────────────────────────────────
     let recv_task = {
-        let connection_id = connection_id;
+        let client_id = client_id.clone();
         tokio::spawn(async move {
             let mut receiver = receiver;
             while let Some(Ok(msg)) = receiver.next().await {
                 match msg {
                     Message::Text(text) => {
+                        // Rate limit check — applies to every text message.
+                        if !state_clone.check_rate_limit(&client_id) {
+                            warn!(
+                                "Rate limit exceeded for connection {}",
+                                connection_id
+                            );
+                            let error_msg = WsMessage::Error {
+                                message: "Rate limit exceeded. Please slow down.".to_string(),
+                            };
+                            if let Ok(json) = serde_json::to_string(&error_msg) {
+                                let mut sender_guard = recv_sender.lock().await;
+                                let _ = sender_guard.send(Message::Text(json)).await;
+                            }
+                            // Drop the message but keep the connection open.
+                            continue;
+                        }
+
                         if let Ok(ws_msg) = serde_json::from_str::<WsMessage>(&text) {
                             match ws_msg {
                                 WsMessage::Ping { timestamp } => {
@@ -341,7 +443,10 @@ async fn handle_socket(socket: WebSocket, state: Arc<WsState>) {
                                     }
                                 }
                                 _ => {
-                                    warn!("Unexpected message type from client: {:?}", ws_msg);
+                                    warn!(
+                                        "Unexpected message type from client: {:?}",
+                                        ws_msg
+                                    );
                                 }
                             }
                         } else {
@@ -363,15 +468,14 @@ async fn handle_socket(socket: WebSocket, state: Arc<WsState>) {
         })
     };
 
-    // Task for sending messages to client
+    // ── Send task ──────────────────────────────────────────────────────────────
     let send_task = {
-        let connection_id = connection_id;
         tokio::spawn(async move {
-            let mut ping_interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
+            let mut ping_interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(30));
 
             loop {
                 tokio::select! {
-                    // Send ping every 30 seconds
                     _ = ping_interval.tick() => {
                         let ping = WsMessage::Ping {
                             timestamp: chrono::Utc::now().timestamp(),
@@ -384,17 +488,18 @@ async fn handle_socket(socket: WebSocket, state: Arc<WsState>) {
                             }
                         }
                     }
-                    // Receive from broadcast channel
                     Ok(msg) = broadcast_rx.recv() => {
                         if let Ok(json) = serde_json::to_string(&msg) {
                             let mut sender_guard = send_sender.lock().await;
                             if sender_guard.send(Message::Text(json)).await.is_err() {
-                                error!("Failed to send broadcast message to {}", connection_id);
+                                error!(
+                                    "Failed to send broadcast message to {}",
+                                    connection_id
+                                );
                                 break;
                             }
                         }
                     }
-                    // Receive from connection-specific channel
                     Some(msg) = rx.recv() => {
                         if let Ok(json) = serde_json::to_string(&msg) {
                             let mut sender_guard = send_sender.lock().await;
@@ -409,7 +514,6 @@ async fn handle_socket(socket: WebSocket, state: Arc<WsState>) {
         })
     };
 
-    // Wait for either task to finish
     tokio::select! {
         _ = recv_task => {
             info!("Receive task finished for {}", connection_id);
@@ -419,7 +523,6 @@ async fn handle_socket(socket: WebSocket, state: Arc<WsState>) {
         }
     }
 
-    // Clean up connection
     state.cleanup_connection(connection_id);
     crate::observability::metrics::set_active_connections(state.connection_count() as i64);
     info!(
@@ -428,6 +531,8 @@ async fn handle_socket(socket: WebSocket, state: Arc<WsState>) {
         state.connection_count()
     );
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -441,7 +546,7 @@ mod tests {
 
     #[test]
     fn test_validate_token_no_env() {
-        // Without WS_AUTH_TOKEN env var, should accept any token
+        // Without WS_AUTH_TOKEN env var, should accept any token.
         assert!(validate_token("any_token"));
     }
 
@@ -457,5 +562,91 @@ mod tests {
         let json = serde_json::to_string(&msg).expect("Failed to serialize WsMessage in test");
         assert!(json.contains("snapshot_update"));
         assert!(json.contains("test-id"));
+    }
+
+    #[test]
+    fn test_websocket_rate_limit_allows_within_window() {
+        let state = WsState::new();
+        let client_id = "test-client-1";
+
+        // First MAX_MESSAGES_PER_WINDOW messages must be allowed.
+        for _ in 0..MAX_MESSAGES_PER_WINDOW {
+            assert!(
+                state.check_rate_limit(client_id),
+                "message within limit should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_websocket_rate_limit_blocks_when_exceeded() {
+        let state = WsState::new();
+        let client_id = "test-client-2";
+
+        // Exhaust the window.
+        for _ in 0..MAX_MESSAGES_PER_WINDOW {
+            state.check_rate_limit(client_id);
+        }
+
+        // The next message must be rejected.
+        assert!(
+            !state.check_rate_limit(client_id),
+            "message beyond limit should be blocked"
+        );
+    }
+
+    #[test]
+    fn test_websocket_rate_limit_independent_per_client() {
+        let state = WsState::new();
+        let client_a = "client-a";
+        let client_b = "client-b";
+
+        // Exhaust client A's window.
+        for _ in 0..MAX_MESSAGES_PER_WINDOW {
+            state.check_rate_limit(client_a);
+        }
+        assert!(!state.check_rate_limit(client_a));
+
+        // Client B should still be fully allowed.
+        assert!(
+            state.check_rate_limit(client_b),
+            "independent client should not be affected by another client's limit"
+        );
+    }
+
+    #[test]
+    fn test_websocket_connection_limit() {
+        let state = WsState::new();
+
+        // Simulate connections up to the limit by inserting dummy senders.
+        for _ in 0..MAX_CONNECTIONS {
+            let (tx, _rx) = tokio::sync::mpsc::channel::<WsMessage>(1);
+            state.connections.insert(Uuid::new_v4(), tx);
+        }
+
+        assert_eq!(state.connection_count(), MAX_CONNECTIONS);
+        // The handler should reject at this point — verified by checking the count.
+        assert!(state.connection_count() >= MAX_CONNECTIONS);
+    }
+
+    #[test]
+    fn test_cleanup_removes_rate_limit_entry() {
+        let state = WsState::new();
+        let connection_id = Uuid::new_v4();
+        let client_id = connection_id.to_string();
+
+        // Create a rate limit entry.
+        state.check_rate_limit(&client_id);
+        assert!(state.rate_limits.contains_key(&client_id));
+
+        // Insert a dummy connection so cleanup_connection can remove it.
+        let (tx, _rx) = tokio::sync::mpsc::channel::<WsMessage>(1);
+        state.connections.insert(connection_id, tx);
+
+        state.cleanup_connection(connection_id);
+        assert!(
+            !state.rate_limits.contains_key(&client_id),
+            "rate limit entry should be removed on cleanup"
+        );
     }
 }

--- a/backend/tests/websocket_integration_test.rs
+++ b/backend/tests/websocket_integration_test.rs
@@ -102,3 +102,51 @@ async fn test_new_payment_message_serialization() {
     assert!(json.contains("1000.5"));
     assert!(json.contains("true"));
 }
+
+#[tokio::test]
+async fn test_websocket_rate_limit_enforcement() {
+    use stellar_insights_backend::websocket::WsState;
+
+    let state = WsState::new();
+    let client_id = "integration-test-client";
+
+    // Allow up to the limit.
+    for i in 0..100u32 {
+        assert!(
+            state.check_rate_limit(client_id),
+            "message {} should be within rate limit",
+            i + 1
+        );
+    }
+
+    // 101st message must be blocked.
+    assert!(
+        !state.check_rate_limit(client_id),
+        "101st message should exceed rate limit"
+    );
+}
+
+#[tokio::test]
+async fn test_websocket_connection_limit_boundary() {
+    use stellar_insights_backend::websocket::{WsMessage, WsState};
+
+    let state = std::sync::Arc::new(WsState::new());
+
+    // Fill to one below the limit.
+    for _ in 0..999 {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<WsMessage>(1);
+        state.connections.insert(uuid::Uuid::new_v4(), tx);
+    }
+
+    assert_eq!(state.connection_count(), 999);
+    // One more should still be within limit.
+    assert!(state.connection_count() < 1000);
+
+    // Add the 1000th.
+    let (tx, _rx) = tokio::sync::mpsc::channel::<WsMessage>(1);
+    state.connections.insert(uuid::Uuid::new_v4(), tx);
+    assert_eq!(state.connection_count(), 1000);
+
+    // Now at capacity — handler would reject.
+    assert!(state.connection_count() >= 1000);
+}


### PR DESCRIPTION
## Description

Adds per-connection message rate limiting and a global connection cap to the WebSocket handler. Before this change, any client could open unlimited connections and flood the server with messages, creating a DoS vector. After this change, connections beyond 1,000 receive `503 Service Unavailable` immediately at the HTTP upgrade step, and individual connections are limited to 100 messages per 60-second window, receiving an error message for each excess message rather than a hard disconnect.

## Related Issue

- Closes #663 

## Changes Made

- Added `RateLimitInfo` struct to `backend/src/websocket.rs` tracking `message_count` and `window_start` per connection
- Added `rate_limits: DashMap<String, RateLimitInfo>` field to `WsState`
- Added `WsState::check_rate_limit(&self, client_id: &str) -> bool` implementing a sliding-window counter reset on window expiry
- Added `WsState::cleanup_rate_limit` called from `cleanup_connection` to avoid unbounded map growth
- Added `MAX_CONNECTIONS` (1000), `MAX_MESSAGES_PER_WINDOW` (100), and `RATE_LIMIT_WINDOW` (60s) module-level constants
- Updated `ws_handler` to reject connections with `503` when `connection_count() >= MAX_CONNECTIONS` before the upgrade
- Updated the receive task in `handle_socket` to call `check_rate_limit` on every text message; drops the message and sends a `WsMessage::Error` to the client when the limit is exceeded
- Added unit tests: `test_websocket_rate_limit_allows_within_window`, `test_websocket_rate_limit_blocks_when_exceeded`, `test_websocket_rate_limit_independent_per_client`, `test_websocket_connection_limit`, `test_cleanup_removes_rate_limit_entry`
- Added integration tests to `backend/tests/websocket_integration_test.rs`

## Acceptance Criteria

- `cargo test test_websocket_rate_limit` passes
- `cargo test test_websocket_connection_limit` passes
- Connections beyond 1,000 receive HTTP `503` before the WebSocket upgrade completes
- Messages beyond 100 per 60-second window receive a `WsMessage::Error` response; the connection remains open
- Rate limit state is cleaned up when a connection closes, preventing memory growth