### PR TITLE
Add HTTP caching headers to corridor detail endpoint

### DIFF
--- a/backend/src/api/corridors.rs
+++ b/backend/src/api/corridors.rs
@@ -702,7 +702,7 @@ fn find_related_corridors(
     tag = "Corridors"
 )]
 #[tracing::instrument(
-    skip(_db, cache, rpc_client, price_feed),
+    skip(_db, cache, rpc_client, price_feed, headers),
     fields(request_id = %request_id.0, corridor_key = %corridor_key)
 )]
 pub async fn get_corridor_detail(
@@ -714,7 +714,8 @@ pub async fn get_corridor_detail(
         Arc<PriceFeedClient>,
     )>,
     Path(corridor_key): Path<String>,
-) -> ApiResult<Json<CorridorDetailResponse>> {
+    headers: HeaderMap,
+) -> ApiResult<Response> {
     use std::collections::HashMap;
     info!("Fetching corridor");
 
@@ -923,7 +924,9 @@ pub async fn get_corridor_detail(
         "Corridor found"
     );
 
-    Ok(Json(response))
+    let ttl = cache.config.get_ttl("corridor");
+    let cached = crate::http_cache::cached_json_response(&headers, &cache_key, &response, ttl)?;
+    Ok(cached)
 }
 
 /// POST /api/corridors - Create a new corridor

--- a/backend/tests/api_corridors_test.rs
+++ b/backend/tests/api_corridors_test.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Body,
-    http::{Request, StatusCode},
+    http::{header, Request, StatusCode},
     middleware, Router,
 };
 use serde_json::Value;
@@ -126,4 +126,78 @@ async fn test_get_corridor_detail_invalid_format() {
     let response = app.oneshot(request).await.unwrap();
     // Handler should return BadRequest for invalid format
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_corridor_detail_returns_cache_headers() {
+    let pool = setup_test_db().await;
+    let db = Arc::new(Database::new(pool));
+    let app = create_test_router(db).await;
+
+    let corridor_key = "XLM%3Anative-%3EXLM%3Anative";
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/corridors/{corridor_key}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get(header::CACHE_CONTROL).is_some(),
+        "Cache-Control header missing"
+    );
+    assert!(
+        response.headers().get(header::ETAG).is_some(),
+        "ETag header missing"
+    );
+    assert!(
+        response.headers().get(header::LAST_MODIFIED).is_some(),
+        "Last-Modified header missing"
+    );
+}
+
+#[tokio::test]
+async fn test_corridor_detail_returns_304_on_if_none_match() {
+    let pool = setup_test_db().await;
+    let db = Arc::new(Database::new(pool));
+    let app = create_test_router(db).await;
+
+    let corridor_key = "XLM%3Anative-%3EXLM%3Anative";
+
+    // First request — get the ETag
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/corridors/{corridor_key}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    let etag = first
+        .headers()
+        .get(header::ETAG)
+        .expect("ETag missing on first response")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // Second request with If-None-Match — expect 304
+    let second = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/corridors/{corridor_key}"))
+                .header(header::IF_NONE_MATCH, &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
 }


### PR DESCRIPTION
closes #1206 

Add HTTP caching headers to corridor detail endpoint
  
  Summary
  
  GET /api/corridors/:corridor_key was returning plain JSON with no cache headers, causing
  unnecessary data transfer on every request. This wires it into the existing
  cached_json_response utility already used by the other cacheable endpoints.
  
  Changes
  
  - src/api/corridors.rs — get_corridor_detail now accepts headers: HeaderMap, returns
  ApiResult<Response>, and calls cached_json_response with the corridor TTL. Returns 304
  Not Modified when If-None-Match or If-Modified-Since matches.
  - tests/api_corridors_test.rs — two new tests: one asserting Cache-Control, ETag, and
  Last-Modified are present; one asserting a 304 is returned on a conditional request with
  a matching ETag.
  
  No new dependencies
  
  Uses the existing http_cache::cached_json_response already in the codebase.
  
  Testing
  
  # Expect Cache-Control, ETag, Last-Modified headers
  curl -I http://localhost:8080/api/corridors/XLM:native->XLM:native
  
  # Expect 304 Not Modified
  curl -I -H 'If-None-Match: "<etag-from-above>"' \
    http://localhost:8080/api/corridors/XLM:native->XLM:native