### PR TITLE
fix(config): log .env loading status with appropriate log levels

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -60,9 +60,9 @@ const DB_POOL_IDLE_LOW_WATERMARK: usize = 2;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     match dotenvy::dotenv() {
-        Ok(path) => tracing::debug!("Loaded environment from {}", path.display()),
+        Ok(path) => tracing::info!("Loaded environment from {}", path.display()),
         Err(dotenvy::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
-            tracing::debug!(".env file not found, using environment variables only");
+            tracing::warn!(".env file not found, using environment variables only");
         }
         Err(e) => tracing::warn!("Failed to load .env file: {}", e),
     }


### PR DESCRIPTION
- Promote successful .env load from debug to info so operators can confirm which file was loaded at normal log verbosity
- Promote the .env-not-found case from debug to warn so the absence of a .env file is visible without enabling debug logging

Previously both the success and not-found paths used tracing::debug!, meaning they were invisible at the default log level. An operator running without a .env file had no indication that environment variables were expected from the process environment instead, making misconfiguration silent and hard to diagnose.

The failure path (unexpected I/O error) already used tracing::warn! and is unchanged. The downstream validate_env() call still fails fast if required variables are missing.

Closes #1077