### PR TITLE
fix(backend): batch queries, OTel HTTP, and restore clean build

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,12 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "ascii_utils"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
-
-[[package]]
 name = "async-compression"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,117 +178,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-graphql"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1057a9f7ccf2404d94571dec3451ade1cb524790df6f1ada0d19c2a49f6b0f40"
-dependencies = [
- "async-graphql-derive",
- "async-graphql-parser",
- "async-graphql-value",
- "async-io",
- "async-trait",
- "asynk-strim",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "fast_chemail",
- "fnv",
- "futures-util",
- "handlebars",
- "http 1.4.0",
- "indexmap 2.13.0",
- "mime",
- "multer",
- "num-traits",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "static_assertions_next",
- "tempfile",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "async-graphql-axum"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e37c5532e4b686acf45e7162bc93da91fc2c702fb0d465efc2c20c8f973795"
-dependencies = [
- "async-graphql",
- "axum 0.8.8",
- "bytes",
- "futures-util",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower-service",
-]
-
-[[package]]
-name = "async-graphql-derive"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6cbeadc8515e66450fba0985ce722192e28443697799988265d86304d7cc68"
-dependencies = [
- "Inflector",
- "async-graphql-parser",
- "darling 0.23.0",
- "proc-macro-crate",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
- "strum",
- "syn 2.0.117",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "async-graphql-parser"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64ef70f77a1c689111e52076da1cd18f91834bcb847de0a9171f83624b07fbf"
-dependencies = [
- "async-graphql-value",
- "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
-dependencies = [
- "bytes",
- "indexmap 2.13.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -323,16 +200,6 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.44",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "asynk-strim"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52697735bdaac441a29391a9e97102c74c6ef0f9b60a40cf109b1b404e29d2f6"
-dependencies = [
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -380,50 +247,22 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -434,66 +273,13 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
-dependencies = [
- "axum-core 0.5.6",
- "base64 0.22.1",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sha1",
- "sync_wrapper 1.0.2",
- "tokio",
- "tokio-tungstenite 0.28.0",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -505,32 +291,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -553,12 +320,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -700,9 +461,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "cast"
@@ -1092,18 +850,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1121,36 +869,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
- "quote 1.0.44",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote 1.0.44",
  "syn 2.0.117",
 ]
@@ -1202,37 +926,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.44",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -1369,15 +1062,6 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "fast_chemail"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
-dependencies = [
- "ascii_utils",
 ]
 
 [[package]]
@@ -1521,16 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,23 +1305,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.27"
+name = "glob"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1660,8 +1321,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.13.0",
+ "http",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1677,22 +1338,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "handlebars"
-version = "6.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3f9296c208515b87bd915a2f5d1163d4b3f863ba83337d7713cf478055948e"
-dependencies = [
- "derive_builder",
- "log",
- "num-order",
- "pest",
- "pest_derive",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1798,17 +1443,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1819,23 +1453,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1846,8 +1469,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1865,30 +1488,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1897,9 +1496,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1916,26 +1515,14 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1948,9 +1535,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2109,16 +1696,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2391,12 +1968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,23 +2028,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.4.0",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -2614,21 +2168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-modular"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
-
-[[package]]
-name = "num-order"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
-dependencies = [
- "num-modular",
-]
-
-[[package]]
 name = "num-rational"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,100 +2262,80 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
-dependencies = [
- "async-trait",
  "futures-core",
- "http 0.2.12",
- "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
- "opentelemetry_api",
- "opentelemetry_sdk",
- "prost",
- "thiserror 1.0.69",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
- "prost",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
+ "futures-sink",
  "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror 1.0.69",
- "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b925a602ffb916fb7421276b86756027b37ee708f9dce2dbdcc51739f07e727"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.20.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
- "ordered-float",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.8.5",
- "regex",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "3.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2883,49 +2402,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "pin-project"
@@ -3012,20 +2488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3142,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3152,15 +2614,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2 1.0.106",
  "quote 1.0.44",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3458,6 +2920,40 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3466,11 +2962,11 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3484,7 +2980,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tower 0.5.3",
@@ -4057,7 +3553,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -4243,12 +3739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions_next"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
-
-[[package]]
 name = "stellar-base"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,11 +3770,9 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "argon2",
- "async-graphql",
- "async-graphql-axum",
  "async-lock",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "criterion",
@@ -4304,10 +3792,11 @@ dependencies = [
  "ndarray",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prometheus",
  "rand 0.8.5",
  "redis",
- "reqwest",
+ "reqwest 0.13.2",
  "rust_xlsxwriter",
  "serde",
  "serde_json",
@@ -4324,7 +3813,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-logstash",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -4399,27 +3888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4457,12 +3925,6 @@ dependencies = [
  "quote 1.0.44",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -4657,16 +4119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4734,18 +4186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,7 +4193,6 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4804,7 +4243,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -4818,7 +4257,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -4841,27 +4280,20 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout",
+ "http",
+ "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "tokio",
  "tokio-stream",
- "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4875,13 +4307,9 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
- "slab",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4896,7 +4324,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4914,8 +4342,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "iri-string",
  "pin-project-lite",
@@ -4986,17 +4414,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -5019,18 +4436,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
+checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -5060,7 +4479,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -5079,7 +4498,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5098,7 +4517,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5108,33 +4527,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.2",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -5249,7 +4645,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -5275,7 +4671,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b39868d43c011961e04b41623e050aedf2cc93652562ff7935ce0f819aaf2da"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -5319,7 +4715,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df0bcf92720c40105ac4b2dda2a4ea3aa717d4d6a862cc217da653a4bd5c6b10"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "once_cell",
  "proc-macro-error",
  "proc-macro2 1.0.106",
@@ -5470,7 +4866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5483,7 +4879,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "semver",
 ]
 
@@ -5957,7 +5353,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5988,7 +5384,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -6007,7 +5403,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -6180,7 +5576,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -54,9 +54,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-log = "0.2"
 tracing-appender = "0.2"
 tracing-logstash = "0.2"
-opentelemetry = { version = "0.20", features = ["trace", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.13", features = ["grpc-tonic", "trace"] }
-tracing-opentelemetry = "0.21"
+opentelemetry = { version = "0.24", features = ["trace"] }
+opentelemetry_sdk = { version = "0.24", features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.17", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
+tracing-opentelemetry = "0.25"
 dotenvy = "0.15"
 sha2 = "0.10"
 hex = "0.4"
@@ -74,8 +75,6 @@ jsonwebtoken = "9.2"
 utoipa = { version = "4.2", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "6.0", features = ["axum"] }
 urlencoding = "2.1"
-async-graphql = { version = "7.0", features = ["chrono", "uuid"] }
-async-graphql-axum = "7.0"
 toml = "0.8"
 prometheus = "0.13"
 ipnetwork = "0.20"

--- a/backend/src/api/anchors.rs
+++ b/backend/src/api/anchors.rs
@@ -20,15 +20,11 @@ use crate::database::Database;
 use crate::error::{ApiError, ApiResult};
 use crate::models::{AnchorDetailResponse, CreateAnchorRequest};
 use crate::rpc::circuit_breaker::rpc_circuit_breaker;
-use crate::rpc::circuit_breaker::{rpc_circuit_breaker, CircuitBreaker, CircuitBreakerConfig};
 use crate::rpc::error::{with_retry, RetryConfig, RpcError};
 use crate::rpc::StellarRpcClient;
 use crate::services::price_feed::PriceFeedClient;
 use crate::state::AppState;
 use tracing::warn;
-use crate::rpc::error::{RetryConfig, with_retry, RpcError};
-use tracing::warn;
-use tracing::{error, info, warn};
 
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -291,19 +287,6 @@ pub async fn create_anchor_asset(
     Ok(Json(asset))
 }
 
-use crate::cache::helpers::cached_query;
-use crate::cache::keys;
-use crate::database::Database;
-use crate::rpc::{
-    circuit_breaker::{CircuitBreaker, CircuitBreakerConfig},
-    error::{RpcError},
-    circuit_breaker::{rpc_circuit_breaker, CircuitBreaker},
-    error::{with_retry, RetryConfig, RpcError},
-    StellarRpcClient,
-};
-use crate::services::price_feed::PriceFeedClient;
-use std::time::Duration;
-
 #[derive(Debug, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct ListAnchorsQuery {
@@ -321,71 +304,17 @@ const fn default_limit() -> i64 {
     50
 }
 
-pub(crate) fn rpc_circuit_breaker() -> Arc<CircuitBreaker> {
-    static CIRCUIT_BREAKER: OnceLock<Arc<CircuitBreaker>> = OnceLock::new();
-    CIRCUIT_BREAKER
-        .get_or_init(|| {
-            Arc::new(CircuitBreaker::new(
-                CircuitBreakerConfig {
-                    failure_threshold: 5,
-                    success_threshold: 2,
-                    timeout_duration: Duration::from_secs(30),
-                    half_open_max_calls: 3,
-                },
-                "horizon",
-            ))
-        })
-        .clone()
-}
-
-pub fn rpc_circuit_breaker_instance() -> Arc<CircuitBreaker> {
-    rpc_circuit_breaker()
-}
-
-// Add retry helper
-async fn with_retry<F, Fut, T>(
-    mut operation: F,
-    max_retries: u32,
-    initial_backoff: Duration,
-) -> Result<T, RpcError>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T, RpcError>>,
-{
-    let mut backoff = initial_backoff;
-    let mut last_error = None;
-    
-    for attempt in 0..=max_retries {
-        match operation().await {
-            Ok(result) => return Ok(result),
-            Err(e) => {
-                last_error = Some(e);
-                if attempt < max_retries {
-                    tokio::time::sleep(backoff).await;
-                    backoff *= 2;  // Exponential backoff
-                }
-            }
-        }
-    }
-    
-    Err(last_error.unwrap_or_else(|| RpcError::NetworkError("No attempts made".to_string())))
-}
-// Shared circuit breaker is now managed in crate::rpc::circuit_breaker
-
 pub async fn get_anchor_metrics_with_rpc(
     anchor_id: Uuid,
     rpc_client: Arc<StellarRpcClient>,
 ) -> anyhow::Result<AnchorMetrics> {
     let circuit_breaker = rpc_circuit_breaker();
+    let rpc = Arc::clone(&rpc_client);
 
-    // Wrap call in circuit breaker as requested in Issue #671
-    let result: Result<AnchorMetrics, failsafe::Error<RpcError>> = circuit_breaker
-        .call(|| async {
-    let metrics: AnchorMetrics = with_retry(
-        || async {
-            rpc_client
-                .fetch_anchor_metrics(anchor_id)
-                .map_err(|e| RpcError::categorize(&e.to_string()))
+    let metrics = with_retry(
+        move || {
+            let rpc = Arc::clone(&rpc);
+            async move { rpc.fetch_anchor_metrics(anchor_id) }
         },
         RetryConfig::default(),
         circuit_breaker,
@@ -397,20 +326,6 @@ pub async fn get_anchor_metrics_with_rpc(
         }
         other => anyhow::anyhow!(other.to_string()),
     })?;
-                .await
-                .map_err(|e| RpcError::categorize(&e.to_string()))
-        })
-        .await;
-
-    let metrics = match result {
-        Ok(metrics) => metrics,
-        Err(failsafe::Error::Rejected) => {
-            return Err(anyhow::anyhow!("Circuit breaker open - RPC service unavailable"));
-        }
-        Err(failsafe::Error::Inner(err)) => {
-            return Err(anyhow::anyhow!(err.to_string()));
-        }
-    };
 
     Ok(metrics)
 }

--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -1044,7 +1044,7 @@ impl Database {
     }
 
     /// Updates the metrics for a corridor.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, cache))]
     pub async fn update_corridor_metrics(
         &self,
         id: Uuid,
@@ -1268,14 +1268,13 @@ impl Database {
     pub async fn save_payments(&self, payments: Vec<crate::models::PaymentRecord>) -> Result<()> {
         self.execute_with_timing("save_payments", async {
             let payment_count = payments.len();
-            let mut tx = self.pool.begin().await.with_context(|| {
-                format!("Failed to begin transaction for save_payments ({payment_count} payments)")
-            })?;
             if payments.is_empty() {
                 return Ok(());
             }
 
-            let mut tx = self.pool.begin().await.with_context(|| format!("Failed to begin transaction for save_payments ({} payments)", payments.len()))?;
+            let mut tx = self.pool.begin().await.with_context(|| {
+                format!("Failed to begin transaction for save_payments ({payment_count} payments)")
+            })?;
 
             for payment in &payments {
                 sqlx::query(
@@ -1519,101 +1518,6 @@ impl Database {
             
             let limit = std::cmp::max(0, top_limit) as usize;
             top_muxed_by_activity.truncate(limit);
-
-            let unique_muxed_addresses = sqlx::query_scalar::<_, i64>(
-                r"
-                SELECT COUNT(DISTINCT addr) FROM (
-                    SELECT source_account AS addr FROM payments WHERE source_account LIKE 'M%' AND LENGTH(source_account) = $1
-                    UNION
-                    SELECT destination_account AS addr FROM payments WHERE destination_account LIKE 'M%' AND LENGTH(destination_account) = $1
-                )
-                ",
-            )
-            .bind(MUXED_LEN)
-            .fetch_one(&self.pool)
-            .await?;
-
-
-            let total_muxed_payments = sqlx::query_scalar::<_, i64>(
-                r"
-                SELECT COUNT(*) FROM payments
-                WHERE (source_account LIKE 'M%' AND LENGTH(source_account) = $1)
-                   OR (destination_account LIKE 'M%' AND LENGTH(destination_account) = $1)
-                ",
-            )
-            .bind(MUXED_LEN)
-            .fetch_one(&self.pool)
-            .await
-            .context("Failed to count total muxed payments")?;
-
-            #[derive(sqlx::FromRow)]
-            struct AddrCount {
-                addr: String,
-                cnt: i64,
-            }
-
-            let source_counts: Vec<AddrCount> = sqlx::query_as(
-                r"
-                SELECT source_account AS addr, COUNT(*) AS cnt FROM payments
-                WHERE source_account LIKE 'M%' AND LENGTH(source_account) = $1
-                GROUP BY source_account
-                ORDER BY cnt DESC
-                LIMIT $2
-                ",
-            )
-            .bind(MUXED_LEN)
-            .bind(top_limit)
-            .fetch_all(&self.pool)
-            .await
-            .with_context(|| format!(
-                "Failed to fetch top muxed source accounts (limit={})",
-                top_limit
-            ))?;
-
-            let dest_counts: Vec<AddrCount> = sqlx::query_as(
-                r"
-                SELECT destination_account AS addr, COUNT(*) AS cnt FROM payments
-                WHERE destination_account LIKE 'M%' AND LENGTH(destination_account) = $1
-                GROUP BY destination_account
-                ORDER BY cnt DESC
-                LIMIT $2
-                ",
-            )
-            .bind(MUXED_LEN)
-            .bind(top_limit)
-            .fetch_all(&self.pool)
-            .await
-            .with_context(|| format!(
-                "Failed to fetch top muxed destination accounts (limit={})",
-                top_limit
-            ))?;
-
-            let mut by_addr: std::collections::HashMap<String, (i64, i64)> =
-                std::collections::HashMap::new();
-            for row in source_counts {
-                by_addr.entry(row.addr).or_insert((0, 0)).0 = row.cnt;
-            }
-            for row in dest_counts {
-                by_addr.entry(row.addr).or_insert((0, 0)).1 = row.cnt;
-            }
-
-            let mut top_muxed_by_activity: Vec<MuxedAccountUsage> = by_addr
-                .into_iter()
-                .map(|(account_address, (src, dest))| {
-                    let total = src + dest;
-                    let info = muxed::parse_muxed_address(&account_address);
-                    MuxedAccountUsage {
-                        account_address,
-                        base_account: info.as_ref().and_then(|i| i.base_account.clone()),
-                        muxed_id: info.and_then(|i| i.muxed_id),
-                        payment_count_as_source: src,
-                        payment_count_as_destination: dest,
-                        total_payments: total,
-                    }
-                })
-                .collect();
-            top_muxed_by_activity.sort_by(|a, b| b.total_payments.cmp(&a.total_payments));
-            top_muxed_by_activity.truncate(top_limit as usize);
 
             let unique_muxed_addresses = sqlx::query_scalar::<_, i64>(
                 r"
@@ -1878,6 +1782,7 @@ impl Database {
         .await
     }
 
+    #[tracing::instrument(skip(self), fields(key_id = %id, wallet_address = %wallet_address))]
     pub async fn revoke_api_key(&self, id: &str, wallet_address: &str) -> Result<bool> {
         self.execute_with_timing("revoke_api_key", async {
             let revoked_at = Utc::now().to_rfc3339();
@@ -1905,6 +1810,7 @@ impl Database {
         .await
     }
 
+    #[tracing::instrument(skip(self), fields(key_id = %id, wallet_address = %wallet_address))]
     pub async fn rotate_api_key(
         &self,
         id: &str,
@@ -2051,63 +1957,6 @@ impl Database {
         .await
     }
 
-    /// Revokes an API key for a specific wallet address.
-    #[tracing::instrument(skip(self), fields(key_id = %id, wallet_address = %wallet_address))]
-    pub async fn revoke_api_key(&self, id: &str, wallet_address: &str) -> Result<bool> {
-        self.execute_with_timing("revoke_api_key", async {
-            let result = sqlx::query(
-                r"
-            UPDATE api_keys
-            SET status = 'revoked', revoked_at = $1
-            WHERE id = $2 AND wallet_address = $3 AND status = 'active'
-            ",
-            )
-            .bind(Utc::now().to_rfc3339())
-            .bind(id)
-            .bind(wallet_address)
-            .execute(&self.pool)
-            .await?;
-            Ok(result.rows_affected() > 0)
-        })
-        .await
-    }
-
-    /// Rotates an API key for a given wallet address.
-    #[tracing::instrument(skip(self), fields(key_id = %id, wallet_address = %wallet_address))]
-    pub async fn rotate_api_key(
-        &self,
-        id: &str,
-        wallet_address: &str,
-    ) -> Result<Option<CreateApiKeyResponse>> {
-        let old_key = sqlx::query_as::<_, ApiKey>(
-            "SELECT * FROM api_keys WHERE id = $1 AND wallet_address = $2 AND status = 'active'",
-        )
-        .bind(id)
-        .bind(wallet_address)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        let old_key = match old_key {
-            Some(k) => k,
-            None => return Ok(None),
-        };
-
-        self.revoke_api_key(id, wallet_address).await?;
-
-        let new_key = self
-            .create_api_key(
-                wallet_address,
-                CreateApiKeyRequest {
-                    name: old_key.name,
-                    scopes: Some(old_key.scopes),
-                    expires_at: old_key.expires_at,
-                },
-            )
-            .await?;
-
-        Ok(Some(new_key))
-    }
-
     /// Retrieves the recent performance metrics for a specific anchor.
     #[tracing::instrument(skip(self), fields(anchor_id = %anchor_id, minutes = minutes))]
     pub async fn get_recent_anchor_performance(
@@ -2142,7 +1991,6 @@ impl Database {
             .bind(start_time.to_rfc3339())
             .fetch_one(&self.pool)
             .await
-            .with_context(|| format!("Failed to get recent anchor performance for anchor_id: {}, minutes: {}", anchor_id, minutes))?;
             .with_context(|| {
                 format!(
                     "Failed to get recent anchor performance for anchor_id: {}, minutes: {}",
@@ -2175,5 +2023,44 @@ impl Database {
             })
         })
         .await
+    }
+
+    /// Latest `corridor_metrics` row per `corridor_key` in a single query (avoids N+1 lookups).
+    #[tracing::instrument(skip(self))]
+    pub async fn fetch_latest_corridor_metrics_for_broadcast(
+        &self,
+    ) -> Result<Vec<crate::models::corridor::CorridorMetrics>> {
+        self.execute_with_timing("fetch_latest_corridor_metrics_for_broadcast", async {
+            sqlx::query_as::<_, crate::models::corridor::CorridorMetrics>(
+                r"
+                SELECT cm.*
+                FROM corridor_metrics cm
+                INNER JOIN (
+                    SELECT corridor_key, MAX(date) AS max_date
+                    FROM corridor_metrics
+                    GROUP BY corridor_key
+                ) latest
+                  ON cm.corridor_key = latest.corridor_key
+                 AND cm.date = latest.max_date
+                ORDER BY cm.corridor_key
+                ",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .context("Failed to fetch latest corridor metrics for broadcast")
+        })
+        .await
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::services::data_port::DataPort for Database {
+    async fn fetch_corridor_updates(
+        &self,
+    ) -> Result<Vec<crate::models::corridor::CorridorMetrics>, Box<dyn std::error::Error + Send + Sync>>
+    {
+        self.fetch_latest_corridor_metrics_for_broadcast()
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
     }
 }

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -15,11 +15,10 @@ use crate::cache::CacheManager;
 use crate::database::Database;
 use crate::error::{ApiError, ApiResult};
 use crate::models::corridor::Corridor;
-use crate::models::{CreateAnchorRequest, CreateCorridorRequest, ListCorridorsQuery, ListCorridorsResponse};
+use crate::api::corridors::ListCorridorsQuery;
+use crate::models::{CreateAnchorRequest, CreateCorridorRequest};
 use crate::rpc::StellarRpcClient;
 use crate::state::AppState;
-use crate::websocket::WsState;
-
 /// DTO for corridor transaction data
 #[derive(Debug, Deserialize, Clone)]
 pub struct CorridorTransactionDto {
@@ -49,6 +48,12 @@ pub struct ComponentHealth {
     pub healthy: bool,
     pub response_time_ms: Option<u64>,
     pub message: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ListCorridorsResponse {
+    pub corridors: Vec<Corridor>,
+    pub total: usize,
 }
 
 /// Check database health
@@ -152,10 +157,10 @@ pub async fn update_anchor_metrics(
 ) -> ApiResult<Json<crate::models::Anchor>> {
     // Verify anchor exists
     if app_state.db.get_anchor_by_id(id).await?.is_none() {
-        return Err(ApiError::NotFound(format!(
-            "Anchor with id {} not found",
-            id
-        )));
+        return Err(ApiError::not_found(
+            "ANCHOR_NOT_FOUND",
+            format!("Anchor with id {id} not found"),
+        ));
     }
 
     let anchor = app_state
@@ -183,10 +188,10 @@ pub async fn get_anchor_assets(
 ) -> ApiResult<Json<Vec<crate::models::Asset>>> {
     // Verify anchor exists
     if app_state.db.get_anchor_by_id(id).await?.is_none() {
-        return Err(ApiError::NotFound(format!(
-            "Anchor with id {} not found",
-            id
-        )));
+        return Err(ApiError::not_found(
+            "ANCHOR_NOT_FOUND",
+            format!("Anchor with id {id} not found"),
+        ));
     }
 
     let assets = app_state.db.get_assets_by_anchor(id).await?;
@@ -208,10 +213,10 @@ pub async fn create_anchor_asset(
 ) -> ApiResult<Json<crate::models::Asset>> {
     // Verify anchor exists
     if app_state.db.get_anchor_by_id(id).await?.is_none() {
-        return Err(ApiError::NotFound(format!(
-            "Anchor with id {} not found",
-            id
-        )));
+        return Err(ApiError::not_found(
+            "ANCHOR_NOT_FOUND",
+            format!("Anchor with id {id} not found"),
+        ));
     }
 
     let asset = app_state
@@ -228,7 +233,7 @@ pub async fn get_anchor(
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<crate::models::Anchor>> {
     let anchor = app_state.db.get_anchor_by_id(id).await?
-        .ok_or_else(|| ApiError::NotFound(format!("Anchor {} not found", id)))?;
+        .ok_or_else(|| ApiError::not_found("ANCHOR_NOT_FOUND", format!("Anchor {id} not found")))?;
     Ok(Json(anchor))
 }
 
@@ -238,21 +243,14 @@ pub async fn get_anchor_by_account(
     Path(stellar_account): Path<String>,
 ) -> ApiResult<Json<crate::models::Anchor>> {
     let anchor = app_state.db.get_anchor_by_stellar_account(&stellar_account).await?
-        .ok_or_else(|| ApiError::NotFound(format!("Anchor for account {} not found", stellar_account)))?;
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "ANCHOR_NOT_FOUND",
+                format!("Anchor for account {stellar_account} not found"),
+            )
+        })?;
     Ok(Json(anchor))
 }
-
-/// GET /api/analytics/muxed - Get muxed account analytics
-pub async fn get_muxed_analytics(
-    State(app_state): State<AppState>,
-    Query(params): Query<crate::models::ListCorridorsQuery>,
-) -> ApiResult<Json<crate::models::MuxedAccountAnalytics>> {
-    let limit = params.limit.unwrap_or(10);
-    let analytics = app_state.db.get_muxed_analytics(limit).await?;
-    Ok(Json(analytics))
-}
-
-
 
 /// GET /metrics - Prometheus metrics endpoint (all registered metrics via global registry)
 pub async fn get_prometheus_metrics() -> impl IntoResponse {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,7 +5,6 @@ use axum::{
         HeaderValue, Method,
     },
     middleware,
-    routing::get,
     Router,
 };
 use std::sync::Arc;
@@ -284,26 +283,16 @@ async fn main() -> anyhow::Result<()> {
         MAX_REQUEST_TIMEOUT_SECONDS,
     );
 
-    // TimeoutLayer returns 408 with a structured JSON body on timeout.
-    // WebSocket routes are intentionally excluded (see ws_routes below).
-    let timeout_layer = tower::ServiceBuilder::new()
-        .layer(axum::error_handling::HandleErrorLayer::new(
-            |_: tower::BoxError| async {
-                (
-                    axum::http::StatusCode::REQUEST_TIMEOUT,
-                    axum::Json(serde_json::json!({
-                        "error": "REQUEST_TIMEOUT",
-                        "message": "Request exceeded the maximum allowed time",
-                    })),
-                )
-            },
-        ))
-        .layer(TimeoutLayer::new(Duration::from_secs(request_timeout_seconds)));
+    // Request timeout: 408 on exceeded time. WebSocket routes are excluded (see `ws_routes`).
+    let timeout_layer = TimeoutLayer::with_status_code(
+        axum::http::StatusCode::REQUEST_TIMEOUT,
+        Duration::from_secs(request_timeout_seconds),
+    );
 
     // WebSocket routes are excluded from the timeout layer — WS connections
     // are long-lived and must not be killed by the HTTP request timeout.
     let ws_routes = Router::new()
-        .route("/ws", get(stellar_insights_backend::websocket::ws_handler))
+        .route("/ws", stellar_insights_backend::websocket::ws_route())
         .with_state(Arc::clone(&ws_state))
         .layer(cors.clone());
 

--- a/backend/src/observability/tracing.rs
+++ b/backend/src/observability/tracing.rs
@@ -1,36 +1,44 @@
 use anyhow::Result;
 use axum::{body::Body, extract::Request, middleware::Next, response::Response};
+use opentelemetry::global;
 use opentelemetry::propagation::TextMapPropagator;
-use opentelemetry::sdk::propagation::TraceContextPropagator;
-use opentelemetry::sdk::{trace as sdktrace, Resource};
-use opentelemetry::{global, KeyValue};
+use opentelemetry::trace::TracerProvider;
+use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::resource::Resource;
+use opentelemetry_sdk::runtime;
+use opentelemetry_sdk::trace::Config;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 const MAX_LOG_FILES: usize = 30;
 
-fn init_otel_tracer(service_name: &str) -> Result<sdktrace::Tracer> {
-    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
-        .unwrap_or_else(|_| "http://localhost:4317".to_string());
+fn init_otel_tracer(service_name: &str) -> Result<opentelemetry_sdk::trace::Tracer> {
+    // HTTP/protobuf OTLP on 4318; OTLP 0.17+ avoids pulling `tonic`'s legacy `axum` into this crate graph.
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").unwrap_or_else(|_| {
+        "http://localhost:4318/v1/traces".to_string()
+    });
 
-    let tracer =
-        opentelemetry_otlp::new_pipeline()
-            .tracing()
-            .with_exporter(
-                opentelemetry_otlp::new_exporter()
-                    .tonic()
-                    .with_endpoint(endpoint),
-            )
-            .with_trace_config(sdktrace::config().with_resource(Resource::new(vec![
-                KeyValue::new("service.name", service_name.to_string()),
-            ])))
-            .install_batch(opentelemetry::runtime::Tokio)?;
+    let resource = Resource::new([KeyValue::new(
+        "service.name",
+        service_name.to_string(),
+    )]);
 
-    Ok(tracer)
+    let provider = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .http()
+                .with_endpoint(endpoint),
+        )
+        .with_trace_config(Config::default().with_resource(resource))
+        .install_batch(runtime::Tokio)?;
+
+    global::set_tracer_provider(provider.clone());
+    Ok(provider.tracer("stellar-insights-backend"))
 }
 
 /// Initialize tracing. When `LOG_DIR` is set, logs are also written to a rotating file
@@ -69,115 +77,111 @@ pub fn init_tracing(service_name: &str) -> Result<Option<WorkerGuard>> {
         (None, None)
     };
 
-    // otel_layer must be added directly on registry() (before other layers) so that
-    // the S: LookupSpan bound is satisfied.
+    // OTel layer must be registered on `registry()` first so `LookupSpan` bounds are satisfied.
+    let stdout = std::io::stdout;
+
     if otel_enabled {
-        let otel_layer =
-            tracing_opentelemetry::layer().with_tracer(init_otel_tracer(service_name)?);
+        let otel_tracer = init_otel_tracer(service_name)?;
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(otel_tracer);
         let base = tracing_subscriber::registry()
             .with(otel_layer)
             .with(env_filter);
 
-        if use_json {
-            Some(
-                tracing_subscriber::fmt::layer()
+        match (use_json, file_writer) {
+            (true, Some(w)) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
                     .json()
-                    .with_writer(writer)
+                    .with_writer(stdout)
                     .with_target(true)
                     .with_level(true)
-                    .boxed(),
-            )
-        } else {
-            Some(
-                tracing_subscriber::fmt::layer()
-                    .with_writer(writer)
+                    .boxed();
+                let file_layer = tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_writer(w)
                     .with_target(true)
                     .with_level(true)
-                    .boxed(),
-            )
-            let fmt = tracing_subscriber::fmt::layer()
-                .json()
-                .with_target(true)
-                .with_level(true);
-            match file_writer {
-                Some(w) => {
-                    let file = tracing_subscriber::fmt::layer()
-                        .json()
-                        .with_writer(w)
-                        .with_target(true)
-                        .with_level(true);
-                    base.with(fmt).with(file).init();
-                }
-                None => base.with(fmt).init(),
+                    .boxed();
+                base.with(stdout_layer).with(file_layer).init();
             }
-        } else {
-            let fmt = tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .with_level(true);
-            match file_writer {
-                Some(w) => {
-                    let file = tracing_subscriber::fmt::layer()
-                        .with_writer(w)
-                        .with_target(true)
-                        .with_level(true);
-                    base.with(fmt).with(file).init();
-                }
-                None => base.with(fmt).init(),
+            (true, None) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_writer(stdout)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                base.with(stdout_layer).init();
+            }
+            (false, Some(w)) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(stdout)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                let file_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(w)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                base.with(stdout_layer).with(file_layer).init();
+            }
+            (false, None) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(stdout)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                base.with(stdout_layer).init();
             }
         }
         tracing::info!("OpenTelemetry tracing enabled");
     } else {
-        None
-    };
-
-    // Add optional OpenTelemetry layer
-    let otel_layer = if otel_enabled {
-        let tracer = init_otel_tracer(service_name)?;
-        Some(tracing_opentelemetry::layer().with_tracer(tracer).boxed())
-    } else {
-        None
-    };
-
-    // Initialize the registry with all layers
-    // Option<Layer> implements Layer, so we can chain them directly
-    registry
-        .with(fmt_layer)
-        .with(otel_layer)
-        .with(file_layer)
-        .init();
-
-    if otel_enabled {
-        tracing::info!("OpenTelemetry tracing enabled");
         let base = tracing_subscriber::registry().with(env_filter);
-        if use_json {
-            let fmt = tracing_subscriber::fmt::layer()
-                .json()
-                .with_target(true)
-                .with_level(true);
-            match file_writer {
-                Some(w) => {
-                    let file = tracing_subscriber::fmt::layer()
-                        .json()
-                        .with_writer(w)
-                        .with_target(true)
-                        .with_level(true);
-                    base.with(fmt).with(file).init();
-                }
-                None => base.with(fmt).init(),
+        match (use_json, file_writer) {
+            (true, Some(w)) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_writer(stdout)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                let file_layer = tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_writer(w)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                base.with(stdout_layer).with(file_layer).init();
             }
-        } else {
-            let fmt = tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .with_level(true);
-            match file_writer {
-                Some(w) => {
-                    let file = tracing_subscriber::fmt::layer()
-                        .with_writer(w)
-                        .with_target(true)
-                        .with_level(true);
-                    base.with(fmt).with(file).init();
-                }
-                None => base.with(fmt).init(),
+            (true, None) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_writer(stdout)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                base.with(stdout_layer).init();
+            }
+            (false, Some(w)) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(stdout)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                let file_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(w)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                base.with(stdout_layer).with(file_layer).init();
+            }
+            (false, None) => {
+                let stdout_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(stdout)
+                    .with_target(true)
+                    .with_level(true)
+                    .boxed();
+                base.with(stdout_layer).init();
             }
         }
     }

--- a/backend/src/rpc/client_trait.rs
+++ b/backend/src/rpc/client_trait.rs
@@ -3,12 +3,10 @@
 //! This module provides a trait-based abstraction for the Stellar RPC client,
 //! allowing easy swapping between real and mock implementations for testing.
 
-use std::sync::Arc;
-
 use crate::network::NetworkConfig;
 use crate::rpc::stellar::{
-    HealthResponse, HorizonOperation, HorizonTransaction, LedgerInfo, OrderBook, Payment,
-    RpcLedger, StellarRpcClient, Trade,
+    GetLedgersResult, HealthResponse, HorizonOperation, HorizonTransaction, LedgerInfo, OrderBook,
+    Payment, RpcLedger, StellarRpcClient, Trade,
 };
 
 use super::error::RpcError;
@@ -37,9 +35,10 @@ pub trait StellarRpcClientTrait: Send + Sync {
     /// Fetch multiple ledgers with pagination
     async fn fetch_ledgers(
         &self,
+        start_ledger: Option<u64>,
         limit: u32,
         cursor: Option<&str>,
-    ) -> Result<Vec<RpcLedger>, RpcError>;
+    ) -> Result<GetLedgersResult, RpcError>;
 
     /// Fetch transactions for a specific ledger
     async fn fetch_transactions_for_ledger(
@@ -114,41 +113,42 @@ pub trait StellarRpcClientTrait: Send + Sync {
 #[async_trait::async_trait]
 impl StellarRpcClientTrait for StellarRpcClient {
     fn network_config(&self) -> &NetworkConfig {
-        &self.network_config
+        StellarRpcClient::network_config(self)
     }
 
     async fn check_health(&self) -> Result<HealthResponse, RpcError> {
-        self.check_health().await
+        StellarRpcClient::check_health(self).await
     }
 
     async fn fetch_latest_ledger(&self) -> Result<LedgerInfo, RpcError> {
-        self.fetch_latest_ledger().await
+        StellarRpcClient::fetch_latest_ledger(self).await
     }
 
     async fn fetch_ledger_by_sequence(&self, sequence: u64) -> Result<LedgerInfo, RpcError> {
-        self.fetch_ledger_by_sequence(sequence).await
+        StellarRpcClient::fetch_ledger_by_sequence(self, sequence).await
     }
 
     async fn fetch_ledgers(
         &self,
+        start_ledger: Option<u64>,
         limit: u32,
         cursor: Option<&str>,
-    ) -> Result<Vec<RpcLedger>, RpcError> {
-        self.fetch_ledgers(limit, cursor).await
+    ) -> Result<GetLedgersResult, RpcError> {
+        StellarRpcClient::fetch_ledgers(self, start_ledger, limit, cursor).await
     }
 
     async fn fetch_transactions_for_ledger(
         &self,
         ledger_sequence: u64,
     ) -> Result<Vec<HorizonTransaction>, RpcError> {
-        self.fetch_transactions_for_ledger(ledger_sequence).await
+        StellarRpcClient::fetch_transactions_for_ledger(self, ledger_sequence).await
     }
 
     async fn fetch_payments_for_ledger(
         &self,
         ledger_sequence: u64,
     ) -> Result<Vec<Payment>, RpcError> {
-        self.fetch_payments_for_ledger(ledger_sequence).await
+        StellarRpcClient::fetch_payments_for_ledger(self, ledger_sequence).await
     }
 
     async fn fetch_account_payments(
@@ -156,7 +156,7 @@ impl StellarRpcClientTrait for StellarRpcClient {
         account_id: &str,
         limit: u32,
     ) -> Result<Vec<Payment>, RpcError> {
-        self.fetch_account_payments(account_id, limit).await
+        StellarRpcClient::fetch_account_payments(self, account_id, limit).await
     }
 
     async fn fetch_all_account_payments(
@@ -164,14 +164,16 @@ impl StellarRpcClientTrait for StellarRpcClient {
         account_id: &str,
         limit: Option<u32>,
     ) -> Result<Vec<Payment>, RpcError> {
-        self.fetch_all_account_payments(account_id, limit).await
+        StellarRpcClient::fetch_all_account_payments(self, account_id, limit)
+            .await
+            .map_err(|e| RpcError::ParseError(e.to_string()))
     }
 
     async fn fetch_operations_for_ledger(
         &self,
         ledger_sequence: u64,
     ) -> Result<Vec<HorizonOperation>, RpcError> {
-        self.fetch_operations_for_ledger(ledger_sequence).await
+        StellarRpcClient::fetch_operations_for_ledger(self, ledger_sequence).await
     }
 
     async fn fetch_trades(
@@ -179,7 +181,7 @@ impl StellarRpcClientTrait for StellarRpcClient {
         limit: u32,
         cursor: Option<&str>,
     ) -> Result<Vec<Trade>, RpcError> {
-        self.fetch_trades(limit, cursor).await
+        StellarRpcClient::fetch_trades(self, limit, cursor).await
     }
 
     async fn fetch_order_book(
@@ -188,7 +190,7 @@ impl StellarRpcClientTrait for StellarRpcClient {
         buying_asset: &crate::rpc::stellar::Asset,
         limit: u32,
     ) -> Result<OrderBook, RpcError> {
-        self.fetch_order_book(selling_asset, buying_asset, limit).await
+        StellarRpcClient::fetch_order_book(self, selling_asset, buying_asset, limit).await
     }
 
     async fn fetch_liquidity_pools(
@@ -196,7 +198,7 @@ impl StellarRpcClientTrait for StellarRpcClient {
         limit: u32,
         cursor: Option<&str>,
     ) -> Result<Vec<crate::rpc::stellar::HorizonLiquidityPool>, RpcError> {
-        self.fetch_liquidity_pools(limit, cursor).await
+        StellarRpcClient::fetch_liquidity_pools(self, limit, cursor).await
     }
 
     async fn fetch_pool_trades(
@@ -204,7 +206,7 @@ impl StellarRpcClientTrait for StellarRpcClient {
         pool_id: &str,
         limit: u32,
     ) -> Result<Vec<Trade>, RpcError> {
-        self.fetch_pool_trades(pool_id, limit).await
+        StellarRpcClient::fetch_pool_trades(self, pool_id, limit).await
     }
 
     async fn fetch_assets(
@@ -212,7 +214,7 @@ impl StellarRpcClientTrait for StellarRpcClient {
         limit: u32,
         sponsored: bool,
     ) -> Result<Vec<crate::rpc::stellar::HorizonAsset>, RpcError> {
-        self.fetch_assets(limit, sponsored).await
+        StellarRpcClient::fetch_assets(self, limit, sponsored).await
     }
 }
 
@@ -252,6 +254,8 @@ impl StellarRpcClientTrait for MockStellarRpcClient {
         Ok(HealthResponse {
             status: "healthy".to_string(),
             latest_ledger: 1000,
+            oldest_ledger: 1,
+            ledger_retention_window: 1000,
         })
     }
 
@@ -259,32 +263,58 @@ impl StellarRpcClientTrait for MockStellarRpcClient {
         Ok(LedgerInfo {
             sequence: 1000,
             hash: "mock-ledger-hash".to_string(),
-            created_at: "2024-01-01T00:00:00Z".to_string(),
+            previous_hash: "mock-prev".to_string(),
+            transaction_count: 0,
+            operation_count: 0,
+            closed_at: "2024-01-01T00:00:00Z".to_string(),
+            total_coins: "0".to_string(),
+            fee_pool: "0".to_string(),
+            base_fee: 100,
+            base_reserve: "0".to_string(),
         })
     }
 
     async fn fetch_ledger_by_sequence(&self, sequence: u64) -> Result<LedgerInfo, RpcError> {
         Ok(LedgerInfo {
             sequence,
-            hash: format!("mock-ledger-hash-{}", sequence),
-            created_at: "2024-01-01T00:00:00Z".to_string(),
+            hash: format!("mock-ledger-hash-{sequence}"),
+            previous_hash: "mock-prev".to_string(),
+            transaction_count: 0,
+            operation_count: 0,
+            closed_at: "2024-01-01T00:00:00Z".to_string(),
+            total_coins: "0".to_string(),
+            fee_pool: "0".to_string(),
+            base_fee: 100,
+            base_reserve: "0".to_string(),
         })
     }
 
     async fn fetch_ledgers(
         &self,
+        start_ledger: Option<u64>,
         limit: u32,
         _cursor: Option<&str>,
-    ) -> Result<Vec<RpcLedger>, RpcError> {
-        Ok((0..limit)
-            .map(|i| RpcLedger {
-                hash: format!("mock-ledger-hash-{}", i),
-                sequence: i as u64,
-                ledger_close_time: "2024-01-01T00:00:00Z".to_string(),
-                header_xdr: None,
-                metadata_xdr: None,
+    ) -> Result<GetLedgersResult, RpcError> {
+        let start = start_ledger.unwrap_or(1000);
+        let ledgers: Vec<RpcLedger> = (0..limit)
+            .map(|i| {
+                let seq = start + u64::from(i);
+                RpcLedger {
+                    hash: format!("mock-ledger-hash-{seq}"),
+                    sequence: seq,
+                    ledger_close_time: "2024-01-01T00:00:00Z".to_string(),
+                    header_xdr: None,
+                    metadata_xdr: None,
+                }
             })
-            .collect())
+            .collect();
+        let latest = start.saturating_add(u64::from(limit).saturating_sub(1));
+        Ok(GetLedgersResult {
+            ledgers,
+            latest_ledger: latest,
+            oldest_ledger: start.saturating_sub(100),
+            cursor: None,
+        })
     }
 
     async fn fetch_transactions_for_ledger(

--- a/backend/src/services/contract.rs
+++ b/backend/src/services/contract.rs
@@ -1,17 +1,14 @@
 /*
 Temporarily disabled due to stellar_sdk 0.1 dependency issues.
 */
-use anyhow::Result;
+use anyhow::{Context, Result};
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
-// Stellar XDR imports (using "curr" for the latest protocol version)
-use stellar_xdr::curr::{
-    Memo, MuxedAccount, Preconditions, SequenceNumber, TimeBounds, Transaction,
-    TransactionEnvelope, DecoratedSignature, Signature,
-};
+// Stellar XDR signing types are referenced in the commented signing block below.
 // Stellar SDK transaction signing is handled via the Soroban RPC simulation flow.
 // Full keypair-based signing requires a Soroban-compatible SDK; the current
 // implementation delegates auth to the RPC layer via simulateTransaction.
@@ -89,16 +86,16 @@ pub struct SubmissionResult {
     pub timestamp: u64,
 }
 
-pub struct ContractService;
 impl ContractService {
-    pub fn new(_config: crate::services::contract_listener::ListenerConfig) -> Self { Self }
-    
-    pub async fn submit_snapshot(&self, _hash: [u8; 32], _ledger: u64) -> Result<SubmissionResult> {
-        Err(anyhow::anyhow!("Contract service is temporarily disabled"))
+    #[must_use]
+    pub fn new(config: ContractConfig) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .expect("Failed to build HTTP client");
+        Self { client, config }
     }
 
-    pub async fn submit_snapshot_hash(&self, _hash: [u8; 32], _ledger: u64) -> Result<SubmissionResult> {
-        Err(anyhow::anyhow!("Contract service is temporarily disabled"))
     /// Create from environment variables
     pub fn from_env() -> Result<Self> {
         let config = ContractConfig {
@@ -112,24 +109,9 @@ impl ContractService {
                 .context("STELLAR_SOURCE_SECRET_KEY environment variable not set")?,
         };
 
-        Self::new(config)
+        Ok(Self::new(config))
     }
 
-    /// Submit a snapshot hash to the on-chain contract
-    ///
-    /// This function will:
-    /// 1. Build and simulate the transaction
-    /// 2. Sign the transaction
-    /// 3. Submit to the network
-    /// 4. Wait for confirmation
-    /// 5. Retry on transient failures
-    ///
-    /// # Arguments
-    /// * `hash` - 32-byte snapshot hash
-    /// * `epoch` - Epoch identifier
-    ///
-    /// # Returns
-    /// Result containing submission details or error
     pub async fn submit_snapshot(&self, hash: [u8; 32], epoch: u64) -> Result<SubmissionResult> {
         self.submit_snapshot_hash(hash, epoch).await
     }
@@ -344,7 +326,6 @@ impl ContractService {
 
         Ok(signed_xdr)
         */
-            .ok_or_else(|| anyhow::anyhow!("Simulation did not return transactionData field"))?;
 
         // Validate the XDR is non-empty base64 before forwarding.
         if transaction_xdr.is_empty() {
@@ -356,6 +337,124 @@ impl ContractService {
             transaction_xdr.len()
         );
         Ok(transaction_xdr.to_string())
+    }
+
+    async fn send_transaction(&self, signed_xdr: &str) -> Result<String> {
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            method: "sendTransaction".to_string(),
+            params: json!({ "transaction": signed_xdr }),
+        };
+
+        let response = self
+            .client
+            .post(&self.config.rpc_url)
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send sendTransaction RPC request")?;
+
+        let body: JsonRpcResponse<serde_json::Value> = response
+            .json()
+            .await
+            .context("Failed to parse sendTransaction RPC response")?;
+
+        if let Some(error) = body.error {
+            return Err(anyhow::anyhow!(
+                "sendTransaction failed: {} (code: {})",
+                error.message,
+                error.code
+            ));
+        }
+
+        let result = body
+            .result
+            .ok_or_else(|| anyhow::anyhow!("sendTransaction returned empty result"))?;
+
+        result
+            .get("hash")
+            .or_else(|| result.get("transactionHash"))
+            .and_then(|h| h.as_str())
+            .map(std::string::ToString::to_string)
+            .context("sendTransaction result missing transaction hash")
+    }
+
+    async fn wait_for_transaction(
+        &self,
+        tx_hash: &str,
+        epoch: u64,
+    ) -> Result<SubmissionResult> {
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            method: "getTransaction".to_string(),
+            params: json!({ "hash": tx_hash }),
+        };
+
+        for _ in 0..60 {
+            let response = self
+                .client
+                .post(&self.config.rpc_url)
+                .json(&request)
+                .send()
+                .await
+                .context("Failed to send getTransaction RPC request")?;
+
+            let body: JsonRpcResponse<serde_json::Value> = response
+                .json()
+                .await
+                .context("Failed to parse getTransaction RPC response")?;
+
+            if let Some(error) = &body.error {
+                let transient = error
+                    .message
+                    .to_ascii_lowercase()
+                    .contains("not found");
+                if !transient {
+                    return Err(anyhow::anyhow!(
+                        "getTransaction failed: {} (code: {})",
+                        error.message,
+                        error.code
+                    ));
+                }
+            } else if let Some(result) = body.result {
+                let status = result
+                    .get("status")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("");
+                if status.eq_ignore_ascii_case("success")
+                    || status.eq_ignore_ascii_case("failed")
+                {
+                    let ledger = result
+                        .get("ledger")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0);
+                    let timestamp = result
+                        .get("createdAt")
+                        .and_then(|s| s.as_str())
+                        .and_then(|s| {
+                            chrono::DateTime::parse_from_rfc3339(s)
+                                .ok()
+                                .map(|d| d.timestamp() as u64)
+                        })
+                        .unwrap_or(0);
+
+                    return Ok(SubmissionResult {
+                        hash: tx_hash.to_string(),
+                        transaction_hash: tx_hash.to_string(),
+                        ledger,
+                        timestamp,
+                    });
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        Err(anyhow::anyhow!(
+            "Timed out waiting for transaction {tx_hash} (epoch {epoch})"
+        ))
     }
 
     pub async fn health_check(&self) -> Result<bool> {

--- a/backend/src/services/contract_listener.rs
+++ b/backend/src/services/contract_listener.rs
@@ -1,8 +1,14 @@
-/*
-Temporarily disabled due to compilation issues.
-*/
-use anyhow::Result;
+use anyhow::{Context, Result};
+use chrono::Utc;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sqlx::Row;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::interval;
+use tracing::{debug, error, info, warn};
+
 use crate::database::Database;
 use crate::services::alert_service::AlertService;
 
@@ -15,16 +21,6 @@ pub struct ListenerConfig {
     pub start_ledger: Option<u64>,
 }
 
-pub struct ContractEventListener;
-impl ContractEventListener {
-    pub fn new(_config: ListenerConfig, _db: Arc<Database>, _alert_service: Arc<AlertService>) -> Result<Self> {
-        Ok(Self)
-    }
-    pub fn from_env(_db: Arc<Database>, _alert_service: Arc<AlertService>) -> Result<Self> {
-        Ok(Self)
-    }
-    pub async fn start_listening(&mut self) -> Result<()> {
-        Err(anyhow::anyhow!("Contract listener is temporarily disabled"))
 /// Represents a contract event from the Soroban RPC
 #[derive(Debug, Clone, Deserialize)]
 pub struct ContractEvent {

--- a/backend/src/services/price_feed.rs
+++ b/backend/src/services/price_feed.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use async_lock::RwLock;
 use reqwest::Client;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
@@ -299,7 +299,13 @@ impl PriceFeedClient {
             return result;
         }
 
-        let provider_ids: Vec<String> = mapped.iter().map(|(_, id)| id.clone()).collect();
+        // Deduplicate provider IDs so one HTTP batch does not repeat the same CoinGecko id.
+        let mut seen_ids = HashSet::new();
+        let provider_ids: Vec<String> = mapped
+            .iter()
+            .map(|(_, id)| id.clone())
+            .filter(|id| seen_ids.insert(id.clone()))
+            .collect();
 
         // Fetch from provider
         match self.provider.fetch_prices(&provider_ids).await {

--- a/backend/src/services/realtime_broadcaster.rs
+++ b/backend/src/services/realtime_broadcaster.rs
@@ -13,14 +13,14 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 /// Real-time broadcaster service for WebSocket updates.
-/// Depends on traits (BroadcasterPort, DataPort) — not concrete types.
+/// Depends on traits (`BroadcasterPort`, `DataPort`) — not concrete types.
 pub struct RealtimeBroadcaster {
     ws_state:       Arc<WsState>,
     data:           Arc<dyn DataPort>,
     subscriptions:  Arc<DashMap<Uuid, HashSet<String>>>,
     webhook_events: Arc<WebhookEventService>,
     shutdown_rx:    Option<tokio::sync::oneshot::Receiver<()>>,
-    shutdown_tx:    std::sync::Mutex<Option<tokio::sync::oneshot::Sder<()>>>,
+    shutdown_tx:    std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,8 +35,19 @@ pub enum SubscriptionMessage {
 pub enum BroadcastMessage {
     CorridorUpdate { corridor: CorridorMetrics, channel: String },
     AnchorStatusChange { anchor: AnchorMetrics, old_status: String, channel: String },
-    NewPayment { corridor_key: String, amount: f64, successful: bool, timestamp: String, channel: String },
-    HealthAlert { corridor_id: String, severity: String, message: String, timestamp: String },
+    NewPayment {
+        corridor_key: String,
+        amount:       f64,
+        successful:   bool,
+        timestamp:    String,
+        channel:      String,
+    },
+    HealthAlert {
+        corridor_id: String,
+        severity:    String,
+        message:     String,
+        timestamp:   String,
+    },
     ConnectionStatus { status: String },
 }
 
@@ -46,7 +57,8 @@ impl RealtimeBroadcaster {
     #[must_use]
     pub fn new(
         ws_state: Arc<WsState>,
-        data: Arc<dyn DataPort>        webhook_events: Arc<WebhookEventService>,
+        data: Arc<dyn DataPort>,
+        webhook_events: Arc<WebhookEventService>,
     ) -> Self {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         Self {
@@ -68,21 +80,27 @@ impl RealtimeBroadcaster {
             .take()
             .expect("Shutdown receiver already taken");
 
-        let corridor_task  = self.start_corridor_broadcast_task();
+        let corridor_task = self.start_corridor_broadcast_task();
         let subscription_task = self.start_subscription_management_task();
 
         tokio::select! {
-            _ = shutdown_rx => { info!("RealtimeBroadcaster received shutdown signal"); }
-            _ = corridor_task => { warn!("Corridor broadcast task completed unexpectedly"); }
-            _ = subscription_task => { warn!("Subscription management task completed unexpectedly"); }
+            _ = shutdown_rx => {
+                info!("RealtimeBroadcaster received shutdown signal");
+            }
+            _ = corridor_task => {
+                warn!("Corridor broadcast task completed unexpectedly");
+            }
+            _ = subscription_task => {
+                warn!("Subscription management task completed unexpectedly");
+            }
         }
 
         info!("RealtimeBroadcaster service stopped");
     }
 
     fn start_corridor_broadcast_task(&self) -> tokio::task::JoinHandle<()> {
-        let ws_state      = Arc::clone(&self.ws_state);
-        let data          = Arc::clone(&self.data);
+        let ws_state = Arc::clone(&self.ws_state);
+        let data = Arc::clone(&self.data);
         let subscriptions = Arc::clone(&self.subscriptions);
 
         tokio::spawn(async move {
@@ -97,17 +115,25 @@ impl RealtimeBroadcaster {
                                 corridor: corridor.clone(),
                                 channel: channel.clone(),
                             };
-                            Self::broadcast_to_subscribers(&ws_state, &subscriptions, &channel, message).await;
+                            Self::broadcast_to_subscribers(
+                                &ws_state,
+                                &subscriptions,
+                                &channel,
+                                message,
+                            )
+                            .await;
                         }
                     }
-                    Err(e) => { error!("Failed to fetch corridor updates: {}", e); }
+                    Err(e) => {
+                        error!("Failed to fetch corridor updates: {}", e);
+                    }
                 }
             }
         })
     }
 
     fn start_subscription_management_task(&self) -> tokio::task::JoinHandle<()> {
-        let ws_state      = Arc::clone(&self.ws_state);
+        let ws_state = Arc::clone(&self.ws_state);
         let subscriptions = Arc::clone(&self.subscriptions);
 
         tokio::spawn(async move {
@@ -121,10 +147,10 @@ impl RealtimeBroadcaster {
     }
 
     async fn broadcast_to_subscribers(
-        ws_state:      &Arc<WsState>,
+        ws_state: &Arc<WsState>,
         subscriptions: &Arc<DashMap<Uuid, HashSet<String>>>,
-        channel:       &str,
-        message:       BroadcastMessage,
+        channel: &str,
+        message: BroadcastMessage,
     ) {
         let ws_message = WsMessage::from_broadcast_message(message);
         let targets: Vec<Uuid> = subscriptions
@@ -179,7 +205,10 @@ impl RealtimeBroadcaster {
 impl BroadcasterPort for RealtimeBroadcaster {
     async fn broadcast_corridor_update(&self, corridor: CorridorMetrics) {
         let channel = format!("corridor:{}", corridor.corridor_key);
-        let message = BroadcastMessage::CorridorUpdate { corridor, channel: channel.clone() };
+        let message = BroadcastMessage::CorridorUpdate {
+            corridor,
+            channel: channel.clone(),
+        };
         Self::broadcast_to_subscribers(&self.ws_state, &self.subscriptions, &channel, message).await;
     }
 
@@ -198,13 +227,20 @@ impl BroadcasterPort for RealtimeBroadcaster {
         };
         Self::broadcast_to_subscribers(&self.ws_state, &self.subscriptions, &channel, message).await;
 
-        let webhook_events  = Arc::clone(&self.webhook_events);
-        let new_status      = anchor.status.as_str().to_string();
-        let reliability     = anchor.reliability_score;
-        let failed_txn      = anchor.failed_transactions;
+        let webhook_events = Arc::clone(&self.webhook_events);
+        let new_status = anchor.status.as_str().to_string();
+        let reliability = anchor.reliability_score;
+        let failed_txn = anchor.failed_transactions;
         tokio::spawn(async move {
             if let Err(e) = webhook_events
-                .trigger_anchor_status_changed(&anchor_id, &anchor_name, &old_status, &new_status, reliability, failed_txn)
+                .trigger_anchor_status_changed(
+                    &anchor_id,
+                    &anchor_name,
+                    &old_status,
+                    &new_status,
+                    reliability,
+                    failed_txn,
+                )
                 .await
             {
                 warn!("Failed to trigger anchor_status_changed webhook: {}", e);
@@ -212,10 +248,16 @@ impl BroadcasterPort for RealtimeBroadcaster {
         });
     }
 
-    async fn broadcast_payment(&self, corridor_key: String, amount: f64, successful: bool, timestamp: String) {
+    async fn broadcast_payment(
+        &self,
+        corridor_key: String,
+        amount: f64,
+        successful: bool,
+        timestamp: String,
+    ) {
         let channel = format!("corridor:{corridor_key}");
         let message = BroadcastMessage::NewPayment {
-            corridor_key,
+            corridor_key: corridor_key.clone(),
             amount,
             successful,
             timestamp,
@@ -224,33 +266,43 @@ impl BroadcasterPort for RealtimeBroadcaster {
         Self::broadcast_to_subscribers(&self.ws_state, &self.subscriptions, &channel, message).await;
     }
 
-    async fn broadcast_health_alert(&self, corridor_id: String, severity: String, message: String) {
-    /// Broadcast health alert to all clients
-    pub fn broadcast_health_alert(
+    async fn broadcast_health_alert(
         &self,
         corridor_id: String,
         severity: String,
         message: String,
     ) {
+        let channel = format!("corridor:{corridor_id}");
         let alert = BroadcastMessage::HealthAlert {
             corridor_id: corridor_id.clone(),
             severity: severity.clone(),
             message: message.clone(),
             timestamp: chrono::Utc::now().to_rfc3339(),
         };
-        self.ws_state.broadcast(WsMessage::from_broadcast_message(alert));
+        Self::broadcast_to_subscribers(&self.ws_state, &self.subscriptions, &channel, alert).await;
 
         let webhook_events = Arc::clone(&self.webhook_events);
         tokio::spawn(async move {
             use crate::webhooks::events::CorridorMetrics as EventMetrics;
             let empty = EventMetrics {
-                success_rate: 0.0, avg_latency_ms: 0.0, p95_latency_ms: 0.0,
-                p99_latency_ms: 0.0, liquidity_depth_usd: 0.0,
-                liquidity_volume_24h_usd: 0.0, total_attempts: 0,
-                successful_payments: 0, failed_payments: 0,
+                success_rate:               0.0,
+                avg_latency_ms:             0.0,
+                p95_latency_ms:             0.0,
+                p99_latency_ms:             0.0,
+                liquidity_depth_usd:        0.0,
+                liquidity_volume_24h_usd:   0.0,
+                total_attempts:             0,
+                successful_payments:        0,
+                failed_payments:            0,
             };
             if let Err(e) = webhook_events
-                .trigger_corridor_health_degraded(&corridor_id, &empty, &empty, &severity, vec![message])
+                .trigger_corridor_health_degraded(
+                    &corridor_id,
+                    &empty,
+                    &empty,
+                    &severity,
+                    vec![message],
+                )
                 .await
             {
                 warn!("Failed to trigger corridor_health_degraded webhook: {}", e);
@@ -259,74 +311,14 @@ impl BroadcasterPort for RealtimeBroadcaster {
     }
 
     fn connection_count(&self) -> usize {
-    /// Subscribe a connection to specific channels
-    pub fn subscribe_connection(&self, connection_id: Uuid, channels: Vec<String>) {
-        let mut subscription_set = self.subscriptions.entry(connection_id).or_default();
-
-        for channel in channels {
-            subscription_set.insert(channel.clone());
-            info!(
-                "Connection {} subscribed to channel: {}",
-                connection_id, channel
-            );
-        }
-    }
-
-    /// Unsubscribe a connection from specific channels
-    pub fn unsubscribe_connection(&self, connection_id: Uuid, channels: Vec<String>) {
-        if let Some(mut subscription_set) = self.subscriptions.get_mut(&connection_id) {
-            for channel in channels {
-                subscription_set.remove(&channel);
-                info!(
-                    "Connection {} unsubscribed from channel: {}",
-                    connection_id, channel
-                );
-            }
-        }
-    }
-
-    /// Broadcast message to subscribers of a specific channel
-    async fn broadcast_to_subscribers(
-        ws_state: &Arc<WsState>,
-        subscriptions: &Arc<DashMap<Uuid, HashSet<String>>>,
-        channel: &str,
-        message: BroadcastMessage,
-    ) {
-        let ws_message = WsMessage::from_broadcast_message(message);
-
-        let target_connections: Vec<Uuid> = subscriptions
-            .iter()
-            .filter(|e| e.value().contains(channel))
-            .map(|e| *e.key())
-            .collect();
-
-        for connection_id in target_connections {
-            if let Some(sender) = ws_state.connections.get(&connection_id) {
-                if let Err(e) = sender.send(ws_message.clone()).await {
-                    warn!("Failed to send message to connection {}: {}", connection_id, e);
-                }
-            }
-        }
-    }
-
-    /// Shutdown the broadcaster
-    pub fn shutdown(&self) {
-        if let Ok(mut tx_guard) = self.shutdown_tx.lock() {
-            if let Some(tx) = tx_guard.take() {
-                if tx.send(()).is_err() {
-                    warn!("Failed to send shutdown signal - receiver may have been dropped");
-                }
-            }
-        }
-    }
-
-    /// Get connection count
-    pub fn connection_count(&self) -> usize {
         self.ws_state.connection_count()
     }
 
     fn channel_subscription_count(&self, channel: &str) -> usize {
-        self.subscriptions.iter().filter(|e| e.value().contains(channel)).count()
+        self.subscriptions
+            .iter()
+            .filter(|e| e.value().contains(channel))
+            .count()
     }
 }
 
@@ -336,14 +328,14 @@ impl WsMessage {
     pub fn from_broadcast_message(msg: BroadcastMessage) -> Self {
         match msg {
             BroadcastMessage::CorridorUpdate { corridor, .. } => Self::CorridorUpdate {
-                corridor_key:          corridor.corridor_key,
-                source_asset_code:     corridor.source_asset_code,
-                source_asset_issuer:   corridor.source_asset_issuer,
+                corridor_key:           corridor.corridor_key,
+                source_asset_code:      corridor.source_asset_code,
+                source_asset_issuer:    corridor.source_asset_issuer,
                 destination_asset_code: corridor.destination_asset_code,
                 destination_asset_issuer: corridor.destination_asset_issuer,
-                success_rate:  Some(corridor.success_rate),
-                health_score:  Some(corridor.success_rate * 100.0),
-                last_updated:  Some(corridor.updated_at.to_rfc3339()),
+                success_rate:           Some(corridor.success_rate),
+                health_score:           Some(corridor.success_rate * 100.0),
+                last_updated:           Some(corridor.updated_at.to_rfc3339()),
             },
             BroadcastMessage::AnchorStatusChange { anchor, .. } => Self::AnchorUpdate {
                 anchor_id:         "unknown".to_string(),
@@ -353,12 +345,29 @@ impl WsMessage {
                     .as_str()
                     .to_string(),
             },
-            BroadcastMessage::NewPayment { corridor_key, amount, successful, timestamp, .. } => {
-                Self::NewPayment { corridor_id: corridor_key, amount, successful, timestamp }
-            }
-            BroadcastMessage::HealthAlert { corridor_id, severity, message, timestamp } => {
-                Self::HealthAlert { corridor_id, severity, message, timestamp }
-            }
+            BroadcastMessage::NewPayment {
+                corridor_key,
+                amount,
+                successful,
+                timestamp,
+                ..
+            } => Self::NewPayment {
+                corridor_id: corridor_key,
+                amount,
+                successful,
+                timestamp,
+            },
+            BroadcastMessage::HealthAlert {
+                corridor_id,
+                severity,
+                message,
+                timestamp,
+            } => Self::HealthAlert {
+                corridor_id,
+                severity,
+                message,
+                timestamp,
+            },
             BroadcastMessage::ConnectionStatus { status } => Self::ConnectionStatus { status },
         }
     }
@@ -386,13 +395,5 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains("connection_status"));
         assert!(json.contains("connected"));
-    fn test_subscription_management() {
-        let _ws_state = Arc::new(WsState::new());
-        let _rpc_client = Arc::new(StellarRpcClient::new(
-            "test".to_string(),
-            "test".to_string(),
-            true,
-        ));
-        // Note: This test would need a mock CacheManager before testing subscription logic.
     }
 }

--- a/backend/src/services/verification_rewards.rs
+++ b/backend/src/services/verification_rewards.rs
@@ -195,16 +195,34 @@ impl VerificationRewardsService {
 
     /// Get leaderboard of top verifiers
     pub async fn get_leaderboard(&self, limit: i32) -> Result<Vec<LeaderboardEntry>> {
+        // Single query with `ROW_NUMBER()` so rank respects ties and matches DB ordering
+        // (no per-row round-trips).
         let rows = sqlx::query(
             r"
             SELECT
+                rank,
                 username,
                 total_points,
                 successful_verifications,
-                CAST(successful_verifications AS REAL) /
-                    NULLIF(successful_verifications + failed_verifications, 0) * 100 AS success_rate
-            FROM verification_leaderboard
-            LIMIT ?
+                success_rate
+            FROM (
+                SELECT
+                    ROW_NUMBER() OVER (
+                        ORDER BY ur.total_points DESC,
+                                 ur.successful_verifications DESC,
+                                 u.username ASC
+                    ) AS rank,
+                    u.username AS username,
+                    ur.total_points AS total_points,
+                    ur.successful_verifications AS successful_verifications,
+                    CAST(ur.successful_verifications AS REAL) /
+                        NULLIF(ur.successful_verifications + ur.failed_verifications, 0) * 100
+                        AS success_rate
+                FROM users u
+                INNER JOIN user_rewards ur ON u.id = ur.user_id
+            ) ranked
+            WHERE rank <= ?
+            ORDER BY rank
             ",
         )
         .bind(limit)
@@ -214,10 +232,9 @@ impl VerificationRewardsService {
 
         let leaderboard = rows
             .iter()
-            .enumerate()
-            .map(|(rank, row)| -> Result<LeaderboardEntry> {
+            .map(|row| -> Result<LeaderboardEntry> {
                 Ok(LeaderboardEntry {
-                    rank: (rank + 1) as i32,
+                    rank: row.try_get::<i64, _>("rank")? as i32,
                     username: row.try_get::<String, _>("username")?,
                     total_points: row.try_get::<i32, _>("total_points")?,
                     successful_verifications: row.try_get::<i32, _>("successful_verifications")?,
@@ -258,19 +275,21 @@ impl VerificationRewardsService {
         .await
         .context("Failed to fetch user verifications")?;
 
-        let mut verifications = Vec::new();
-        for row in rows {
-            verifications.push(VerificationRecord {
-                id: row.try_get::<String, _>("id")?,
-                snapshot_id: row.try_get::<String, _>("snapshot_id")?,
-                epoch: row.try_get::<i64, _>("epoch")?,
-                submitted_hash: row.try_get::<String, _>("submitted_hash")?,
-                expected_hash: row.try_get::<String, _>("expected_hash")?,
-                is_match: row.try_get::<bool, _>("is_match")?,
-                reward_points: row.try_get::<i32, _>("reward_points")?,
-                verified_at: row.try_get::<String, _>("verified_at")?,
-            });
-        }
+        let verifications = rows
+            .into_iter()
+            .map(|row| {
+                Ok(VerificationRecord {
+                    id: row.try_get::<String, _>("id")?,
+                    snapshot_id: row.try_get::<String, _>("snapshot_id")?,
+                    epoch: row.try_get::<i64, _>("epoch")?,
+                    submitted_hash: row.try_get::<String, _>("submitted_hash")?,
+                    expected_hash: row.try_get::<String, _>("expected_hash")?,
+                    is_match: row.try_get::<bool, _>("is_match")?,
+                    reward_points: row.try_get::<i32, _>("reward_points")?,
+                    verified_at: row.try_get::<String, _>("verified_at")?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(verifications)
     }

--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -4,6 +4,7 @@ use axum::{
         Query, State,
     },
     response::{IntoResponse, Response},
+    routing::MethodRouter,
     Json,
 };
 use dashmap::DashMap;
@@ -335,13 +336,19 @@ pub struct WsQueryParams {
     pub token: Option<String>,
 }
 
+/// `MethodRouter` for `GET /ws` (built in the library crate so Axum types stay consistent).
+#[must_use]
+pub fn ws_route() -> MethodRouter<Arc<WsState>> {
+    axum::routing::get(ws_handler)
+}
+
 // ── Handlers ──────────────────────────────────────────────────────────────────
 
 /// WebSocket upgrade handler.
 ///
 /// Rejects with `503 Service Unavailable` when the server has reached
 /// `MAX_CONCURRENT_CONNECTIONS`, and with `401 Unauthorized` for invalid tokens.
-pub fn ws_handler(
+pub async fn ws_handler(
     ws: WebSocketUpgrade,
     Query(params): Query<WsQueryParams>,
     State(state): State<Arc<WsState>>,


### PR DESCRIPTION
- verification_rewards: leaderboard via SQL window ranking; cleaner user query mapping
- price_feed: dedupe provider IDs before batch fetch
- realtime_broadcaster: coherent module and broadcast path
- database: latest corridor metrics join; remove duplicate muxed/API-key blocks; save_payments tx fix
- anchors: get_anchor_metrics_with_rpc uses shared with_retry + circuit breaker; remove duplicate imports
- contract + contract_listener: repair stubs/imports and Soroban send/getTransaction helpers
- client_trait: UFCS delegations, fetch_ledgers signature, mock models aligned with stellar types
- tracing: single subscriber init; OTLP over HTTP (no grpc-tonic axum split); SDK tracer for layer
- main: request timeout via TimeoutLayer::with_status_code; ws route from library
- websocket: async ws_handler for Axum 0.7; ws_route helper
- handlers: fix imports and ApiError::not_found; list corridors DTO
- Cargo: drop unused async-graphql; align opentelemetry/tracing-opentelemetry

closes #1112