### PR TITLE
 fix: env validation, SEP10 key check, OTel update (#1120, #1126, #1127, #1133)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -54,10 +54,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-log = "0.2"
 tracing-appender = "0.2"
 tracing-logstash = "0.2"
-opentelemetry = { version = "0.24", features = ["trace"] }
-opentelemetry_sdk = { version = "0.24", features = ["trace", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.17", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
-tracing-opentelemetry = "0.25"
+opentelemetry = { version = "0.27", features = ["trace"] }
+opentelemetry_sdk = { version = "0.27", features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.27", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
+tracing-opentelemetry = "0.28"
 dotenvy = "0.15"
 sha2 = "0.10"
 hex = "0.4"

--- a/backend/src/env_config.rs
+++ b/backend/src/env_config.rs
@@ -18,7 +18,8 @@ const VALIDATED_VARS: &[(&str, fn(&str) -> bool)] = &[
     ("RPC_MAX_RECORDS_PER_REQUEST", validate_positive_number),
     ("RPC_MAX_TOTAL_RECORDS", validate_positive_number),
     ("RPC_PAGINATION_DELAY_MS", validate_positive_number),
-    ("REQUEST_TIMEOUT_SECONDS", validate_positive_number),
+    ("REQUEST_TIMEOUT_SECONDS", validate_request_timeout),
+    ("SLOW_QUERY_THRESHOLD_MS", validate_slow_query_threshold),
     ("JWT_SECRET", validate_jwt_secret),
 ];
 
@@ -60,6 +61,19 @@ pub fn validate_env() -> Result<()> {
                 Generate a secure secret with: openssl rand -base64 48",
                 jwt_secret.len()
             ));
+        }
+    }
+
+    // SEP10_SERVER_PUBLIC_KEY must be a valid Stellar public key when set
+    if let Ok(sep10_key) = env::var("SEP10_SERVER_PUBLIC_KEY") {
+        if !validate_stellar_public_key(&sep10_key) {
+            errors.push(
+                "SEP10_SERVER_PUBLIC_KEY is not a valid Stellar public key. \
+                It must start with 'G', be exactly 56 characters, use base32 encoding (A-Z, 2-7), \
+                and must not be a placeholder. \
+                Generate one with: stellar keys generate"
+                    .to_string(),
+            );
         }
     }
 
@@ -196,9 +210,18 @@ fn validate_jwt_secret(value: &str) -> bool {
     value.len() >= 32
 }
 
+/// Validate REQUEST_TIMEOUT_SECONDS: must be in range [1, 300]
+fn validate_request_timeout(value: &str) -> bool {
+    value.parse::<u64>().map(|n| (1..=300).contains(&n)).unwrap_or(false)
+}
+
+/// Validate SLOW_QUERY_THRESHOLD_MS: must be in range [1, 60000]
+fn validate_slow_query_threshold(value: &str) -> bool {
+    value.parse::<u64>().map(|n| (1..=60_000).contains(&n)).unwrap_or(false)
+}
+
 /// Validate Stellar public key format
 /// Must start with 'G' and be exactly 56 characters (Ed25519 public key in base32)
-#[allow(dead_code)]
 fn validate_stellar_public_key(value: &str) -> bool {
     if !value.starts_with('G') || value.len() != 56 {
         return false;

--- a/backend/src/observability/tracing.rs
+++ b/backend/src/observability/tracing.rs
@@ -7,7 +7,6 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::resource::Resource;
 use opentelemetry_sdk::runtime;
-use opentelemetry_sdk::trace::Config;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -16,7 +15,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 const MAX_LOG_FILES: usize = 30;
 
 fn init_otel_tracer(service_name: &str) -> Result<opentelemetry_sdk::trace::Tracer> {
-    // HTTP/protobuf OTLP on 4318; OTLP 0.17+ avoids pulling `tonic`'s legacy `axum` into this crate graph.
+    // HTTP/protobuf OTLP on 4318; avoids pulling `tonic` into the crate graph.
     let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").unwrap_or_else(|_| {
         "http://localhost:4318/v1/traces".to_string()
     });
@@ -26,15 +25,15 @@ fn init_otel_tracer(service_name: &str) -> Result<opentelemetry_sdk::trace::Trac
         service_name.to_string(),
     )]);
 
-    let provider = opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(
-            opentelemetry_otlp::new_exporter()
-                .http()
-                .with_endpoint(endpoint),
-        )
-        .with_trace_config(Config::default().with_resource(resource))
-        .install_batch(runtime::Tokio)?;
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint)
+        .build()?;
+
+    let provider = opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .with_config(opentelemetry_sdk::trace::Config::default().with_resource(resource))
+        .build();
 
     global::set_tracer_provider(provider.clone());
     Ok(provider.tracer("stellar-insights-backend"))


### PR DESCRIPTION
## Summary                                                                                  
                                                                                           
                                                                                            
  #1126 — TypeScript Strict Mode                                                           
                                                                                           
  No code change needed. frontend/tsconfig.json already has "strict": true along with all  
  individual strict flags (noImplicitAny, strictNullChecks, strictFunctionTypes,           
  strictBindCallApply, strictPropertyInitialization, noImplicitThis, alwaysStrict). Issue  
  is resolved as-is.                                                                       
                                                                                           
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  #1120 — Missing Environment Variable Validation                                          
                                                                                           
  File: backend/src/env_config.rs                                                          
                                                                                           
  - Added SLOW_QUERY_THRESHOLD_MS to VALIDATED_VARS with a new                             
  validate_slow_query_threshold validator (range: 1–60,000 ms). Previously this variable   
  was parsed without any bounds check.                                                     
  - Tightened REQUEST_TIMEOUT_SECONDS to use a new validate_request_timeout validator      
  (range: 1–300 s) instead of the generic validate_positive_number, matching the clamping  
  already applied in main.rs.                                                              
                                                                                           
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  #1127 — Placeholder SEP10 Public Key Not Validated                                       
                                                                                           
  File: backend/src/env_config.rs                                                          
                                                                                           
  - Added a startup check in validate_env() for SEP10_SERVER_PUBLIC_KEY. If the variable is
  set but fails validate_stellar_public_key (wrong length, wrong prefix, placeholder value,
  or invalid base32 chars), the server now fails fast with a clear error message including 
  the fix command.                                                                         
  - Removed the #[allow(dead_code)] attribute from validate_stellar_public_key since it is 
  now actively called.                                                                     
                                                                                           
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  #1133 — OpenTelemetry Version Update                                                     
                                                                                           
  Files: backend/Cargo.toml, backend/src/observability/tracing.rs                          
                                                                                           
  ┌─────────────────────────┬────────┬───────┐                                             
  │ Crate                   │ Before │ After │                                             
  ├─────────────────────────┼────────┼───────┤                                             
  │ `opentelemetry`         │ 0.24   │ 0.27  │                                             
  │ `opentelemetry_sdk`     │ 0.24   │ 0.27  │                                             
  │ `opentelemetry-otlp`    │ 0.17   │ 0.27  │                                             
  │ `tracing-opentelemetry` │ 0.25   │ 0.28  │                                             
  └─────────────────────────┴────────┴───────┘                                             
                                                                                           
  The new_pipeline() / new_exporter() API was removed in 0.27. Migrated init_otel_tracer to
  the new builder pattern:                                                                 
                                                                                           
  - opentelemetry_otlp::SpanExporter::builder().with_http().with_endpoint(…).build()       
  - TracerProvider::builder().with_batch_exporter(…).with_config(…).build()                
                                                                                           
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
closes #1120 
closes #1126 
closes #1127 
closes #1133                                                        
                                   