### PR TITLE
feat: batch endpoints (#1372)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -52,6 +52,7 @@ use stellar_insights_backend::{
         DatabaseSchemaSeparation, WebSocketRealTimeUpdates, ApiVersioning,
         DeprecationWarnings, MobileRequestLogging,
         ConcurrencyLimitState, concurrency_limit_middleware, panic_recovery_middleware,
+        BatchEndpoints,
     },
 };
 
@@ -191,6 +192,7 @@ async fn main() -> anyhow::Result<()> {
     let _api_versioning = ApiVersioning::new(Default::default());
     let _deprecation_warnings = DeprecationWarnings::new(Default::default());
     let _mobile_request_logging = MobileRequestLogging::new(Default::default());
+    let _batch_endpoints = BatchEndpoints::new(Default::default());
 
     let fee_bump_tracker = services.fee_bump_tracker;
     let account_merge_detector = services.account_merge_detector;

--- a/backend/src/middleware/batch_endpoints.rs
+++ b/backend/src/middleware/batch_endpoints.rs
@@ -1,0 +1,196 @@
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::models::{
+    batch_endpoints::{BatchConfig, BatchItemResult, BatchRequest, BatchResponse},
+    network_context_middleware::NetworkContext,
+};
+
+#[derive(Clone)]
+pub struct BatchEndpoints {
+    config: BatchConfig,
+    /// Running count of total items processed across all batches.
+    state: Arc<RwLock<u64>>,
+}
+
+impl BatchEndpoints {
+    pub fn new(config: BatchConfig) -> Self {
+        Self {
+            config,
+            state: Arc::new(RwLock::new(0)),
+        }
+    }
+
+    /// Process a batch of items using the provided per-item handler.
+    ///
+    /// Returns an error only for structural problems (e.g. batch too large).
+    /// Individual item failures are captured inside [`BatchItemResult`].
+    pub async fn process<T, U, F>(
+        &self,
+        context: &NetworkContext,
+        request: BatchRequest<T>,
+        mut handler: F,
+    ) -> Result<BatchResponse<U>>
+    where
+        T: Serialize,
+        U: Serialize,
+        F: FnMut(usize, T) -> Result<U>,
+    {
+        let total = request.items.len();
+
+        if total > self.config.max_batch_size {
+            bail!(
+                "Batch size {} exceeds maximum of {}",
+                total,
+                self.config.max_batch_size
+            );
+        }
+
+        let mut results = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        for (index, item) in request.items.into_iter().enumerate() {
+            match handler(index, item) {
+                Ok(data) => {
+                    succeeded += 1;
+                    results.push(BatchItemResult {
+                        index,
+                        success: true,
+                        data: Some(data),
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    failed += 1;
+                    tracing::warn!(
+                        network = ?context.network,
+                        index,
+                        error = %e,
+                        "Batch item failed"
+                    );
+                    results.push(BatchItemResult {
+                        index,
+                        success: false,
+                        data: None,
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        }
+
+        let mut count = self.state.write().await;
+        *count += total as u64;
+
+        tracing::info!(
+            network = ?context.network,
+            total,
+            succeeded,
+            failed,
+            total_processed = *count,
+            "Batch processed"
+        );
+
+        Ok(BatchResponse {
+            results,
+            total,
+            succeeded,
+            failed,
+        })
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instance() -> BatchEndpoints {
+        BatchEndpoints::new(BatchConfig::default())
+    }
+
+    #[tokio::test]
+    async fn test_basic_functionality() {
+        let inst = instance();
+        let ctx = NetworkContext::testnet();
+        let req = BatchRequest { items: vec![1u32, 2, 3] };
+        let result = inst.process(&ctx, req, |_, v| Ok(v * 2)).await;
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert_eq!(resp.total, 3);
+        assert_eq!(resp.succeeded, 3);
+        assert_eq!(resp.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_mainnet_supported() {
+        let inst = instance();
+        let ctx = NetworkContext::mainnet();
+        let req = BatchRequest { items: vec!["a", "b"] };
+        let result = inst.process(&ctx, req, |_, v| Ok(v.to_uppercase())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_partial_failures_captured() {
+        let inst = instance();
+        let ctx = NetworkContext::testnet();
+        let req = BatchRequest { items: vec![0u32, 1, 2] };
+        let result = inst
+            .process(&ctx, req, |_, v| {
+                if v == 0 {
+                    bail!("zero not allowed")
+                } else {
+                    Ok(v)
+                }
+            })
+            .await;
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert_eq!(resp.total, 3);
+        assert_eq!(resp.succeeded, 2);
+        assert_eq!(resp.failed, 1);
+        assert!(!resp.results[0].success);
+        assert_eq!(resp.results[0].error.as_deref(), Some("zero not allowed"));
+    }
+
+    #[tokio::test]
+    async fn test_exceeds_max_batch_size_returns_error() {
+        let inst = BatchEndpoints::new(BatchConfig { max_batch_size: 2 });
+        let ctx = NetworkContext::testnet();
+        let req = BatchRequest { items: vec![1, 2, 3] };
+        let result = inst.process(&ctx, req, |_, v: i32| Ok(v)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
+    }
+
+    #[tokio::test]
+    async fn test_empty_batch_succeeds() {
+        let inst = instance();
+        let ctx = NetworkContext::testnet();
+        let req: BatchRequest<i32> = BatchRequest { items: vec![] };
+        let result = inst.process(&ctx, req, |_, v| Ok(v)).await;
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert_eq!(resp.total, 0);
+        assert_eq!(resp.succeeded, 0);
+        assert_eq!(resp.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_result_indices_are_correct() {
+        let inst = instance();
+        let ctx = NetworkContext::testnet();
+        let req = BatchRequest { items: vec!["x", "y", "z"] };
+        let resp = inst
+            .process(&ctx, req, |_, v| Ok(v.to_string()))
+            .await
+            .unwrap();
+        for (i, item) in resp.results.iter().enumerate() {
+            assert_eq!(item.index, i);
+        }
+    }
+}

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -7,6 +7,7 @@ pub mod api_versioning;
 pub mod deprecation_warnings;
 pub mod mobile_request_logging;
 pub mod concurrency_limit;
+pub mod batch_endpoints;
 
 pub use network_context_middleware::NetworkContextMiddleware;
 pub use network_aware_rpc_client::NetworkAwareRpcClient;
@@ -17,3 +18,4 @@ pub use api_versioning::ApiVersioning;
 pub use deprecation_warnings::DeprecationWarnings;
 pub use mobile_request_logging::MobileRequestLogging;
 pub use concurrency_limit::{ConcurrencyLimitState, concurrency_limit_middleware, panic_recovery_middleware};
+pub use batch_endpoints::BatchEndpoints;

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -23,6 +23,7 @@ pub mod websocket_streaming_models;
 pub mod redis_caching_models;
 pub mod elasticsearch_integration;
 pub mod message_queue_system;
+pub mod batch_endpoints;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/backend/src/models/batch_endpoints.rs
+++ b/backend/src/models/batch_endpoints.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BatchConfig {
+    /// Maximum number of items allowed in a single batch request
+    pub max_batch_size: usize,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self { max_batch_size: 100 }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchRequest<T> {
+    pub items: Vec<T>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchItemResult<T> {
+    pub index: usize,
+    pub success: bool,
+    pub data: Option<T>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchResponse<T> {
+    pub results: Vec<BatchItemResult<T>>,
+    pub total: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+}


### PR DESCRIPTION
## Summary
Implements batch endpoints for the backend, closing #1372.

## Changes
- **New** `backend/src/models/batch_endpoints.rs` — `BatchConfig`, `BatchRequest`, `BatchItemResult`, `BatchResponse` generic types
- **New** `backend/src/middleware/batch_endpoints.rs` — `BatchEndpoints` middleware with generic `process()`
- **Modified** `backend/src/middleware/mod.rs` — registers and re-exports `BatchEndpoints`
- **Modified** `backend/src/models.rs` — registers `batch_endpoints` module
- **Modified** `backend/src/main.rs` — imports and instantiates `BatchEndpoints`

## Acceptance criteria
- [x] Core batch endpoints functionality implemented
- [x] Testnet and mainnet both supported
- [x] Per-item errors captured in result, batch never fails mid-flight
- [x] Batch size limit validated upfront with clear error
- [x] All operations logged with network context via `tracing`
- [x] No `unwrap`/`expect`; all errors via `Result`
- [x] 6 unit tests: basic, mainnet, partial failure, size limit, empty batch, index correctness