### PR TITLE
fix(P1): wire analytics dashboard to real API path

### DIFF
--- a/backend/src/api/analytics_dashboard.rs
+++ b/backend/src/api/analytics_dashboard.rs
@@ -38,10 +38,10 @@ pub struct AnalyticsDashboardData {
     pub corridor_performance: Vec<CorridorPerformanceMetric>,
 }
 
-/// Handler for GET /api/analytics/dashboard (cached with 1 min TTL)
+/// Handler for GET /analytics/dashboard (cached with 1 min TTL; mounted under `/analytics` in the API router)
 #[utoipa::path(
     get,
-    path = "/api/analytics/dashboard",
+    path = "/analytics/dashboard",
     responses(
         (status = 200, description = "Analytics dashboard data", body = AnalyticsDashboardData),
         (status = 500, description = "Internal server error")
@@ -284,6 +284,6 @@ fn generate_fallback_data() -> AnalyticsDashboardData {
 
 pub fn routes(cache: Arc<CacheManager>) -> Router {
     Router::new()
-        .route("/api/analytics/dashboard", get(analytics_dashboard))
+        .route("/dashboard", get(analytics_dashboard))
         .with_state(cache)
 }

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,92 +1,94 @@
 
 /**
- * Analytics Data Interfaces
+ * Analytics dashboard types and API client (GET /analytics/dashboard).
  */
 
-import { api } from './api/api';
+import { ApiError, api } from "./api/api";
 
 export interface NetworkVolumeDataPoint {
-    time: string;
-    volume: number;
-    corridors: number;
-    anchors: number;
+  time: string;
+  volume: number;
+  corridors: number;
+  anchors: number;
 }
 
 export interface CorridorPerformanceMetric {
-    corridor: string;
-    success_rate: number;
-    volume: number;
-    health: number;
+  corridor: string;
+  success_rate: number;
+  volume: number;
+  health: number;
 }
 
 export interface NetworkStats {
-    volume_24h: number;
-    volume_growth: number;
-    avg_success_rate: number;
-    success_rate_growth: number;
-    active_corridors: number;
-    corridors_growth: number;
+  volume_24h: number;
+  volume_growth: number;
+  avg_success_rate: number;
+  success_rate_growth: number;
+  active_corridors: number;
+  corridors_growth: number;
 }
 
 export interface AnalyticsDashboardData {
-    stats: NetworkStats;
-    time_series_data: NetworkVolumeDataPoint[];
-    corridor_performance: CorridorPerformanceMetric[];
+  stats: NetworkStats;
+  time_series_data: NetworkVolumeDataPoint[];
+  corridor_performance: CorridorPerformanceMetric[];
+}
+
+/** Raw JSON from backend may use integers for some fields; normalize for chart code. */
+function normalizeDashboardData(raw: AnalyticsDashboardData): AnalyticsDashboardData {
+  return {
+    stats: {
+      volume_24h: Number(raw.stats.volume_24h),
+      volume_growth: Number(raw.stats.volume_growth),
+      avg_success_rate: Number(raw.stats.avg_success_rate),
+      success_rate_growth: Number(raw.stats.success_rate_growth),
+      active_corridors: Number(raw.stats.active_corridors),
+      corridors_growth: Number(raw.stats.corridors_growth),
+    },
+    time_series_data: (raw.time_series_data ?? []).map((p) => ({
+      time: p.time,
+      volume: Number(p.volume),
+      corridors: Number(p.corridors),
+      anchors: Number(p.anchors),
+    })),
+    corridor_performance: (raw.corridor_performance ?? []).map((c) => ({
+      corridor: c.corridor,
+      success_rate: Number(c.success_rate),
+      volume: Number(c.volume),
+      health: Number(c.health),
+    })),
+  };
 }
 
 /**
- * Mock Data Generator
- */
-function generateMockAnalyticsData(): AnalyticsDashboardData {
-    // Mock data for charts
-    const time_series_data: NetworkVolumeDataPoint[] = [
-        { time: "00:00", volume: 45000, corridors: 18, anchors: 42 },
-        { time: "04:00", volume: 52000, corridors: 21, anchors: 45 },
-        { time: "08:00", volume: 48000, corridors: 19, anchors: 48 },
-        { time: "12:00", volume: 61000, corridors: 24, anchors: 52 },
-        { time: "16:00", volume: 55000, corridors: 22, anchors: 50 },
-        { time: "20:00", volume: 67000, corridors: 25, anchors: 56 },
-        { time: "23:59", volume: 72000, corridors: 28, anchors: 62 },
-    ];
-
-    const corridor_performance: CorridorPerformanceMetric[] = [
-        { corridor: "USDC→PHP", success_rate: 98.5, volume: 240000, health: 95 },
-        { corridor: "USD→PHP", success_rate: 97.2, volume: 180000, health: 92 },
-        { corridor: "EUR→USDC", success_rate: 99.1, volume: 150000, health: 98 },
-        { corridor: "USDC→SGD", success_rate: 96.8, volume: 120000, health: 89 },
-        { corridor: "USD→EUR", success_rate: 98.9, volume: 200000, health: 97 },
-    ];
-
-    const stats: NetworkStats = {
-        volume_24h: 2400000,
-        volume_growth: 18,
-        avg_success_rate: 98.1,
-        success_rate_growth: 0.8,
-        active_corridors: 24,
-        corridors_growth: 3,
-    };
-
-    return {
-        stats,
-        time_series_data,
-        corridor_performance,
-    };
-}
-
-/**
- * Fetch Analytics Dashboard Data
+ * Load the analytics dashboard from the backend (no mock fallback).
+ * @throws {ApiError} On HTTP error or network failure
  */
 export async function getAnalyticsDashboard(): Promise<AnalyticsDashboardData> {
-    try {
-        const response = await api.get<AnalyticsDashboardData>('/analytics/dashboard');
-        return response;
-    } catch (error) {
-        // Fallback to mock data if backend is unavailable
-        console.warn('Backend analytics endpoint unavailable, using mock data:', error);
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(generateMockAnalyticsData());
-            }, 1000); // Simulate network latency
-        });
-    }
+  const data = await api.get<AnalyticsDashboardData>("/analytics/dashboard");
+  return normalizeDashboardData(data);
+}
+
+export type AnalyticsDashboardFetchResult =
+  | { ok: true; data: AnalyticsDashboardData }
+  | { ok: false; error: string; status?: number };
+
+/**
+ * Same as {@link getAnalyticsDashboard} but returns a result instead of throwing
+ * (for UI loading / error states).
+ */
+export async function tryGetAnalyticsDashboard(): Promise<AnalyticsDashboardFetchResult> {
+  try {
+    const data = await getAnalyticsDashboard();
+    return { ok: true, data };
+  } catch (e) {
+    const message =
+      e instanceof ApiError
+        ? e.message
+        : e instanceof Error
+          ? e.message
+          : "Failed to load analytics dashboard";
+    const status = e instanceof ApiError ? e.status : undefined;
+    return { ok: false, error: message, status };
+  }
 }


### PR DESCRIPTION
Frontend: remove mock fallback from lib/analytics.ts; call GET /analytics/dashboard via the shared api client, normalize numeric fields from JSON, and add tryGetAnalyticsDashboard for non-throwing error handling.

Backend: register the dashboard handler at /dashboard under the existing /analytics nest so the live URL is /analytics/dashboard (matches muxed-style paths and the frontend client).
closes #1098 