### PR TITLE
Feat/validation middleware

### DIFF
--- a/backend/src/api/alerts.rs
+++ b/backend/src/api/alerts.rs
@@ -14,65 +14,8 @@ use crate::{
     error::{ApiError, ApiResult},
     models::alerts::{CreateAlertRuleRequest, SnoozeAlertRequest, UpdateAlertRuleRequest},
     state::AppState,
+    validation::ValidatedJson,
 };
-
-const VALID_METRIC_TYPES: &[&str] = &["success_rate", "latency", "liquidity", "volume"];
-const VALID_CONDITIONS: &[&str] = &["above", "below", "equals"];
-const MAX_CORRIDOR_ID_LEN: usize = 256;
-
-fn validate_metric_type(metric_type: &str) -> ApiResult<()> {
-    if !VALID_METRIC_TYPES.contains(&metric_type) {
-        return Err(ApiError::bad_request(
-            "INVALID_METRIC_TYPE",
-            format!("metric_type must be one of: {}", VALID_METRIC_TYPES.join(", ")),
-        ));
-    }
-    Ok(())
-}
-
-fn validate_condition(condition: &str) -> ApiResult<()> {
-    if !VALID_CONDITIONS.contains(&condition) {
-        return Err(ApiError::bad_request(
-            "INVALID_CONDITION",
-            format!("condition must be one of: {}", VALID_CONDITIONS.join(", ")),
-        ));
-    }
-    Ok(())
-}
-
-fn validate_threshold(threshold: f64) -> ApiResult<()> {
-    if !threshold.is_finite() {
-        return Err(ApiError::bad_request(
-            "INVALID_THRESHOLD",
-            "threshold must be a finite number",
-        ));
-    }
-    if threshold < 0.0 {
-        return Err(ApiError::bad_request(
-            "INVALID_THRESHOLD",
-            "threshold must be non-negative",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_corridor_id(corridor_id: &Option<String>) -> ApiResult<()> {
-    if let Some(id) = corridor_id {
-        if id.is_empty() {
-            return Err(ApiError::bad_request(
-                "INVALID_CORRIDOR_ID",
-                "corridor_id must not be empty if provided",
-            ));
-        }
-        if id.len() > MAX_CORRIDOR_ID_LEN {
-            return Err(ApiError::bad_request(
-                "INVALID_CORRIDOR_ID",
-                format!("corridor_id must not exceed {MAX_CORRIDOR_ID_LEN} characters"),
-            ));
-        }
-    }
-    Ok(())
-}
 
 // Route configuration
 pub fn router() -> Router<AppState> {
@@ -125,12 +68,8 @@ async fn list_rules(
 async fn create_rule(
     State(state): State<AppState>,
     auth_user: AuthUser,
-    Json(payload): Json<CreateAlertRuleRequest>,
+    ValidatedJson(payload): ValidatedJson<CreateAlertRuleRequest>,
 ) -> ApiResult<impl IntoResponse> {
-    validate_corridor_id(&payload.corridor_id)?;
-    validate_metric_type(&payload.metric_type)?;
-    validate_condition(&payload.condition)?;
-    validate_threshold(payload.threshold)?;
     let rule = state
         .db
         .create_alert_rule(&auth_user.user_id, payload)
@@ -159,18 +98,8 @@ async fn update_rule(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
-    Json(payload): Json<UpdateAlertRuleRequest>,
+    ValidatedJson(payload): ValidatedJson<UpdateAlertRuleRequest>,
 ) -> ApiResult<impl IntoResponse> {
-    validate_corridor_id(&payload.corridor_id)?;
-    if let Some(ref mt) = payload.metric_type {
-        validate_metric_type(mt)?;
-    }
-    if let Some(ref cond) = payload.condition {
-        validate_condition(cond)?;
-    }
-    if let Some(t) = payload.threshold {
-        validate_threshold(t)?;
-    }
     let rule = state
         .db
         .update_alert_rule(&id, &auth_user.user_id, payload)

--- a/backend/src/api/anchors.rs
+++ b/backend/src/api/anchors.rs
@@ -159,11 +159,8 @@ pub async fn get_muxed_analytics(
 #[tracing::instrument(skip(app_state, req), fields(anchor_name = %req.name))]
 pub async fn create_anchor(
     State(app_state): State<AppState>,
-    Json(req): Json<CreateAnchorRequest>,
+    crate::validation::ValidatedJson(req): crate::validation::ValidatedJson<CreateAnchorRequest>,
 ) -> ApiResult<Json<crate::models::Anchor>> {
-    // Struct-level field validation (lengths)
-    crate::validation::validate_request(&req)?;
-
     // Business logic: stellar account must start with 'G'
     crate::validation::validate_stellar_account(&req.stellar_account)?;
 

--- a/backend/src/api/api_keys.rs
+++ b/backend/src/api/api_keys.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use crate::database::Database;
 use crate::models::api_key::CreateApiKeyRequest;
+use crate::validation::ValidatedJson;
 
 fn extract_wallet_address(headers: &HeaderMap) -> Result<String, ApiKeyError> {
     headers
@@ -35,19 +36,11 @@ fn extract_wallet_address(headers: &HeaderMap) -> Result<String, ApiKeyError> {
 pub async fn create_api_key(
     State(db): State<Arc<Database>>,
     headers: HeaderMap,
-    Json(req): Json<CreateApiKeyRequest>,
+    ValidatedJson(req): ValidatedJson<CreateApiKeyRequest>,
 ) -> Result<Response, ApiKeyError> {
     let wallet_address = extract_wallet_address(&headers)?;
 
     let name = req.name.trim();
-    if name.is_empty() {
-        return Err(ApiKeyError::BadRequest("Key name is required".to_string()));
-    }
-    if name.len() > 100 {
-        return Err(ApiKeyError::BadRequest(
-            "Key name must not exceed 100 characters".to_string(),
-        ));
-    }
     if !name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == ' ') {
         return Err(ApiKeyError::BadRequest(
             "Key name may only contain letters, digits, spaces, hyphens, and underscores"

--- a/backend/src/api/corridors.rs
+++ b/backend/src/api/corridors.rs
@@ -920,11 +920,8 @@ pub async fn get_corridor_detail(
 /// POST /api/corridors - Create a new corridor
 pub async fn create_corridor(
     State(app_state): State<AppState>,
-    Json(req): Json<CreateCorridorRequest>,
+    crate::validation::ValidatedJson(req): crate::validation::ValidatedJson<CreateCorridorRequest>,
 ) -> ApiResult<Json<Corridor>> {
-    // Struct-level field validation (lengths, formats)
-    crate::validation::validate_request(&req)?;
-
     // Business logic: source and destination must differ
     crate::validation::validate_corridor_not_self_referential(
         &req.source_asset_code,

--- a/backend/src/models/alerts.rs
+++ b/backend/src/models/alerts.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use validator::Validate;
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct AlertRule {
@@ -34,11 +35,15 @@ pub struct AlertHistory {
     pub triggered_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct CreateAlertRuleRequest {
+    #[validate(length(max = 256, message = "corridor_id must not exceed 256 characters"))]
     pub corridor_id: Option<String>,
+    #[validate(length(min = 1, max = 64, message = "metric_type must be between 1 and 64 characters"))]
     pub metric_type: String,
+    #[validate(length(min = 1, max = 32, message = "condition must be between 1 and 32 characters"))]
     pub condition: String,
+    #[validate(range(min = 0.0, message = "threshold must be non-negative"))]
     pub threshold: f64,
     #[serde(default)]
     pub notify_email: bool,
@@ -48,11 +53,15 @@ pub struct CreateAlertRuleRequest {
     pub notify_in_app: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct UpdateAlertRuleRequest {
+    #[validate(length(max = 256, message = "corridor_id must not exceed 256 characters"))]
     pub corridor_id: Option<String>,
+    #[validate(length(min = 1, max = 64, message = "metric_type must be between 1 and 64 characters"))]
     pub metric_type: Option<String>,
+    #[validate(length(min = 1, max = 32, message = "condition must be between 1 and 32 characters"))]
     pub condition: Option<String>,
+    #[validate(range(min = 0.0, message = "threshold must be non-negative"))]
     pub threshold: Option<f64>,
     pub notify_email: Option<bool>,
     pub notify_webhook: Option<bool>,

--- a/backend/src/models/api_key.rs
+++ b/backend/src/models/api_key.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
+use validator::Validate;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct ApiKey {
@@ -48,8 +49,9 @@ impl From<ApiKey> for ApiKeyInfo {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Validate)]
 pub struct CreateApiKeyRequest {
+    #[validate(length(min = 1, max = 100, message = "name must be between 1 and 100 characters"))]
     pub name: String,
     pub scopes: Option<String>,
     pub expires_at: Option<String>,

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -1,7 +1,46 @@
 //! Request parameter validation to prevent invalid inputs (NaN, infinity, negative values, invalid ranges).
 
 use crate::error::{ApiError, ApiResult};
+use async_trait::async_trait;
+use axum::{
+    extract::{FromRequest, Request},
+    Json,
+};
 use validator::Validate;
+
+// ── ValidatedJson extractor ───────────────────────────────────────────────────
+
+/// Axum extractor that deserializes JSON and immediately runs `validator::Validate`.
+/// Handlers use `ValidatedJson<T>` instead of `Json<T>` to get automatic validation.
+pub struct ValidatedJson<T>(pub T);
+
+#[async_trait]
+impl<T, S> FromRequest<S> for ValidatedJson<T>
+where
+    T: serde::de::DeserializeOwned + Validate,
+    S: Send + Sync,
+    Json<T>: FromRequest<S>,
+{
+    type Rejection = axum::response::Response;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let Json(value) = Json::<T>::from_request(req, state)
+            .await
+            .map_err(|e| e.into_response())?;
+        validate_request(&value).map_err(|e| {
+            use axum::response::IntoResponse;
+            e.into_response()
+        })?;
+        Ok(ValidatedJson(value))
+    }
+}
+
+impl<T> std::ops::Deref for ValidatedJson<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
 
 /// Validates a single optional filter value: must be finite (no NaN/Infinity), and within [`min_allowed`, `max_allowed`].
 #[inline]

--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -204,6 +204,16 @@ pub struct TimelockActionCancelledEvent {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfigUpdatedEvent {
+    pub old_config: ContractConfig,
+    pub new_config: ContractConfig,
+    pub updated_by: Address,
+    pub timestamp: u64,
+    pub ledger_sequence: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SnapshotsPrunedEvent {
     pub removed_count: u32,
     pub cutoff_epoch: u64,
@@ -644,11 +654,18 @@ impl AnalyticsContract {
         if admin != stored_admin {
             return Err(Error::Unauthorized.log_context(&env, "update_config: caller is not the admin"));
         }
+        let old_config = get_config(&env);
         env.storage().instance().set(&DataKey::Config, &config);
 
         env.events().publish(
-            (symbol_short!("cfg_upd"), admin),
-            config,
+            (symbol_short!("cfg_upd"), admin.clone()),
+            ConfigUpdatedEvent {
+                old_config,
+                new_config: config,
+                updated_by: admin,
+                timestamp: env.ledger().timestamp(),
+                ledger_sequence: env.ledger().sequence(),
+            },
         );
 
         Ok(())

--- a/contracts/governance/src/events.rs
+++ b/contracts/governance/src/events.rs
@@ -224,3 +224,85 @@ pub fn emit_parameter_proposal_created(
     };
     env.events().publish((PARAM_PROPOSAL, GOV_LIFECYCLE), event);
 }
+
+// ============================================================================
+// Governance Admin / Parameter Change Events
+// ============================================================================
+
+/// Topic for governance parameter change events (quorum, voting period, admin).
+pub const GOV_PARAM: Symbol = symbol_short!("GOV_PRM");
+
+/// Event emitted when a governance parameter (quorum or voting_period) is updated.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceParamChangedEvent {
+    pub param_name: String,
+    pub old_value: u64,
+    pub new_value: u64,
+    pub changed_by: Address,
+    pub timestamp: u64,
+    pub ledger_sequence: u32,
+}
+
+impl GovernanceParamChangedEvent {
+    pub fn publish(
+        env: &Env,
+        param_name: String,
+        old_value: u64,
+        new_value: u64,
+        changed_by: Address,
+    ) {
+        let event = GovernanceParamChangedEvent {
+            param_name,
+            old_value,
+            new_value,
+            changed_by,
+            timestamp: env.ledger().timestamp(),
+            ledger_sequence: env.ledger().sequence(),
+        };
+        env.events().publish((GOV_PARAM, GOV_LIFECYCLE), event);
+    }
+}
+
+/// Event emitted when the governance admin is changed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceAdminChangedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+    pub changed_by: Address,
+    pub timestamp: u64,
+    pub ledger_sequence: u32,
+}
+
+impl GovernanceAdminChangedEvent {
+    pub fn publish(env: &Env, old_admin: Address, new_admin: Address, changed_by: Address) {
+        let event = GovernanceAdminChangedEvent {
+            old_admin,
+            new_admin,
+            changed_by,
+            timestamp: env.ledger().timestamp(),
+            ledger_sequence: env.ledger().sequence(),
+        };
+        env.events().publish((GOV_PARAM, GOV_LIFECYCLE), event);
+    }
+}
+
+pub fn emit_governance_param_changed(
+    env: &Env,
+    param_name: String,
+    old_value: u64,
+    new_value: u64,
+    changed_by: Address,
+) {
+    GovernanceParamChangedEvent::publish(env, param_name, old_value, new_value, changed_by);
+}
+
+pub fn emit_governance_admin_changed(
+    env: &Env,
+    old_admin: Address,
+    new_admin: Address,
+    changed_by: Address,
+) {
+    GovernanceAdminChangedEvent::publish(env, old_admin, new_admin, changed_by);
+}

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -7,7 +7,8 @@ mod events;
 use analytics::AnalyticsContractClient;
 use errors::Error;
 use events::{
-    emit_governance_initialized, emit_parameter_proposal_created, emit_proposal_created,
+    emit_governance_initialized, emit_governance_param_changed, emit_governance_admin_changed,
+    emit_parameter_proposal_created, emit_proposal_created,
     emit_proposal_executed, emit_proposal_finalized, emit_vote_cast,
 };
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Map, String};
@@ -602,6 +603,81 @@ impl GovernanceContract {
 
         emit_proposal_executed(&env, proposal_id, caller, target_contract);
 
+        Ok(())
+    }
+
+    // ========================================================================
+    // Admin Parameter Update Functions
+    // ========================================================================
+
+    /// Update the quorum threshold. Admin-only.
+    pub fn update_quorum(env: Env, caller: Address, new_quorum: u64) -> Result<(), Error> {
+        caller.require_auth();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        if caller != admin {
+            return Err(Error::UnauthorizedCaller);
+        }
+        let old_quorum: u64 = env.storage().instance().get(&DataKey::Quorum).unwrap_or(0);
+        env.storage().instance().set(&DataKey::Quorum, &new_quorum);
+        bump_instance(&env);
+        emit_governance_param_changed(
+            &env,
+            String::from_str(&env, "quorum"),
+            old_quorum,
+            new_quorum,
+            caller,
+        );
+        Ok(())
+    }
+
+    /// Update the voting period. Admin-only.
+    pub fn update_voting_period(env: Env, caller: Address, new_period: u64) -> Result<(), Error> {
+        caller.require_auth();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        if caller != admin {
+            return Err(Error::UnauthorizedCaller);
+        }
+        let old_period: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VotingPeriod)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::VotingPeriod, &new_period);
+        bump_instance(&env);
+        emit_governance_param_changed(
+            &env,
+            String::from_str(&env, "voting_period"),
+            old_period,
+            new_period,
+            caller,
+        );
+        Ok(())
+    }
+
+    /// Transfer governance admin to a new address. Admin-only.
+    pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), Error> {
+        caller.require_auth();
+        let old_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        if caller != old_admin {
+            return Err(Error::UnauthorizedCaller);
+        }
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        bump_instance(&env);
+        emit_governance_admin_changed(&env, old_admin, new_admin, caller);
         Ok(())
     }
 


### PR DESCRIPTION
Here's what changed across 7 files:                                                          
                                                                                                     
  `backend/src/validation.rs` — Added ValidatedJson<T> Axum extractor. It implements FromRequest,    
  deserializes JSON via the standard Json<T> extractor, then immediately calls validate_request. Any 
  validation failure returns the same VALIDATION_ERROR format as the rest of the API. Also implements
  Deref<Target = T> so handlers can use the inner value directly.                                    
                                                                                                     
  `backend/src/models/alerts.rs` — Added Validate derive to CreateAlertRuleRequest and               
  UpdateAlertRuleRequest with field constraints (length bounds on metric_type, condition,            
  corridor_id; non-negative threshold).                                                              
                                                                                                     
  `backend/src/models/api_key.rs` — Added Validate derive to CreateApiKeyRequest with a length       
  constraint on name.                                                                                
                                                                                                     
  `backend/src/api/alerts.rs` — Removed the four local validate_* functions (54 lines). create_rule  
  and update_rule now use ValidatedJson.                                                             
                                                                                                     
  `backend/src/api/anchors.rs` — create_anchor uses ValidatedJson, manual validate_request call      
  removed.                                                                                           
                                                                                                     
  `backend/src/api/corridors.rs` — create_corridor uses ValidatedJson, manual validate_request call  
  removed.                                                                                           
                                                                                                     
  `backend/src/api/api_keys.rs` — create_api_key uses ValidatedJson, redundant empty/length checks   
  removed (now handled by the Validate derive).

closes #1211 