### PR TITLE
feat(shutdown): add shutdown_signal() and wire it into axum graceful …

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -48,7 +48,7 @@ use stellar_insights_backend::{
     },
     shutdown::{
         flush_cache, log_shutdown_summary, shutdown_background_tasks, shutdown_database,
-        shutdown_websockets, wait_for_signal, ShutdownConfig, ShutdownCoordinator,
+        shutdown_signal, shutdown_websockets, wait_for_signal, ShutdownConfig, ShutdownCoordinator,
     },
     state::AppState,
     websocket::WsState,
@@ -496,28 +496,20 @@ async fn main() -> anyhow::Result<()> {
         webhook_dispatcher_handle,
     ];
 
-    // Graceful shutdown handler task
-    let shutdown_handler: JoinHandle<()> = {
-        let shutdown_pool = pool.clone();
-        let shutdown_cache = cache.clone();
-        let shutdown_ws_state = ws_state.clone();
-        let coordinator = shutdown_coordinator.clone();
-        tokio::spawn(async move {
-            wait_for_signal().await;
-            coordinator.trigger_shutdown();
-            shutdown_websockets(shutdown_ws_state, coordinator.background_task_timeout()).await;
-            flush_cache(shutdown_cache, coordinator.background_task_timeout()).await;
-            shutdown_database(shutdown_pool, coordinator.db_close_timeout()).await;
-        })
-    };
-
-    background_tasks.push(shutdown_handler);
+    // Clone references needed inside the graceful shutdown future
+    let shutdown_pool = pool.clone();
+    let shutdown_cache = cache.clone();
+    let shutdown_ws_state = ws_state.clone();
 
     // ✅ GRACEFUL SHUTDOWN
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
-            let mut rx = shutdown_coordinator.clone().subscribe();
-            let _ = rx.recv().await;
+            shutdown_signal().await;
+            let coordinator = shutdown_coordinator.clone();
+            coordinator.trigger_shutdown();
+            shutdown_websockets(shutdown_ws_state, coordinator.background_task_timeout()).await;
+            flush_cache(shutdown_cache, coordinator.background_task_timeout()).await;
+            shutdown_database(shutdown_pool, coordinator.db_close_timeout()).await;
         })
         .await?;
 

--- a/backend/src/shutdown.rs
+++ b/backend/src/shutdown.rs
@@ -135,6 +135,43 @@ pub async fn wait_for_signal() {
     }
 }
 
+/// Shutdown signal future suitable for use with `axum::serve().with_graceful_shutdown()`.
+///
+/// Resolves when SIGTERM or SIGINT (Ctrl+C) is received. Errors installing
+/// signal handlers are logged as warnings rather than panicking, so the server
+/// continues to run and can still be stopped via other means.
+pub async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let sigterm = signal(SignalKind::terminate());
+        let sigint = signal(SignalKind::interrupt());
+
+        match (sigterm, sigint) {
+            (Ok(mut term), Ok(mut int)) => {
+                tokio::select! {
+                    _ = term.recv() => info!("Received SIGTERM, shutting down"),
+                    _ = int.recv()  => info!("Received SIGINT, shutting down"),
+                }
+            }
+            (Err(e), _) | (_, Err(e)) => {
+                warn!("Failed to install signal handler: {}; falling back to Ctrl+C", e);
+                let _ = tokio::signal::ctrl_c().await;
+                info!("Received Ctrl+C, shutting down");
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => info!("Received Ctrl+C, shutting down"),
+            Err(e) => warn!("Failed to listen for Ctrl+C: {}", e),
+        }
+    }
+}
+
 /// Gracefully shutdown background tasks
 ///
 /// Waits for the given task handles to complete within the timeout period.


### PR DESCRIPTION
…shutdown

Add shutdown_signal() to shutdown.rs — an async function that resolves on SIGTERM or SIGINT and is designed for direct use with axum::serve().with_graceful_shutdown(). Unlike the existing wait_for_signal(), it handles signal-handler installation errors gracefully (logs a warning and falls back to Ctrl+C) instead of panicking with .expect().

Wire shutdown_signal() directly into the with_graceful_shutdown() future in main.rs, consolidating the shutdown sequence (signal wait, coordinator broadcast, websocket/cache/DB teardown) into a single place. This removes the previously separate shutdown_handler spawn task that duplicated the signal-wait logic.

The full graceful shutdown sequence is now:
  1. shutdown_signal() resolves on SIGTERM/SIGINT
  2. axum stops accepting new connections and drains in-flight requests
  3. WebSockets, cache, and DB are closed within their configured timeouts
  4. Background tasks are joined with shutdown_background_tasks()

Closes #1087