### PR TITLE
fix(security): HSTS headers, Argon2 API key hashing, CSV injection, network isolation test

### DIFF
--- a/backend/migrations/031_rehash_api_keys.sql
+++ b/backend/migrations/031_rehash_api_keys.sql
@@ -1,0 +1,6 @@
+-- Existing API keys were hashed with SHA-256 which is incompatible with the
+-- new Argon2id scheme. Revoke all active keys so users re-issue fresh ones
+-- that will be stored with Argon2id.
+UPDATE api_keys
+SET status = 'revoked', revoked_at = datetime('now')
+WHERE status = 'active';

--- a/backend/src/api/export.rs
+++ b/backend/src/api/export.rs
@@ -18,6 +18,16 @@ use crate::error::{ApiError, ApiResult};
 use crate::models::PaymentRow;
 use crate::state::AppState;
 
+/// Prefix any cell that begins with a formula-trigger character so spreadsheet
+/// applications treat it as literal text instead of executing it as a formula.
+fn sanitize_csv_field(value: String) -> String {
+    if value.starts_with(['=', '+', '-', '@', '\t', '\r']) {
+        format!("'{value}")
+    } else {
+        value
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ExportQuery {
     pub format: String, // "csv", "json", "excel"
@@ -68,11 +78,11 @@ pub async fn export_corridors(
 
             for m in corridors {
                 wtr.write_record(&[
-                    m.corridor_key,
-                    m.source_asset_code,
-                    m.source_asset_issuer,
-                    m.destination_asset_code,
-                    m.destination_asset_issuer,
+                    sanitize_csv_field(m.corridor_key),
+                    sanitize_csv_field(m.source_asset_code),
+                    sanitize_csv_field(m.source_asset_issuer),
+                    sanitize_csv_field(m.destination_asset_code),
+                    sanitize_csv_field(m.destination_asset_issuer),
                     format!("{:.2}", m.avg_success_rate),
                     m.total_transactions.to_string(),
                     m.successful_transactions.to_string(),
@@ -232,16 +242,16 @@ pub async fn export_anchors(
 
             for a in anchors {
                 wtr.write_record(&[
-                    a.id,
-                    a.name,
-                    a.stellar_account,
-                    a.home_domain.unwrap_or_default(),
+                    sanitize_csv_field(a.id),
+                    sanitize_csv_field(a.name),
+                    sanitize_csv_field(a.stellar_account),
+                    sanitize_csv_field(a.home_domain.unwrap_or_default()),
                     format!("{:.2}", a.reliability_score),
                     a.total_transactions.to_string(),
                     a.successful_transactions.to_string(),
                     a.failed_transactions.to_string(),
                     format!("{:.2}", a.total_volume_usd),
-                    a.status,
+                    sanitize_csv_field(a.status),
                     a.updated_at.to_rfc3339(),
                 ])
                 .map_err(|e| ApiError::internal("EXPORT_ERROR", e.to_string()))?;
@@ -410,14 +420,17 @@ pub async fn export_payments(
 
             for p in payments {
                 wtr.write_record(&[
-                    p.transaction_hash,
-                    p.source_account,
-                    p.destination_account,
-                    format!("{}:{}", p.source_asset_code, p.source_asset_issuer),
-                    format!(
+                    sanitize_csv_field(p.transaction_hash),
+                    sanitize_csv_field(p.source_account),
+                    sanitize_csv_field(p.destination_account),
+                    sanitize_csv_field(format!(
+                        "{}:{}",
+                        p.source_asset_code, p.source_asset_issuer
+                    )),
+                    sanitize_csv_field(format!(
                         "{}:{}",
                         p.destination_asset_code, p.destination_asset_issuer
-                    ),
+                    )),
                     p.amount.to_string(),
                     p.successful.to_string(),
                     p.created_at.to_rfc3339(),

--- a/backend/src/db/api_keys.rs
+++ b/backend/src/db/api_keys.rs
@@ -247,27 +247,28 @@ impl ApiKeyDb {
     }
 
     /// Validates an API key using the plaintext key.
+    ///
+    /// Looks up candidates by stored prefix (fast), then verifies each one
+    /// with Argon2 (slow, intentional). This avoids a full-table scan while
+    /// keeping Argon2's brute-force resistance.
     #[tracing::instrument(skip(self, plain_key))]
     pub async fn validate_api_key(&self, plain_key: &str) -> Result<Option<ApiKey>> {
-        use crate::models::api_key::hash_api_key;
-        let key_hash = hash_api_key(plain_key);
+        use crate::models::api_key::{extract_key_prefix, verify_api_key};
 
-        let key = sqlx::query_as::<_, ApiKey>(
-            "SELECT * FROM api_keys WHERE key_hash = $1 AND status = 'active'",
+        let prefix = extract_key_prefix(plain_key);
+
+        let candidates = sqlx::query_as::<_, ApiKey>(
+            "SELECT * FROM api_keys WHERE key_prefix = $1 AND status = 'active'",
         )
-        .bind(&key_hash)
-        .fetch_optional(&self.pool)
+        .bind(&prefix)
+        .fetch_all(&self.pool)
         .await
-        .context("Failed to validate API key")?;
+        .context("Failed to query API keys by prefix")?;
 
-        if let Some(ref k) = key {
+        for k in candidates {
             if let Some(ref expires_at) = k.expires_at {
                 match DateTime::parse_from_rfc3339(expires_at) {
-                    Ok(exp) => {
-                        if exp < Utc::now() {
-                            return Ok(None);
-                        }
-                    }
+                    Ok(exp) if exp < Utc::now() => continue,
                     Err(e) => {
                         tracing::warn!(
                             "API key {} has malformed expires_at '{}': {}. Treating as expired.",
@@ -275,19 +276,23 @@ impl ApiKeyDb {
                             expires_at,
                             e
                         );
-                        return Ok(None);
+                        continue;
                     }
+                    _ => {}
                 }
             }
 
-            // last_used_at update is best-effort
-            let _ = sqlx::query("UPDATE api_keys SET last_used_at = $1 WHERE id = $2")
-                .bind(Utc::now().to_rfc3339())
-                .bind(&k.id)
-                .execute(&self.pool)
-                .await;
+            if verify_api_key(plain_key, &k.key_hash) {
+                // best-effort last_used_at update
+                let _ = sqlx::query("UPDATE api_keys SET last_used_at = $1 WHERE id = $2")
+                    .bind(Utc::now().to_rfc3339())
+                    .bind(&k.id)
+                    .execute(&self.pool)
+                    .await;
+                return Ok(Some(k));
+            }
         }
 
-        Ok(key)
+        Ok(None)
     }
 }

--- a/backend/src/models/api_key.rs
+++ b/backend/src/models/api_key.rs
@@ -1,5 +1,8 @@
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 use validator::Validate;
 
@@ -71,14 +74,39 @@ pub struct CreateApiKeyResponse {
 pub fn generate_api_key() -> (String, String, String) {
     let raw = Uuid::new_v4().to_string().replace('-', "");
     let plain_key = format!("si_live_{raw}");
-    let prefix = format!("si_live_{}...", &raw[..8.min(raw.len())]);
+    let prefix = extract_key_prefix(&plain_key);
     let hash = hash_api_key(&plain_key);
     (plain_key, prefix, hash)
 }
 
+/// Returns the stored prefix used for efficient DB lookup before Argon2 verify.
+#[must_use]
+pub fn extract_key_prefix(plain_key: &str) -> String {
+    // plain_key format: "si_live_<32-char uuid without hyphens>"
+    // We store the first 16 chars + "..." as the prefix.
+    let end = plain_key.len().min(16);
+    format!("{}...", &plain_key[..end])
+}
+
+/// Hash an API key with Argon2id. The PHC-format hash embeds the salt so
+/// it can be verified later with `verify_api_key`.
 #[must_use]
 pub fn hash_api_key(plain_key: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(plain_key.as_bytes());
-    hex::encode(hasher.finalize())
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(plain_key.as_bytes(), &salt)
+        .expect("argon2 hash failed")
+        .to_string()
+}
+
+/// Verify a plaintext key against a stored Argon2id PHC hash.
+#[must_use]
+pub fn verify_api_key(plain_key: &str, stored_hash: &str) -> bool {
+    let parsed = match PasswordHash::new(stored_hash) {
+        Ok(h) => h,
+        Err(_) => return false,
+    };
+    Argon2::default()
+        .verify_password(plain_key.as_bytes(), &parsed)
+        .is_ok()
 }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -34,6 +34,11 @@ const analyzer = withBundleAnalyzer({
  */
 const securityHeaders = [
   {
+    // HSTS: enforce HTTPS for 2 years across all subdomains and opt into preload list
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
     key: "Content-Security-Policy",
     value: [
       "default-src 'self'",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/acceptance",
+  timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/acceptance/network_isolation_test.ts
+++ b/tests/acceptance/network_isolation_test.ts
@@ -1,0 +1,113 @@
+/**
+ * Acceptance test: testnet ↔ mainnet data isolation
+ *
+ * Verifies that a transaction submitted on testnet never leaks into the
+ * mainnet dashboard view and reappears correctly when switching back.
+ *
+ * Requires a running dev server (BASE_URL env var, default http://localhost:3000).
+ */
+import { test, expect, Page } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
+
+// Selectors — adjust if the markup changes.
+const NETWORK_SWITCHER = '[data-testid="network-switcher"]';
+const NETWORK_OPTION = (name: "testnet" | "mainnet") =>
+  `[data-testid="network-option-${name}"]`;
+const CONFIRM_SWITCH_BTN = '[data-testid="confirm-network-switch"]';
+const TRANSACTION_LIST = '[data-testid="transaction-list"]';
+const TRANSACTION_ITEM = '[data-testid="transaction-item"]';
+
+// Unique memo used to identify the synthetic testnet transaction.
+const TEST_MEMO = `isolation-test-${Date.now()}`;
+
+async function switchNetwork(page: Page, target: "testnet" | "mainnet") {
+  await page.click(NETWORK_SWITCHER);
+  await page.click(NETWORK_OPTION(target));
+  // The NetworkSwitcher shows a confirmation warning before switching.
+  await page.click(CONFIRM_SWITCH_BTN);
+  await page.waitForResponse((res) =>
+    res.url().includes("/api/network/switch") && res.status() === 200
+  );
+}
+
+async function injectTestnetTransaction(page: Page): Promise<void> {
+  // POST a synthetic payment to the backend test-seeding endpoint so the
+  // dashboard can display it without requiring a real Stellar wallet.
+  const response = await page.request.post(`${BASE_URL}/api/test/seed-transaction`, {
+    data: {
+      network: "testnet",
+      memo: TEST_MEMO,
+      source_account: "TESTNET_SEED_ACCOUNT",
+      destination_account: "TESTNET_DEST_ACCOUNT",
+      amount: "1.0000000",
+      asset_code: "XLM",
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+}
+
+async function transactionVisible(page: Page): Promise<boolean> {
+  const items = page.locator(TRANSACTION_ITEM);
+  const count = await items.count();
+  for (let i = 0; i < count; i++) {
+    const text = await items.nth(i).textContent();
+    if (text?.includes(TEST_MEMO)) return true;
+  }
+  return false;
+}
+
+test.describe("Network switchover — testnet → mainnet data isolation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE_URL);
+  });
+
+  test("testnet transaction is visible on testnet dashboard", async ({ page }) => {
+    // Ensure we start on testnet.
+    await switchNetwork(page, "testnet");
+
+    await injectTestnetTransaction(page);
+
+    await page.goto(`${BASE_URL}/dashboard`);
+    await page.waitForSelector(TRANSACTION_LIST);
+
+    expect(await transactionVisible(page)).toBe(true);
+  });
+
+  test("testnet transaction is NOT visible after switching to mainnet", async ({
+    page,
+  }) => {
+    // Start on testnet and seed the transaction.
+    await switchNetwork(page, "testnet");
+    await injectTestnetTransaction(page);
+
+    // Switch to mainnet.
+    await switchNetwork(page, "mainnet");
+
+    await page.goto(`${BASE_URL}/dashboard`);
+    await page.waitForSelector(TRANSACTION_LIST);
+
+    expect(await transactionVisible(page)).toBe(false);
+  });
+
+  test("testnet transaction reappears after switching back to testnet", async ({
+    page,
+  }) => {
+    // Seed the transaction on testnet.
+    await switchNetwork(page, "testnet");
+    await injectTestnetTransaction(page);
+
+    // Switch to mainnet, verify it's gone.
+    await switchNetwork(page, "mainnet");
+    await page.goto(`${BASE_URL}/dashboard`);
+    await page.waitForSelector(TRANSACTION_LIST);
+    expect(await transactionVisible(page)).toBe(false);
+
+    // Switch back to testnet.
+    await switchNetwork(page, "testnet");
+    await page.goto(`${BASE_URL}/dashboard`);
+    await page.waitForSelector(TRANSACTION_LIST);
+
+    expect(await transactionVisible(page)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **#1721** — Add `Strict-Transport-Security` (HSTS) header to `frontend/next.config.ts`; enforces HTTPS for 2 years with `includeSubDomains` and `preload`.
- **#1717** — Replace SHA-256 API key hashing with Argon2id in `backend/src/models/api_key.rs` and `backend/src/db/api_keys.rs`; lookup now queries by stored prefix then verifies with Argon2. Migration `031_rehash_api_keys.sql` revokes all existing keys so users re-issue under the new scheme.
- **#1718** — Sanitize user-controlled CSV fields in `backend/src/api/export.rs` to prevent formula injection; any value starting with `=`, `+`, `-`, `@`, `\t`, or `\r` is prefixed with `'` before writing.
- **#1722** — Add Playwright acceptance test `tests/acceptance/network_isolation_test.ts` verifying testnet/mainnet data isolation across network switches.

## Closes

Closes #1717
Closes #1718
Closes #1721
Closes #1722

## Test plan

- [ ] Build frontend: HSTS header present in response for all routes
- [ ] Run backend: create API key, verify Argon2 PHC string stored in DB, validate with plaintext key
- [ ] Export CSV from corridors/anchors/payments endpoint; open in spreadsheet and confirm formula-trigger cells are escaped
- [ ] Run `npx playwright test tests/acceptance/network_isolation_test.ts` against local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)