### PR TITLE
fix: remove ambiguity around get_event_stats_old (closes #issue)

### DIFF
--- a/backend/src/services/event_indexer.rs
+++ b/backend/src/services/event_indexer.rs
@@ -338,7 +338,7 @@ impl EventIndexer {
         Ok(())
     }
 
-    /// Get event statistics
+    /// Get event statistics. This is the canonical implementation; no legacy variant exists.
     pub async fn get_event_stats(&self) -> Result<EventStats> {
         let total_events: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM contract_events")
             .fetch_one(self.db.pool())


### PR DESCRIPTION
get_event_stats_old() does not exist in the codebase. get_event_stats() is the sole canonical implementation. Added doc comment to make this explicit.
closes #1102