### PR TITLE
fix(P1): premium env override, alert HTTP webhook, anchor metrics fal…

### DIFF
--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -2142,7 +2142,6 @@ impl Database {
             .bind(start_time.to_rfc3339())
             .fetch_one(&self.pool)
             .await
-            .with_context(|| format!("Failed to get recent anchor performance for anchor_id: {}, minutes: {}", anchor_id, minutes))?;
             .with_context(|| {
                 format!(
                     "Failed to get recent anchor performance for anchor_id: {}, minutes: {}",

--- a/backend/src/rate_limit.rs
+++ b/backend/src/rate_limit.rs
@@ -88,6 +88,13 @@ pub enum ClientTier {
     Premium,
 }
 
+/// Comma-separated user/API-key IDs in `STELLAR_INSIGHTS_PREMIUM_CLIENT_IDS` map to premium tier.
+fn client_id_has_premium_env_override(client_id: &str) -> bool {
+    std::env::var("STELLAR_INSIGHTS_PREMIUM_CLIENT_IDS").ok().is_some_and(|raw| {
+        raw.split(',').any(|part| part.trim() == client_id)
+    })
+}
+
 /// Rate limiter state
 pub struct RateLimiter {
     redis_connection: Arc<RwLock<Option<MultiplexedConnection>>>,
@@ -199,6 +206,9 @@ impl RateLimiter {
     async fn get_client_tier(&self, client: &ClientIdentifier) -> ClientTier {
         match client {
             ClientIdentifier::ApiKey(id) => {
+                if client_id_has_premium_env_override(id) {
+                    return ClientTier::Premium;
+                }
                 // For API keys, we check if the associated user/wallet has a premium subscription
                 // If we have a DB pool, query the user_subscriptions table
                 if let Some(pool) = &self.db_pool {
@@ -218,6 +228,9 @@ impl RateLimiter {
                 }
             }
             ClientIdentifier::User(user_id) => {
+                if client_id_has_premium_env_override(user_id) {
+                    return ClientTier::Premium;
+                }
                 if let Some(pool) = &self.db_pool {
                     match self.get_subscription_tier_by_client_id(pool, user_id).await {
                         Ok(tier) => tier,

--- a/backend/src/services/alert_service.rs
+++ b/backend/src/services/alert_service.rs
@@ -109,6 +109,13 @@ impl AlertService {
                 .await;
         }
 
+        if let Ok(url) = std::env::var("DEFAULT_ALERT_HTTP_WEBHOOK") {
+            let payload = serde_json::json!({
+                "text": format!("*ALERT [{:?}]*\n{}\n`{:?}`", alert.severity, alert.message, alert.alert_type)
+            });
+            let _ = self.slack_client.post(&url).json(&payload).send().await;
+        }
+
         Ok(())
     }
 

--- a/backend/src/services/anchor_monitor.rs
+++ b/backend/src/services/anchor_monitor.rs
@@ -11,7 +11,7 @@ pub struct AnchorMonitor {
     last_metrics: Arc<tokio::sync::RwLock<HashMap<String, AnchorMetrics>>>,
 }
 
-use crate::models::AnchorMetrics;
+use crate::models::{AnchorMetrics, AnchorStatus};
 
 impl AnchorMonitor {
     #[must_use]
@@ -47,8 +47,21 @@ impl AnchorMonitor {
             {
                 Ok(m) => m,
                 Err(e) => {
-                    tracing::error!("Failed to get performance for anchor {}: {}", anchor.id, e);
-                    continue;
+                    tracing::warn!(
+                        "Failed to get performance for anchor {} (using neutral metrics): {}",
+                        anchor.id,
+                        e
+                    );
+                    AnchorMetrics {
+                        success_rate: 100.0,
+                        failure_rate: 0.0,
+                        reliability_score: 100.0,
+                        total_transactions: 0,
+                        successful_transactions: 0,
+                        failed_transactions: 0,
+                        avg_settlement_time_ms: None,
+                        status: AnchorStatus::Green,
+                    }
                 }
             };
 


### PR DESCRIPTION
…lback

- Add STELLAR_INSIGHTS_PREMIUM_CLIENT_IDS for explicit premium tier before DB lookup.
- Post alerts to DEFAULT_ALERT_HTTP_WEBHOOK when set (JSON body, same shape as Slack).
- Use neutral AnchorMetrics when get_recent_anchor_performance fails so the monitor keeps state.
- Repair duplicate .with_context chain in get_recent_anchor_performance (syntax).

Note: main currently fails cargo check in anchors.rs, tracing.rs, and contract.rs; this commit only touches the P1 areas above.
closes #1080 