### PR TITLE
fix(#589): extend persistent storage TTL in all contracts

### DIFF
--- a/contracts/Snapshot Comparison Function/src/lib.rs
+++ b/contracts/Snapshot Comparison Function/src/lib.rs
@@ -76,11 +76,26 @@ impl SnapshotComparison {
             .persistent()
             .set(&DataKey::Snapshots, &snapshots);
 
+        const LEDGERS_TO_EXTEND: u32 = 518_400;
+        env.storage().persistent().extend_ttl(
+            &DataKey::Snapshots,
+            LEDGERS_TO_EXTEND,
+            LEDGERS_TO_EXTEND,
+        );
+
         Ok(())
     }
 
     /// Get a specific snapshot by epoch
     pub fn get_snapshot(env: Env, epoch: u64) -> SorobanResult<SnapshotMetadata> {
+        const LEDGERS_TO_EXTEND: u32 = 518_400;
+        if env.storage().persistent().has(&DataKey::Snapshots) {
+            env.storage().persistent().extend_ttl(
+                &DataKey::Snapshots,
+                LEDGERS_TO_EXTEND,
+                LEDGERS_TO_EXTEND,
+            );
+        }
         let snapshots: Map<u64, SnapshotMetadata> = env
             .storage()
             .persistent()

--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -297,6 +297,8 @@ fn validate_epoch(env: &Env, epoch: u64) -> Result<u64, Error> {
 }
 
 /// Write one snapshot to per-epoch persistent storage and update the shared map + latest epoch.
+const LEDGERS_TO_EXTEND: u32 = 518_400; // ~30 days at 5s per ledger
+
 fn write_snapshot(
     env: &Env,
     epoch: u64,
@@ -306,10 +308,20 @@ fn write_snapshot(
     env.storage()
         .persistent()
         .set(&DataKey::Snapshot(epoch), metadata);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Snapshot(epoch),
+        LEDGERS_TO_EXTEND,
+        LEDGERS_TO_EXTEND,
+    );
     snapshots.set(epoch, metadata.clone());
     env.storage()
         .persistent()
         .set(&DataKey::Snapshots, snapshots);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Snapshots,
+        LEDGERS_TO_EXTEND,
+        LEDGERS_TO_EXTEND,
+    );
     env.storage().instance().set(&DataKey::LatestEpoch, &epoch);
 }
 
@@ -626,6 +638,13 @@ impl AnalyticsContract {
     /// Get snapshot metadata for a specific epoch.
     pub fn get_snapshot(env: Env, epoch: u64) -> Result<Option<SnapshotMetadata>, Error> {
         require_initialized(&env)?;
+        if env.storage().persistent().has(&DataKey::Snapshot(epoch)) {
+            env.storage().persistent().extend_ttl(
+                &DataKey::Snapshot(epoch),
+                LEDGERS_TO_EXTEND,
+                LEDGERS_TO_EXTEND,
+            );
+        }
         Ok(env.storage().persistent().get(&DataKey::Snapshot(epoch)))
     }
 

--- a/contracts/snapshot-contract/src/lib.rs
+++ b/contracts/snapshot-contract/src/lib.rs
@@ -433,6 +433,19 @@ impl SnapshotContract {
             .persistent()
             .set(&DataKey::LatestEpoch, &epoch);
 
+        // Extend storage TTL (~30 days at 5s per ledger)
+        const LEDGERS_TO_EXTEND: u32 = 518_400;
+        env.storage().persistent().extend_ttl(
+            &DataKey::Snapshots,
+            LEDGERS_TO_EXTEND,
+            LEDGERS_TO_EXTEND,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::LatestEpoch,
+            LEDGERS_TO_EXTEND,
+            LEDGERS_TO_EXTEND,
+        );
+
         env.events().publish(
             (symbol_short!("SNAP_SUB"),),
             SnapshotSubmittedEvent {
@@ -454,6 +467,14 @@ impl SnapshotContract {
     /// Get snapshot hash for a specific epoch
     pub fn get_snapshot(env: Env, epoch: u64) -> Result<Bytes, Error> {
         Self::require_not_stopped(&env)?;
+        const LEDGERS_TO_EXTEND: u32 = 518_400;
+        if env.storage().persistent().has(&DataKey::Snapshots) {
+            env.storage().persistent().extend_ttl(
+                &DataKey::Snapshots,
+                LEDGERS_TO_EXTEND,
+                LEDGERS_TO_EXTEND,
+            );
+        }
         let snapshots: Map<u64, Snapshot> = env
             .storage()
             .persistent()

--- a/contracts/stellar_insights/src/lib.rs
+++ b/contracts/stellar_insights/src/lib.rs
@@ -196,6 +196,14 @@ impl StellarInsightsContract {
             .persistent()
             .set(&DataKey::Snapshots, &snapshots);
 
+        // Extend storage TTL (~30 days at 5s per ledger)
+        const LEDGERS_TO_EXTEND: u32 = 518_400;
+        env.storage().persistent().extend_ttl(
+            &DataKey::Snapshots,
+            LEDGERS_TO_EXTEND,
+            LEDGERS_TO_EXTEND,
+        );
+
         env.storage().instance().set(&DataKey::LatestEpoch, &epoch);
 
         // Emit structured event for off-chain indexing
@@ -221,6 +229,15 @@ impl StellarInsightsContract {
     /// # Returns
     /// * The 32-byte hash stored for that epoch
     pub fn get_snapshot(env: Env, epoch: u64) -> Result<BytesN<32>, Error> {
+        // Extend TTL on read to keep data alive
+        const LEDGERS_TO_EXTEND: u32 = 518_400;
+        if env.storage().persistent().has(&DataKey::Snapshots) {
+            env.storage().persistent().extend_ttl(
+                &DataKey::Snapshots,
+                LEDGERS_TO_EXTEND,
+                LEDGERS_TO_EXTEND,
+            );
+        }
         let snapshots: Map<u64, Snapshot> = env
             .storage()
             .persistent()


### PR DESCRIPTION
### Problem

Soroban persistent storage expires after ~30 days without a TTL extension. None of the 
contracts were calling extend_ttl, meaning all snapshot data would silently be deleted by 
the network — with no way to recover it.

### Changes

Added extend_ttl calls (518_400 ledgers ≈ 30 days at 5s/ledger) in two places per contract:

On write — TTL is extended immediately after storing data, so freshly written entries don't
expire before they're ever read.

On read — TTL is extended when data is accessed, so actively-queried entries stay alive 
indefinitely.

| Contract | Keys extended |
|---|---|
| analytics | DataKey::Snapshot(epoch), DataKey::Snapshots |
| stellar_insights | DataKey::Snapshots |
| snapshot-contract | DataKey::Snapshots, DataKey::LatestEpoch |
| Snapshot Comparison Function | DataKey::Snapshots |

### Why 518_400

518_400 ledgers × 5s/ledger = 2_592_000s = 30 days


This matches the Soroban network's default persistent storage lifetime, effectively 
resetting the clock on every interaction.

### Testing

Existing test suites cover the affected functions. No logic was changed — only TTL 
extension calls were added around existing storage reads and writes.

close #589 