### PR TITLE
feat: implement OpenAPI specification generation and integrate

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,23 @@
+name: OpenAPI Check
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  check-openapi:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Generate OpenAPI spec
+      working-directory: ./backend
+      run: cargo run --bin generate_openapi
+    
+    - name: Verify committed openapi.json matches generated
+      run: git diff --exit-code docs/openapi.json

--- a/backend/src/api/snapshots.rs
+++ b/backend/src/api/snapshots.rs
@@ -5,13 +5,14 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{error, info};
+use utoipa::ToSchema;
 
 use crate::database::Database;
 use crate::services::contract::ContractService;
 use crate::services::snapshot::SnapshotService;
 
 /// Response for snapshot generation
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SnapshotResponse {
     pub epoch: u64,
     pub timestamp: String,
@@ -24,7 +25,7 @@ pub struct SnapshotResponse {
 }
 
 /// Submission information
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SubmissionInfo {
     pub transaction_hash: String,
     pub ledger: u64,
@@ -32,7 +33,7 @@ pub struct SubmissionInfo {
 }
 
 /// Request for snapshot generation
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GenerateSnapshotRequest {
     pub epoch: u64,
     #[serde(default)]
@@ -50,6 +51,16 @@ pub struct SnapshotAppState {
 /// Generate a snapshot (optionally submit to contract)
 ///
 /// POST /api/snapshots/generate
+#[utoipa::path(
+    post,
+    path = "/api/snapshots/generate",
+    request_body = GenerateSnapshotRequest,
+    responses(
+        (status = 200, description = "Snapshot generated successfully", body = SnapshotResponse),
+        (status = 500, description = "Snapshot generation failed")
+    ),
+    tag = "Snapshots"
+)]
 pub async fn generate_snapshot(
     State(state): State<SnapshotAppState>,
     Json(request): Json<GenerateSnapshotRequest>,
@@ -105,6 +116,16 @@ pub async fn generate_snapshot(
 /// Health check for contract service
 ///
 /// GET /api/snapshots/contract/health
+#[utoipa::path(
+    get,
+    path = "/api/snapshots/contract/health",
+    responses(
+        (status = 200, description = "Contract service health status", body = ContractHealthResponse),
+        (status = 500, description = "Config error"),
+        (status = 503, description = "Connection error")
+    ),
+    tag = "Snapshots"
+)]
 pub async fn contract_health_check(
     State(state): State<SnapshotAppState>,
 ) -> Result<Json<ContractHealthResponse>, SnapshotError> {
@@ -124,7 +145,7 @@ pub async fn contract_health_check(
     }))
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ContractHealthResponse {
     pub status: &'static str,
     pub timestamp: String,

--- a/backend/src/bin/generate_openapi.rs
+++ b/backend/src/bin/generate_openapi.rs
@@ -1,0 +1,21 @@
+use stellar_insights_backend::openapi::ApiDoc;
+use utoipa::OpenApi;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let json = ApiDoc::openapi()
+        .to_pretty_json()
+        .expect("Failed to serialize OpenAPI spec");
+    
+    let path = if Path::new("../docs").exists() {
+        "../docs/openapi.json"
+    } else {
+        "docs/openapi.json"
+    };
+    
+    let mut file = File::create(path).expect("Failed to create docs/openapi.json");
+    file.write_all(json.as_bytes()).expect("Failed to write to docs/openapi.json");
+    println!("Successfully generated OpenAPI spec at {}", path);
+}

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -162,6 +162,9 @@ use utoipa::OpenApi;
         crate::api::verification_rewards::get_leaderboard,
         crate::api::verification_rewards::get_user_verifications,
         crate::api::verification_rewards::get_public_user_stats,
+        // Snapshots
+        crate::api::snapshots::generate_snapshot,
+        crate::api::snapshots::contract_health_check,
     ),
     components(
         schemas(
@@ -182,6 +185,10 @@ use utoipa::OpenApi;
             crate::api::cost_calculator::RouteEstimate,
             crate::api::cost_calculator::CostCalculationResponse,
             crate::api::cost_calculator::ErrorResponse,
+            crate::api::snapshots::SnapshotResponse,
+            crate::api::snapshots::SubmissionInfo,
+            crate::api::snapshots::GenerateSnapshotRequest,
+            crate::api::snapshots::ContractHealthResponse,
         )
     ),
     tags(
@@ -214,6 +221,31 @@ use utoipa::OpenApi;
         (name = "SEP-10", description = "SEP-10 authentication endpoints"),
         (name = "SEP-24", description = "SEP-24 hosted deposit/withdrawal endpoints"),
         (name = "Verification Rewards", description = "Snapshot verification reward endpoints"),
+        (name = "Snapshots", description = "Snapshot generation and submission endpoints"),
     )
 )]
 pub struct ApiDoc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+
+    #[test]
+    fn generate_openapi_json() {
+        let json = ApiDoc::openapi()
+            .to_pretty_json()
+            .expect("Failed to serialize OpenAPI spec");
+        
+        let path = if Path::new("../docs").exists() {
+            "../docs/openapi.json"
+        } else {
+            "docs/openapi.json"
+        };
+        
+        let mut file = File::create(path).expect("Failed to create docs/openapi.json");
+        file.write_all(json.as_bytes()).expect("Failed to write to docs/openapi.json");
+    }
+}

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -55,8 +55,28 @@ Content-Type: application/json
 
 ### Payment Corridors
 - `GET /api/corridors` - List payment corridors
-- `GET /api/corridors/{source}/{destination}` - Get corridor details
-- `GET /api/corridors/{source}/{destination}/metrics` - Get corridor metrics
+- `GET /api/corridors/{corridor_key}` - Get corridor details
+
+### Contract Events
+- `GET /api/analytics/verification-summary` - Get smart contract verification summary
+- `GET /api/analytics/contract-events` - List contract events
+- `GET /api/analytics/contract-events/{id}` - Get details of a contract event
+- `GET /api/analytics/contract-events/epoch/{epoch}` - List contract events for a specific epoch
+- `GET /api/analytics/event-stats` - Get contract event statistics
+
+### SEP-31 Proxy
+- `GET /api/sep31/info` - Get SEP-31 anchor info
+- `POST /api/sep31/quote` - Create a SEP-31 payment quote
+- `POST /api/sep31/transactions` - Create a SEP-31 transaction
+- `GET /api/sep31/transactions` - List SEP-31 transactions
+- `GET /api/sep31/transactions/{id}` - Get a specific SEP-31 transaction
+- `GET /api/sep31/customer` - Get KYC customer information
+- `PUT /api/sep31/customer` - Update KYC customer information
+- `GET /api/sep31/anchors` - List configured SEP-31 anchors
+
+### Snapshots
+- `POST /api/snapshots/generate` - Generate a ledger state snapshot
+- `GET /api/snapshots/contract/health` - Check health of snapshot contract service
 
 ### Price Feed
 - `GET /api/prices` - Get current asset prices

--- a/docs/testnet-quickstart.md
+++ b/docs/testnet-quickstart.md
@@ -1,0 +1,132 @@
+# Testnet Quickstart Guide
+
+This guide describes how to connect the entire Stellar Insights stack (backend, frontend, mobile, contracts, and SDK examples) to the Stellar Testnet.
+
+## Fund a testnet account with Friendbot
+
+Before deploying contracts or making transactions, you need a funded Stellar account on the testnet.
+
+1. **Generate a new keypair**:
+   Using the Stellar CLI:
+   ```bash
+   stellar keys generate --network testnet my-identity
+   ```
+   Or using standard tools to obtain a Public Key (starting with `G`) and a Secret Key (starting with `S`).
+
+2. **Fund the account with Friendbot**:
+   You can fund your new account via the Stellar CLI:
+   ```bash
+   stellar keys fund my-identity --network testnet
+   ```
+   Alternatively, trigger Friendbot using `curl`:
+   ```bash
+   curl "https://friendbot.stellar.org/?addr=YOUR_STELLAR_PUBLIC_KEY"
+   ```
+
+---
+
+## Configure backend .env for testnet
+
+To configure the backend to read from the testnet:
+
+1. Copy `backend/.env.example` to `backend/.env`.
+2. Update the network environment variables:
+   ```ini
+   # Set network to testnet
+   STELLAR_NETWORK=testnet
+   STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+   
+   # SEP-10 server key (must start with G and be 56 characters)
+   SEP10_SERVER_PUBLIC_KEY=YOUR_TESTNET_PUBLIC_KEY
+   SEP10_HOME_DOMAIN=localhost:8080
+   ```
+3. Verify that the testnet RPC/Horizon endpoints are set correctly:
+   ```ini
+   STELLAR_RPC_URL_TESTNET=https://soroban-testnet.stellar.org
+   STELLAR_HORIZON_URL_TESTNET=https://horizon-testnet.stellar.org
+   ```
+
+---
+
+## Deploy contracts to testnet
+
+To deploy the Soroban contracts to the testnet:
+
+1. **Build the contracts**:
+   Navigate to the `contracts/` directory and compile the WASM targets:
+   ```bash
+   cd contracts
+   cargo build --target wasm32-unknown-unknown --release
+   ```
+
+2. **Deploy via Stellar CLI**:
+   Deploy the `stellar_insights` analytics contract to the testnet:
+   ```bash
+   stellar contract deploy \
+     --wasm target/wasm32-unknown-unknown/release/stellar_insights.wasm \
+     --source my-identity \
+     --network testnet
+   ```
+   Note the returned Contract ID (64-character hex string) for use in backend configuration.
+
+---
+
+## Run frontend against testnet API
+
+To point the Next.js frontend to the testnet backend API:
+
+1. Create a `frontend/.env.local` file.
+2. Set the backend API URL:
+   ```ini
+   NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+   NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
+   ```
+3. Run the development server:
+   ```bash
+   cd frontend
+   npm run dev
+   ```
+
+---
+
+## Run mobile app against testnet
+
+To run the React Native mobile app pointing to the testnet:
+
+1. Copy `mobile/.env.example` to `mobile/.env`.
+2. Configure the backend API URL and the Stellar network settings:
+   ```ini
+   # API Configuration pointing to local backend (or deployed staging backend)
+   # For Android emulator, use 10.0.2.2 instead of localhost
+   API_BASE_URL=http://localhost:8080/api/v1
+   
+   # Stellar Network Configuration
+   STELLAR_NETWORK=testnet
+   STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+   ```
+3. Run the mobile application:
+   ```bash
+   cd mobile
+   npm run android  # or npm run ios
+   ```
+
+---
+
+## Run SDK examples against testnet
+
+To run SDK examples pointing to the testnet:
+
+1. Verify that your SDK configuration imports the testnet passphrase and endpoint.
+2. Example script usage:
+   ```javascript
+   import { StellarSdk } from '@stellar-insights/sdk';
+   
+   const sdk = new StellarSdk({
+     network: 'testnet',
+     rpcUrl: 'https://soroban-testnet.stellar.org',
+     horizonUrl: 'https://horizon-testnet.stellar.org'
+   });
+   
+   // Run your integration script
+   await sdk.fetchCorridors();
+   ```

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -54,6 +54,13 @@ export function useWebSocket(
     ConnectionState.DISCONNECTED
   );
 
+  const [appState, setAppState] = useState<"active" | "background">("active");
+  const appStateRef = useRef<"active" | "background">("active");
+
+  useEffect(() => {
+    appStateRef.current = appState;
+  }, [appState]);
+
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const shouldReconnectRef = useRef(true);
@@ -94,10 +101,11 @@ export function useWebSocket(
         isConnectingRef.current = false;
         onClose?.();
 
-        // Attempt to reconnect if enabled and under max attempts
+        // Attempt to reconnect if enabled, under max attempts, and not in background
         if (
           shouldReconnectRef.current &&
-          connectionAttempts < maxReconnectAttempts
+          connectionAttempts < maxReconnectAttempts &&
+          appStateRef.current !== "background"
         ) {
           setConnectionAttempts((prev) => prev + 1);
           reconnectTimeoutRef.current = setTimeout(
@@ -212,6 +220,43 @@ export function useWebSocket(
       disconnect();
     };
   }, [connect, disconnect]);
+
+  // Handle visibility change (background/foreground)
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      const nextState = document.visibilityState === "hidden" ? "background" : "active";
+      const prevState = appStateRef.current;
+
+      if (nextState === prevState) return;
+
+      setAppState(nextState);
+
+      if (nextState === "active" && prevState === "background") {
+        logger.debug("App active. Resuming WebSocket reconnection with exponential backoff.");
+        if (shouldReconnectRef.current && !isConnected && !isConnectingRef.current) {
+          const delay = reconnectInterval * Math.pow(1.5, connectionAttempts);
+          if (reconnectTimeoutRef.current) {
+            clearTimeout(reconnectTimeoutRef.current);
+          }
+          reconnectTimeoutRef.current = setTimeout(() => {
+            connect();
+          }, delay);
+          setConnectionAttempts((prev) => prev + 1);
+        }
+      } else if (nextState === "background") {
+        logger.debug("App in background. Pausing WebSocket reconnection.");
+        if (reconnectTimeoutRef.current) {
+          clearTimeout(reconnectTimeoutRef.current);
+          reconnectTimeoutRef.current = null;
+        }
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [connect, isConnected, connectionAttempts, reconnectInterval]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -3,7 +3,7 @@ import { StatusBar } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { NavigationContainer, LinkingOptions } from '@react-navigation/native';
+import { NavigationContainer, LinkingOptions, getStateFromPath } from '@react-navigation/native';
 import NetInfo from '@react-native-community/netinfo';
 import { RootNavigator } from './navigation/RootNavigator';
 import type { RootStackParamList } from './navigation/RootNavigator';
@@ -67,7 +67,45 @@ const linking: LinkingOptions<RootStackParamList> = {
           Login: 'login',
         },
       },
+      Error: 'error',
     },
+  },
+  getStateFromPath(path, options) {
+    const matchAnchor = path.match(/anchors\/([^\/]+)/);
+    if (matchAnchor) {
+      const anchorId = matchAnchor[1];
+      if (!/^[A-F0-9]{64}$/i.test(anchorId)) {
+        return {
+          routes: [
+            {
+              name: 'Error',
+              params: {
+                message: 'Invalid Anchor ID. Deep links must contain a 64-character hexadecimal ID.',
+              },
+            },
+          ],
+        };
+      }
+    }
+
+    const matchCorridor = path.match(/corridors\/([^\/]+)/);
+    if (matchCorridor) {
+      const corridorId = matchCorridor[1];
+      if (!/^[A-F0-9]{64}$/i.test(corridorId)) {
+        return {
+          routes: [
+            {
+              name: 'Error',
+              params: {
+                message: 'Invalid Corridor ID. Deep links must contain a 64-character hexadecimal ID.',
+              },
+            },
+          ],
+        };
+      }
+    }
+
+    return getStateFromPath(path, options);
   },
 };
 

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -4,10 +4,12 @@ import { useAuthStore } from '@store/authStore';
 import { SplashScreen } from '@components/SplashScreen';
 import { AuthNavigator } from './AuthNavigator';
 import { MainNavigator } from './MainNavigator';
+import { ErrorScreen } from '../screens/ErrorScreen';
 
 export type RootStackParamList = {
   Auth: undefined;
   Main: undefined;
+  Error: { message: string };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -26,6 +28,11 @@ export function RootNavigator() {
       ) : (
         <Stack.Screen name="Auth" component={AuthNavigator} />
       )}
+      <Stack.Screen
+        name="Error"
+        component={ErrorScreen}
+        options={{ headerShown: true, title: 'Error' }}
+      />
     </Stack.Navigator>
   );
 }

--- a/mobile/src/screens/ErrorScreen.tsx
+++ b/mobile/src/screens/ErrorScreen.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { RootStackParamList } from '../navigation/RootNavigator';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+type ErrorScreenRouteProp = RouteProp<RootStackParamList, 'Error'>;
+type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Error'>;
+
+export function ErrorScreen() {
+  const route = useRoute<ErrorScreenRouteProp>();
+  const navigation = useNavigation<NavigationProp>();
+  const message = route.params?.message ?? 'An invalid deep link was provided.';
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Invalid Link</Text>
+        <Text style={styles.message}>{message}</Text>
+        <Pressable
+          onPress={() => navigation.navigate('Main')}
+          style={styles.button}
+          accessibilityRole="button"
+          accessibilityLabel="Go to main dashboard"
+        >
+          <Text style={styles.buttonText}>Go to Dashboard</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FAFAFA',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 24,
+    width: '100%',
+    maxWidth: 340,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#FCA5A5',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#DC2626',
+    marginBottom: 12,
+  },
+  message: {
+    fontSize: 14,
+    color: '#4B5563',
+    textAlign: 'center',
+    marginBottom: 20,
+    lineHeight: 20,
+  },
+  button: {
+    backgroundColor: '#DC2626',
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
### Summary of Changes

- **Frontend**: Modified `useWebSocket` hook to pause reconnection in background mode (`visibilitychange` hidden state) and resume with exponential backoff on active.
- **Mobile**: Added deep link parameter validation (`/^[A-F0-9]{64}$/i`) for `:anchorId` and `:corridorId` in the linking configuration, routing malformed links to a new `ErrorScreen`.
- **Backend API & OpenAPI**:
  - Added `utoipa` path and schema annotations to snapshot endpoints in `snapshots.rs`.
  - Added `generate_openapi` binary, a unit test, and a GitHub Actions workflow to check and auto-generate `docs/openapi.json`.
  - Corrected endpoints and documented Contract Events, SEP-31 Proxy, and Snapshots in `docs/API_DOCUMENTATION.md`.
- **Docs**: Created `docs/testnet-quickstart.md` quickstart guide for testnet integration.


Closes: #1704
Closes: #1705
Closes: #1709
Closes: #1710