### PR TITLE
Fix: Prevent cascading renders on progress update

### DIFF
--- a/frontend/src/app/[locale]/quests/page.tsx
+++ b/frontend/src/app/[locale]/quests/page.tsx
@@ -25,7 +25,9 @@ export default function QuestsPage() {
   useEffect(() => {
     checkPathCompletion(pathname);
     const newProgress = getProgress();
-    setProgress((prev) => (prev !== newProgress ? newProgress : prev));
+    setProgress((prev) => 
+      JSON.stringify(prev) === JSON.stringify(newProgress) ? prev : newProgress
+    );
   }, [pathname]);
 
   const completedCount = getCompletedCount();


### PR DESCRIPTION
Closes #1073

This PR resolves the critical issue where synchronous setState within useEffect triggers cascading renders, improving performance and user experience.