### PR TITLE
feat(sdk): add retry with exponential backoff for transient failures

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run",
     "lint": "tsc --noEmit"
   },
-  "keywords": ["stellar", "sdk", "payments", "analytics"],
+  "keywords": ["stellar", "sdk", "payments", "analytics", "retry-backoff"],
   "license": "MIT",
   "devDependencies": {
     "tsup": "8.0.2",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -73,6 +73,7 @@ export { NPMPublishingSetup } from "./npm_publishing_setup.js";
 export { AnalyticsAPIModule } from "./analytics_api_module.js";
 export { TypeScriptTypes } from "./typescript_types.js";
 export { RequestCancellation } from "./request_cancellation.js";
+export { RetryWithBackoff } from "./retry_with_backoff.js";
 export { AnchorsAPIModule } from "./anchors_api_module.js";
 
 // SDK Initialization exports
@@ -89,4 +90,5 @@ export type * from "./types/npm_publishing_setup.js";
 export type * from "./types/analytics_api_module.js";
 export type * from "./types/typescript_types.js";
 export type * from "./types/request_cancellation.js";
+export type * from "./types/retry_with_backoff.js";
 export type * from "./types/anchors_api_module.js";

--- a/sdk/typescript/src/retry_with_backoff.test.ts
+++ b/sdk/typescript/src/retry_with_backoff.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { RetryWithBackoff, SDKError, StellarInsightsError } from "../src/index.js";
+
+describe("RetryWithBackoff", () => {
+  let retry: RetryWithBackoff;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    retry = new RetryWithBackoff({ maxRetries: 3, retryDelay: 100 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── execute ────────────────────────────────────────────────────────────────
+
+  it("should execute successfully on first attempt", async () => {
+    const operation = vi.fn().mockResolvedValue({ ok: true });
+
+    const resultPromise = retry.execute({ operation, operationKey: "fetch-data" });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ ok: true });
+    expect(result.attempts).toBe(1);
+    expect(result.retried).toBe(false);
+    expect(result.totalDelayMs).toBe(0);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on retryable errors and eventually succeeds", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new StellarInsightsError(503, "UNAVAILABLE", "Service unavailable"))
+      .mockRejectedValueOnce(new StellarInsightsError(502, "BAD_GATEWAY", "Bad gateway"))
+      .mockResolvedValue("success");
+
+    const resultPromise = retry.execute({ operation, maxRetries: 3, initialDelayMs: 100 });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("success");
+    expect(result.attempts).toBe(3);
+    expect(result.retried).toBe(true);
+    expect(result.totalDelayMs).toBeGreaterThan(0);
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-retryable 4xx errors", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValue(new StellarInsightsError(404, "NOT_FOUND", "Not found"));
+
+    await expect(retry.execute({ operation })).rejects.toBeInstanceOf(SDKError);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 429 rate limit errors", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new StellarInsightsError(429, "RATE_LIMITED", "Too many requests"))
+      .mockResolvedValue("ok");
+
+    const resultPromise = retry.execute({ operation, initialDelayMs: 50 });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.data).toBe("ok");
+    expect(result.attempts).toBe(2);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on network TypeError failures", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValue("recovered");
+
+    const resultPromise = retry.execute({ operation, initialDelayMs: 50 });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.data).toBe("recovered");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws SDKError after exhausting max retries", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValue(new StellarInsightsError(500, "SERVER_ERROR", "Server error"));
+
+    const resultPromise = retry.execute({ operation, maxRetries: 2, initialDelayMs: 10 });
+    const expectation = expect(resultPromise).rejects.toBeInstanceOf(SDKError);
+    await vi.runAllTimersAsync();
+    await expectation;
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects custom shouldRetry predicate", async () => {
+    const operation = vi.fn().mockRejectedValue(new Error("custom failure"));
+    const shouldRetry = vi.fn().mockReturnValue(false);
+
+    await expect(retry.execute({ operation, shouldRetry })).rejects.toBeInstanceOf(SDKError);
+    expect(shouldRetry).toHaveBeenCalledTimes(1);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws SDKError when operation is missing", async () => {
+    await expect(
+      retry.execute({ operation: undefined as unknown as () => Promise<unknown> }),
+    ).rejects.toBeInstanceOf(SDKError);
+  });
+
+  it("throws SDKError when maxRetries is negative", async () => {
+    await expect(
+      retry.execute({ operation: vi.fn(), maxRetries: -1 }),
+    ).rejects.toBeInstanceOf(SDKError);
+  });
+
+  // ── calculateDelay ─────────────────────────────────────────────────────────
+
+  it("calculateDelay applies exponential backoff", () => {
+    expect(RetryWithBackoff.calculateDelay(0, 100, 10_000, false)).toBe(100);
+    expect(RetryWithBackoff.calculateDelay(1, 100, 10_000, false)).toBe(200);
+    expect(RetryWithBackoff.calculateDelay(2, 100, 10_000, false)).toBe(400);
+  });
+
+  it("calculateDelay caps delay at maxDelayMs", () => {
+    expect(RetryWithBackoff.calculateDelay(10, 100, 1000, false)).toBe(1000);
+  });
+
+  it("calculateDelay adds jitter when enabled", () => {
+    const withJitter = RetryWithBackoff.calculateDelay(1, 100, 10_000, true);
+    expect(withJitter).toBeGreaterThanOrEqual(200);
+  });
+
+  // ── isRetryableError ───────────────────────────────────────────────────────
+
+  it("isRetryableError identifies retryable HTTP statuses", () => {
+    expect(
+      RetryWithBackoff.isRetryableError(
+        new StellarInsightsError(503, "UNAVAILABLE", "Unavailable"),
+      ),
+    ).toBe(true);
+    expect(
+      RetryWithBackoff.isRetryableError(new StellarInsightsError(404, "NOT_FOUND", "Missing")),
+    ).toBe(false);
+    expect(RetryWithBackoff.isRetryableError(new TypeError("network"))).toBe(true);
+  });
+
+  // ── metrics ────────────────────────────────────────────────────────────────
+
+  it("tracks retry metrics", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new StellarInsightsError(500, "ERR", "fail"))
+      .mockResolvedValue("done");
+
+    const resultPromise = retry.execute({ operation, initialDelayMs: 10 });
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    const metrics = retry.getMetrics();
+    expect(metrics.totalExecutions).toBe(1);
+    expect(metrics.totalRetries).toBe(1);
+    expect(metrics.totalFailures).toBe(0);
+  });
+
+  it("resetMetrics clears counters", async () => {
+    const operation = vi.fn().mockResolvedValue("ok");
+    const resultPromise = retry.execute({ operation });
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    retry.resetMetrics();
+    expect(retry.getMetrics()).toEqual({
+      totalExecutions: 0,
+      totalRetries: 0,
+      totalFailures: 0,
+    });
+  });
+
+  // ── constructor ────────────────────────────────────────────────────────────
+
+  it("works with no config argument", async () => {
+    const instance = new RetryWithBackoff();
+    const operation = vi.fn().mockResolvedValue(true);
+    const resultPromise = instance.execute({ operation });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/sdk/typescript/src/retry_with_backoff.ts
+++ b/sdk/typescript/src/retry_with_backoff.ts
@@ -1,0 +1,164 @@
+import type { StellarInsightsConfig } from "./types.js";
+import type {
+  RetryWithBackoffMetrics,
+  RetryWithBackoffParams,
+  RetryWithBackoffResult,
+} from "./types/retry_with_backoff.js";
+import { StellarInsightsError } from "./http.js";
+import { SDKError } from "./sdk_error.js";
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_INITIAL_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+const DEFAULT_RETRYABLE_STATUSES = [429, 500, 502, 503, 504];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class RetryWithBackoff {
+  private readonly config: StellarInsightsConfig;
+  private totalExecutions = 0;
+  private totalRetries = 0;
+  private totalFailures = 0;
+
+  constructor(config: StellarInsightsConfig = {}) {
+    this.config = config;
+  }
+
+  /**
+   * Execute an operation with exponential backoff retries on transient failures.
+   */
+  public async execute<T>(params: RetryWithBackoffParams<T>): Promise<RetryWithBackoffResult<T>> {
+    this.validateParams(params);
+
+    const maxRetries = params.maxRetries ?? this.config.maxRetries ?? DEFAULT_MAX_RETRIES;
+    const initialDelayMs = params.initialDelayMs ?? this.config.retryDelay ?? DEFAULT_INITIAL_DELAY_MS;
+    const maxDelayMs = params.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+    const jitter = params.jitter ?? true;
+    const retryableStatuses = new Set(params.retryableStatuses ?? DEFAULT_RETRYABLE_STATUSES);
+
+    this.totalExecutions++;
+
+    let attempt = 0;
+    let totalDelayMs = 0;
+
+    while (true) {
+      try {
+        const data = await params.operation();
+        const retried = attempt > 0;
+
+        if (retried) {
+          this.totalRetries += attempt;
+        }
+
+        return {
+          success: true,
+          data,
+          attempts: attempt + 1,
+          retried,
+          totalDelayMs,
+          operationKey: params.operationKey?.trim() || undefined,
+        };
+      } catch (error) {
+        const canRetry =
+          attempt < maxRetries &&
+          (params.shouldRetry?.(error, attempt) ??
+            RetryWithBackoff.isRetryableError(error, retryableStatuses));
+
+        if (!canRetry) {
+          this.totalFailures++;
+          if (error instanceof SDKError) throw error;
+          throw new SDKError("Operation failed after retries", {
+            params,
+            attempts: attempt + 1,
+            operationKey: params.operationKey,
+          }, { cause: error });
+        }
+
+        const delayMs = RetryWithBackoff.calculateDelay(attempt, initialDelayMs, maxDelayMs, jitter);
+        totalDelayMs += delayMs;
+        attempt++;
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  /** Calculate exponential backoff delay with optional jitter. */
+  public static calculateDelay(
+    attempt: number,
+    initialDelayMs: number,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    jitter = true,
+  ): number {
+    const exponential = initialDelayMs * 2 ** attempt;
+    const capped = Math.min(exponential, maxDelayMs);
+    if (!jitter) return capped;
+    return capped + Math.floor(Math.random() * Math.min(100, capped * 0.1));
+  }
+
+  /** Determine whether an error should be retried. */
+  public static isRetryableError(
+    error: unknown,
+    retryableStatuses: Set<number> = new Set(DEFAULT_RETRYABLE_STATUSES),
+  ): boolean {
+    if (error instanceof TypeError) {
+      return true;
+    }
+
+    if (error instanceof StellarInsightsError) {
+      if (retryableStatuses.has(error.status)) {
+        return true;
+      }
+      if (error.status >= 400 && error.status < 500) {
+        return false;
+      }
+      return error.status >= 500;
+    }
+
+    if (error instanceof SDKError) {
+      const status = error.details?.status;
+      if (typeof status === "number") {
+        if (retryableStatuses.has(status)) return true;
+        if (status >= 400 && status < 500) return false;
+        return status >= 500;
+      }
+    }
+
+    return false;
+  }
+
+  /** Snapshot of retry metrics for observability. */
+  public getMetrics(): RetryWithBackoffMetrics {
+    return {
+      totalExecutions: this.totalExecutions,
+      totalRetries: this.totalRetries,
+      totalFailures: this.totalFailures,
+    };
+  }
+
+  /** Reset retry metrics counters. */
+  public resetMetrics(): void {
+    this.totalExecutions = 0;
+    this.totalRetries = 0;
+    this.totalFailures = 0;
+  }
+
+  private validateParams<T>(params: RetryWithBackoffParams<T>): void {
+    if (!params || typeof params.operation !== "function") {
+      throw new SDKError("operation must be a function", { params });
+    }
+    if (params.maxRetries !== undefined && (typeof params.maxRetries !== "number" || params.maxRetries < 0)) {
+      throw new SDKError("maxRetries must be a non-negative number", { params });
+    }
+    if (
+      params.initialDelayMs !== undefined &&
+      (typeof params.initialDelayMs !== "number" || params.initialDelayMs <= 0)
+    ) {
+      throw new SDKError("initialDelayMs must be a positive number", { params });
+    }
+    if (params.maxDelayMs !== undefined && (typeof params.maxDelayMs !== "number" || params.maxDelayMs <= 0)) {
+      throw new SDKError("maxDelayMs must be a positive number", { params });
+    }
+  }
+}

--- a/sdk/typescript/src/types/retry_with_backoff.ts
+++ b/sdk/typescript/src/types/retry_with_backoff.ts
@@ -1,0 +1,33 @@
+export interface RetryWithBackoffParams<T = unknown> {
+  /** Async operation to execute with retries */
+  operation: () => Promise<T>;
+  /** Maximum retry attempts after the initial try (default: 3) */
+  maxRetries?: number;
+  /** Initial backoff delay in ms (default: 500) */
+  initialDelayMs?: number;
+  /** Cap for backoff delay in ms */
+  maxDelayMs?: number;
+  /** Add random jitter to backoff delays (default: true) */
+  jitter?: boolean;
+  /** HTTP status codes that should trigger a retry */
+  retryableStatuses?: number[];
+  /** Optional custom retry predicate */
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  /** Optional label for observability */
+  operationKey?: string;
+}
+
+export interface RetryWithBackoffResult<T = unknown> {
+  success: true;
+  data: T;
+  attempts: number;
+  retried: boolean;
+  totalDelayMs: number;
+  operationKey?: string;
+}
+
+export interface RetryWithBackoffMetrics {
+  totalExecutions: number;
+  totalRetries: number;
+  totalFailures: number;
+}


### PR DESCRIPTION
Closes #1389

## Summary

This PR adds a `RetryWithBackoff` module to the TypeScript SDK so web and React Native clients can reliably handle transient API failures without duplicating retry logic.

**What it does**
- Wraps any async `operation` with configurable exponential backoff and jitter
- Retries on network errors, 429 rate limits, and 5xx server errors
- Skips retry for non-retryable 4xx responses (e.g. 404, 401)
- Returns attempt count, total delay, and whether retries were used
- Exposes static helpers for delay calculation and error classification

**Why it matters**
Mobile and web clients hit flaky networks and overloaded APIs constantly. Centralizing retry logic with sane defaults keeps request handling consistent across the SDK and apps that consume it.

## Changes

- `sdk/typescript/src/retry_with_backoff.ts` — core retry engine
- `sdk/typescript/src/types/retry_with_backoff.ts` — params, result, and metrics types
- `sdk/typescript/src/retry_with_backoff.test.ts` — 16 unit tests
- `sdk/typescript/src/index.ts` — public exports
- `sdk/typescript/package.json` — keyword update

## Test plan

- [x] `npm test -- src/retry_with_backoff.test.ts` — 16/16 passing
- [x] Succeeds on first attempt with no delay
- [x] Retries 503/502/429 and succeeds on later attempt
- [x] Does not retry 404 or other non-retryable 4xx
- [x] Retries `TypeError` network failures
- [x] Throws `SDKError` after max retries exhausted
- [x] Custom `shouldRetry` predicate respected
- [x] `calculateDelay` exponential backoff and cap verified
- [x] Metrics track executions, retries, and failures