### PR TITLE
docs(P2): clarify contract profiles belong in workspace root

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -18,6 +18,10 @@ panic = "deny"
 soroban-sdk = "25.3.0"
 soroban-token-sdk = "25.3.0"
 
+# Release and bench profiles must stay in this workspace root only. Cargo ignores
+# `[profile.*]` in member crates (e.g. access-control, stellar_insights, governance)
+# and prints: "profiles for non-root package will be ignored".
+
 [profile.release]
 opt-level = "z"
 overflow-checks = true


### PR DESCRIPTION
Member crates (access-control, stellar_insights, governance, analytics, benches) already omit [profile.*]; Cargo only honors profiles in the contracts workspace manifest. Document this to avoid the non-root profile warning and ignored settings.

Closes #1103