### PR TITLE
feat: add error boundaries to corridors, anchors, analytics, governan…

### DIFF
--- a/frontend/src/app/[locale]/analytics/page.tsx
+++ b/frontend/src/app/[locale]/analytics/page.tsx
@@ -11,6 +11,7 @@ import {
 import { Link } from "@/i18n/navigation";
 import { fetchAnalyticsMetrics, AnalyticsMetrics } from "@/lib/analytics-api";
 import dynamic from "next/dynamic";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 const ChartSkeleton = () => (
   <div className="h-64 w-full rounded-xl bg-white/5 animate-pulse" />
@@ -122,115 +123,114 @@ export default function AnalyticsPage() {
   };
 
   return (
-    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
-      {/* Page Header */}
-      <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border/50 pb-6">
-        <div>
-          <div className="text-[10px] font-mono text-accent uppercase tracking-[0.2em] mb-2">
-            Deep Analytics // 03
+    <ErrorBoundary>
+      <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border/50 pb-6">
+          <div>
+            <div className="text-[10px] font-mono text-accent uppercase tracking-[0.2em] mb-2">
+              Deep Analytics // 03
+            </div>
+            <h2 className="text-4xl font-black tracking-tighter uppercase italic flex items-center gap-3">
+              Network Intelligence
+            </h2>
           </div>
-          <h2 className="text-4xl font-black tracking-tighter uppercase italic flex items-center gap-3">
-            Network Intelligence
-          </h2>
-        </div>
-        <div className="flex items-center gap-3">
-          <div className="px-4 py-2 glass rounded-lg text-[10px] font-mono uppercase tracking-widest text-muted-foreground">
-            Last Sync: {lastUpdated?.toLocaleTimeString()}
-          </div>
-          <button
-            onClick={handleRefresh}
-            className="px-4 py-2 bg-accent text-white rounded-lg text-[10px] font-bold uppercase tracking-widest hover:scale-105 transition-transform flex items-center gap-2"
-          >
-            <RefreshCw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} />
-            Re-Scan
-          </button>
-        </div>
-      </div>
-
-      {/* Error State */}
-      {error && (
-        <div className="glass border-red-500/50 p-4 rounded-xl flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <AlertCircle className="w-5 h-5 text-red-500" />
-            <p className="text-[10px] font-mono text-red-500 uppercase tracking-widest">
-              Emergency Shutdown Avoided // Running on Local Cache (Mock Data)
-            </p>
+            <div className="px-4 py-2 glass rounded-lg text-[10px] font-mono uppercase tracking-widest text-muted-foreground">
+              Last Sync: {lastUpdated?.toLocaleTimeString()}
+            </div>
+            <button
+              onClick={handleRefresh}
+              className="px-4 py-2 bg-accent text-white rounded-lg text-[10px] font-bold uppercase tracking-widest hover:scale-105 transition-transform flex items-center gap-2"
+            >
+              <RefreshCw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} />
+              Re-Scan
+            </button>
           </div>
-          <Badge
-            variant="outline"
-            className="border-red-500/30 text-red-500 text-[10px]"
-          >
-            FIX_REQUIRED
-          </Badge>
         </div>
-      )}
 
-      {/* Key Metrics */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <MetricCard
-          label="Cumulative Volume"
-          value={metrics ? formatCurrency(metrics.total_volume_usd) : "$0"}
-          subLabel="Total Network Flow"
-        />
-        <MetricCard
-          label="Success Probability"
-          value={metrics ? `${metrics.avg_success_rate.toFixed(1)}%` : "0%"}
-          trend={1.2}
-          trendDirection="up"
-        />
-        <MetricCard
-          label="Active Routing Nodes"
-          value={metrics ? metrics.active_corridors : "0"}
-          subLabel="Online Corridors"
-        />
-        <MetricCard
-          label="Aggregated Liquidity"
-          value={
-            metrics
-              ? formatCurrency(
-                  metrics.top_corridors.reduce(
-                    (sum, c) => sum + c.liquidity_depth_usd,
-                    0,
-                  ),
-                )
-              : "$0"
-          }
-          subLabel="Available Capital"
-        />
-      </div>
+        {error && (
+          <div className="glass border-red-500/50 p-4 rounded-xl flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <AlertCircle className="w-5 h-5 text-red-500" />
+              <p className="text-[10px] font-mono text-red-500 uppercase tracking-widest">
+                Emergency Shutdown Avoided // Running on Local Cache (Mock Data)
+              </p>
+            </div>
+            <Badge
+              variant="outline"
+              className="border-red-500/30 text-red-500 text-[10px]"
+            >
+              FIX_REQUIRED
+            </Badge>
+          </div>
+        )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        <div className="lg:col-span-8 space-y-6">
-          <div className="glass-card rounded-2xl p-1">
-            {metrics && <LiquidityChart data={metrics.liquidity_history} />}
-          </div>
-          <div className="glass-card rounded-2xl p-1">
-            {metrics && <TVLChart data={metrics.tvl_history} />}
-          </div>
-          <div className="glass-card rounded-2xl p-1">
-            {metrics && (
-              <SettlementLatencyChart
-                data={metrics.settlement_latency_history}
-              />
-            )}
-          </div>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <MetricCard
+            label="Cumulative Volume"
+            value={metrics ? formatCurrency(metrics.total_volume_usd) : "$0"}
+            subLabel="Total Network Flow"
+          />
+          <MetricCard
+            label="Success Probability"
+            value={metrics ? `${metrics.avg_success_rate.toFixed(1)}%` : "0%"}
+            trend={1.2}
+            trendDirection="up"
+          />
+          <MetricCard
+            label="Active Routing Nodes"
+            value={metrics ? metrics.active_corridors : "0"}
+            subLabel="Online Corridors"
+          />
+          <MetricCard
+            label="Aggregated Liquidity"
+            value={
+              metrics
+                ? formatCurrency(
+                    metrics.top_corridors.reduce(
+                      (sum, c) => sum + c.liquidity_depth_usd,
+                      0,
+                    ),
+                  )
+                : "$0"
+            }
+            subLabel="Available Capital"
+          />
         </div>
-        <div className="lg:col-span-4 space-y-6">
-          <div className="glass-card rounded-2xl p-1">
-            {metrics && <TopCorridors corridors={metrics.top_corridors} />}
+
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+          <div className="lg:col-span-8 space-y-6">
+            <div className="glass-card rounded-2xl p-1">
+              {metrics && <LiquidityChart data={metrics.liquidity_history} />}
+            </div>
+            <div className="glass-card rounded-2xl p-1">
+              {metrics && <TVLChart data={metrics.tvl_history} />}
+            </div>
+            <div className="glass-card rounded-2xl p-1">
+              {metrics && (
+                <SettlementLatencyChart
+                  data={metrics.settlement_latency_history}
+                />
+              )}
+            </div>
           </div>
-          <div className="glass-card rounded-2xl p-1">
-            {metrics && (
-              <LiquidityHeatmap
-                corridors={metrics.top_corridors}
-                onTimePeriodChange={handleRefresh}
-              />
-            )}
+          <div className="lg:col-span-4 space-y-6">
+            <div className="glass-card rounded-2xl p-1">
+              {metrics && <TopCorridors corridors={metrics.top_corridors} />}
+            </div>
+            <div className="glass-card rounded-2xl p-1">
+              {metrics && (
+                <LiquidityHeatmap
+                  corridors={metrics.top_corridors}
+                  onTimePeriodChange={handleRefresh}
+                />
+              )}
+            </div>
+            <MuxedAccountCard />
+            <OnChainVerification />
           </div>
-          <MuxedAccountCard />
-          <OnChainVerification />
         </div>
       </div>
-    </div>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/app/[locale]/anchors/page.tsx
+++ b/frontend/src/app/[locale]/anchors/page.tsx
@@ -1,29 +1,30 @@
 "use client";
 import { Suspense } from "react";
-import {
-  Home as AnchorIcon,
-} from "lucide-react";
+import { Home as AnchorIcon } from "lucide-react";
 import { MainLayout } from "@/components/layout";
 import AnchorsPageContent from "./components/AnchorsPageContent";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 const AnchorsPage = () => {
   return (
-    <Suspense
-      fallback={
-        <MainLayout>
-          <div className="flex items-center justify-center min-h-screen">
-            <div className="text-center">
-              <AnchorIcon className="w-12 h-12 text-gray-400 mx-auto mb-4 animate-pulse" />
-              <p className="text-gray-600 dark:text-gray-400">
-                Loading anchors...
-              </p>
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <MainLayout>
+            <div className="flex items-center justify-center min-h-screen">
+              <div className="text-center">
+                <AnchorIcon className="w-12 h-12 text-gray-400 mx-auto mb-4 animate-pulse" />
+                <p className="text-gray-600 dark:text-gray-400">
+                  Loading anchors...
+                </p>
+              </div>
             </div>
-          </div>
-        </MainLayout>
-      }
-    >
-      <AnchorsPageContent />
-    </Suspense>
+          </MainLayout>
+        }
+      >
+        <AnchorsPageContent />
+      </Suspense>
+    </ErrorBoundary>
   );
 };
 

--- a/frontend/src/app/[locale]/corridors/page.tsx
+++ b/frontend/src/app/[locale]/corridors/page.tsx
@@ -23,6 +23,7 @@ import {
   useUserPreferences,
   type CorridorsTimePeriod,
 } from "@/contexts/UserPreferencesContext";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 function CorridorsPageContent() {
   const { prefs, setPrefs } = useUserPreferences();
@@ -30,7 +31,6 @@ function CorridorsPageContent() {
   const [corridors, setCorridors] = useState<CorridorMetrics[]>([]);
   const [isExportOpen, setIsExportOpen] = useState(false);
 
-  // Persisted preferences
   const viewMode = prefs.corridorsViewMode;
   const setViewMode = (v: typeof viewMode) =>
     setPrefs({ corridorsViewMode: v });
@@ -41,7 +41,6 @@ function CorridorsPageContent() {
     setPrefs({ corridorsTimePeriod: v });
 
   const [loading, setLoading] = useState(true);
-  // Volatile filters — intentionally session-only
   const [searchTerm, setSearchTerm] = useState("");
   const [showFilters, setShowFilters] = useState(false);
 
@@ -89,8 +88,6 @@ function CorridorsPageContent() {
           const result = await getCorridors(filters);
           setCorridors(result);
         } catch {
-          // Backend API not available - gracefully fall back to mock data
-          // This is expected behavior when the backend server isn't running
           setCorridors(mockCorridors);
         }
       } catch (err) {
@@ -128,9 +125,9 @@ function CorridorsPageContent() {
     if (rate >= 75) return <TrendingUp className="w-5 h-5 text-yellow-500" />;
     return <AlertCircle className="w-5 h-5 text-red-500" />;
   };
+
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
-      {/* Page Header */}
       <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border/50 pb-6">
         <div>
           <div className="text-[10px] font-mono text-accent uppercase tracking-[0.2em] mb-2">
@@ -165,7 +162,6 @@ function CorridorsPageContent() {
         title="Payment Corridors"
       />
 
-      {/* Search and Filter */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
         <div className="lg:col-span-8 relative group">
           <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground group-focus-within:text-accent transition-colors" />
@@ -212,7 +208,6 @@ function CorridorsPageContent() {
         </div>
       </div>
 
-      {/* View Mode Toggle */}
       <div className="flex items-center gap-1 p-1 bg-slate-950/50 border border-border/20 rounded-xl w-fit">
         <button
           onClick={() => setViewMode("grid")}
@@ -236,7 +231,6 @@ function CorridorsPageContent() {
         </button>
       </div>
 
-      {/* Content */}
       {loading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {[1, 2, 3, 4, 5, 6].map((i) => (
@@ -270,7 +264,6 @@ function CorridorsPageContent() {
               className="group glass-card rounded-2xl p-6 border border-border/50 hover:border-accent/30 transition-all duration-300"
             >
               <Link href={`/corridors/${corridor.id}`}>
-                {/* Header */}
                 <div className="flex items-start justify-between mb-6">
                   <div className="flex-1 min-w-0">
                     <h2 className="text-xl font-bold tracking-tight text-foreground group-hover:text-accent transition-colors truncate">
@@ -294,7 +287,6 @@ function CorridorsPageContent() {
                   </div>
                 </div>
 
-                {/* Health Radial Area */}
                 <div className="mb-6 p-4 rounded-xl bg-slate-900/30 border border-white/5">
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-[10px] font-mono text-muted-foreground uppercase tracking-widest">
@@ -326,20 +318,15 @@ function CorridorsPageContent() {
                   </div>
                 </div>
 
-                {/* Metrics */}
                 <div className="space-y-3">
                   <div className="flex justify-between items-center text-[10px] font-mono uppercase tracking-tighter">
-                    <span className="text-muted-foreground">
-                      Settlement Time
-                    </span>
+                    <span className="text-muted-foreground">Settlement Time</span>
                     <span className="text-accent font-bold">
                       {corridor.average_latency_ms.toFixed(0)}ms
                     </span>
                   </div>
                   <div className="flex justify-between items-center text-[10px] font-mono uppercase tracking-tighter">
-                    <span className="text-muted-foreground">
-                      Liquidity Depth
-                    </span>
+                    <span className="text-muted-foreground">Liquidity Depth</span>
                     <span className="text-foreground font-bold">
                       {new Intl.NumberFormat("en-US", {
                         style: "currency",
@@ -369,7 +356,6 @@ function CorridorsPageContent() {
         </div>
       )}
 
-      {/* Pagination */}
       <div className="flex flex-col sm:flex-row items-center justify-between gap-4 glass-card rounded-2xl p-6 border border-border/30">
         <div className="text-[10px] font-mono text-muted-foreground uppercase tracking-widest">
           Telemetry Feed: Viewing {startIndex + 1}-
@@ -390,16 +376,18 @@ function CorridorsPageContent() {
 
 export default function CorridorsPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex h-[80vh] items-center justify-center">
-          <div className="text-sm font-mono text-accent animate-pulse uppercase tracking-widest italic">
-            Syncing Satellite Routes... // 404-X
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <div className="flex h-[80vh] items-center justify-center">
+            <div className="text-sm font-mono text-accent animate-pulse uppercase tracking-widest italic">
+              Syncing Satellite Routes... // 404-X
+            </div>
           </div>
-        </div>
-      }
-    >
-      <CorridorsPageContent />
-    </Suspense>
+        }
+      >
+        <CorridorsPageContent />
+      </Suspense>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/app/[locale]/governance/page.tsx
+++ b/frontend/src/app/[locale]/governance/page.tsx
@@ -8,6 +8,7 @@ import { CreateProposalModal } from "@/components/governance/CreateProposalModal
 import { useWallet } from "@/components/lib/wallet-context";
 import { getProposals } from "@/lib/governance-api";
 import type { Proposal, ProposalStatus } from "@/types/governance";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 const STATUS_TABS: { label: string; value: ProposalStatus | "all" }[] = [
   { label: "All", value: "all" },
@@ -75,93 +76,90 @@ export default function GovernancePage() {
   }
 
   return (
-    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
-      {/* Page Header */}
-      <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border/50 pb-6">
-        <div>
-          <div className="text-[10px] font-mono text-accent uppercase tracking-[0.2em] mb-2">
-            Governance // Proposals
+    <ErrorBoundary>
+      <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border/50 pb-6">
+          <div>
+            <div className="text-[10px] font-mono text-accent uppercase tracking-[0.2em] mb-2">
+              Governance // Proposals
+            </div>
+            <h2 className="text-4xl font-black tracking-tighter uppercase italic flex items-center gap-3">
+              <ScrollText className="w-8 h-8 text-accent" />
+              Governance
+            </h2>
           </div>
-          <h2 className="text-4xl font-black tracking-tighter uppercase italic flex items-center gap-3">
-            <ScrollText className="w-8 h-8 text-accent" />
-            Governance
-          </h2>
+          {isAuthenticated && authToken && (
+            <button
+              onClick={() => setShowCreateModal(true)}
+              className="flex items-center gap-2 px-4 py-2 rounded-xl bg-accent/10 border border-accent/30 text-accent text-xs font-bold uppercase tracking-widest hover:bg-accent/20 transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              Create Proposal
+            </button>
+          )}
         </div>
-        {isAuthenticated && authToken && (
-          <button
-            onClick={() => setShowCreateModal(true)}
-            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-accent/10 border border-accent/30 text-accent text-xs font-bold uppercase tracking-widest hover:bg-accent/20 transition-colors"
-          >
-            <Plus className="w-4 h-4" />
-            Create Proposal
-          </button>
-        )}
-      </div>
 
-      {/* Metric Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricCard
-          label="Active Proposals"
-          value={activeCount}
-          subLabel="Currently voting"
-        />
-        <MetricCard
-          label="Total Votes"
-          value={totalVotes}
-          subLabel="Across all proposals"
-        />
-        <MetricCard
-          label="Passed"
-          value={passedCount}
-          subLabel="Approved proposals"
-        />
-        <MetricCard
-          label="Failed"
-          value={failedCount}
-          subLabel="Rejected proposals"
-        />
-      </div>
-
-      {/* Status Filter Tabs */}
-      <div className="flex items-center gap-2 overflow-x-auto pb-2">
-        {STATUS_TABS.map((tab) => (
-          <button
-            key={tab.value}
-            onClick={() => setActiveTab(tab.value)}
-            className={`px-4 py-2 rounded-xl text-[10px] font-bold uppercase tracking-widest transition-all duration-300 whitespace-nowrap ${
-              activeTab === tab.value
-                ? "bg-accent/10 text-accent border border-accent/30"
-                : "text-muted-foreground hover:text-foreground hover:bg-white/5 border border-transparent"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Proposals Grid */}
-      {proposals.length === 0 ? (
-        <div className="glass-card rounded-2xl p-12 border border-border/50 text-center">
-          <p className="text-xs font-mono text-muted-foreground/50 uppercase tracking-widest">
-            No proposals found
-          </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <MetricCard
+            label="Active Proposals"
+            value={activeCount}
+            subLabel="Currently voting"
+          />
+          <MetricCard
+            label="Total Votes"
+            value={totalVotes}
+            subLabel="Across all proposals"
+          />
+          <MetricCard
+            label="Passed"
+            value={passedCount}
+            subLabel="Approved proposals"
+          />
+          <MetricCard
+            label="Failed"
+            value={failedCount}
+            subLabel="Rejected proposals"
+          />
         </div>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {proposals.map((proposal) => (
-            <ProposalCard key={proposal.id} proposal={proposal} />
+
+        <div className="flex items-center gap-2 overflow-x-auto pb-2">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setActiveTab(tab.value)}
+              className={`px-4 py-2 rounded-xl text-[10px] font-bold uppercase tracking-widest transition-all duration-300 whitespace-nowrap ${
+                activeTab === tab.value
+                  ? "bg-accent/10 text-accent border border-accent/30"
+                  : "text-muted-foreground hover:text-foreground hover:bg-white/5 border border-transparent"
+              }`}
+            >
+              {tab.label}
+            </button>
           ))}
         </div>
-      )}
 
-      {/* Create Proposal Modal */}
-      {showCreateModal && authToken && (
-        <CreateProposalModal
-          authToken={authToken}
-          onClose={() => setShowCreateModal(false)}
-          onCreated={fetchData}
-        />
-      )}
-    </div>
+        {proposals.length === 0 ? (
+          <div className="glass-card rounded-2xl p-12 border border-border/50 text-center">
+            <p className="text-xs font-mono text-muted-foreground/50 uppercase tracking-widest">
+              No proposals found
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {proposals.map((proposal) => (
+              <ProposalCard key={proposal.id} proposal={proposal} />
+            ))}
+          </div>
+        )}
+
+        {showCreateModal && authToken && (
+          <CreateProposalModal
+            authToken={authToken}
+            onClose={() => setShowCreateModal(false)}
+            onCreated={fetchData}
+          />
+        )}
+      </div>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
Closes #815

## What changed
Added `ErrorBoundary` wrapper to the following pages to prevent full app crashes when a component error occurs:

- `frontend/src/app/[locale]/corridors/page.tsx`
- `frontend/src/app/[locale]/anchors/page.tsx`
- `frontend/src/app/[locale]/analytics/page.tsx`
- `frontend/src/app/[locale]/governance/page.tsx`

## How it works
Each page now wraps its content with the existing `ErrorBoundary` component from `@/components/ErrorBoundary`. 
- For pages using `Suspense`, the `ErrorBoundary` wraps the `Suspense` boundary so both loading and error states are handled cleanly.
- The `ErrorBoundary` displays a user-friendly fallback UI with a "Try Again" button and a "Go Home" link instead of crashing the entire app.
- Error details are shown in development mode only for easier debugging.

## Testing
- Verified all 4 pages render normally without errors
- ErrorBoundary fallback UI displays correctly when a child component throws