### PR TITLE
#809 Backend - unwrap() in Production Code (Risk of Panics)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -108,7 +108,11 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("Backup scheduler enabled");
     }
 
-    let rate_limiter = Arc::new(RateLimiter::new().await.unwrap());
+    let rate_limiter = Arc::new(
+        RateLimiter::new()
+            .await
+            .context("Failed to initialize rate limiter")?,
+    );
 
     // Start webhook dispatcher as a background task
     let webhook_pool = pool.clone();

--- a/backend/src/rpc/stellar.rs
+++ b/backend/src/rpc/stellar.rs
@@ -801,9 +801,9 @@ impl StellarRpcClient {
         if let Some(c) = cursor {
             params
                 .get_mut("pagination")
-                .unwrap()
+                .expect("pagination field should exist")
                 .as_object_mut()
-                .unwrap()
+                .expect("pagination should be an object")
                 .insert("cursor".to_string(), json!(c));
         } else if let Some(start) = start_ledger {
             params.insert("startLedger".to_string(), json!(start));


### PR DESCRIPTION
closes #809 

## Summary

This PR improves backend stability by replacing unsafe `unwrap()` calls with context-aware error handling and descriptive expectations.

Previously, certain `unwrap()` usages could cause unexpected panics in production. This update ensures failures are handled gracefully with meaningful error messages, improving reliability and debuggability.

---

## Changes Made

### main.rs Improvements

In `backend/src/main.rs`, the `RateLimiter::new().await.unwrap()` call was replaced with:

```rust
.context("Failed to initialize rate limiter")?