### PR TITLE
feat: fix collab conflicts, add 503 retry, E2E testnet tests, export …

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/__tests__/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'pnpm dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: true,
+      },
+});

--- a/frontend/src/__tests__/e2e/dashboard-realtime.test.ts
+++ b/frontend/src/__tests__/e2e/dashboard-realtime.test.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard — realtime updates on testnet', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/network/info', (route) =>
+      route.fulfill({
+        json: {
+          network: 'testnet',
+          display_name: 'Testnet',
+          rpc_url: 'https://soroban-testnet.stellar.org',
+          horizon_url: 'https://horizon-testnet.stellar.org',
+          network_passphrase: 'Test SDF Network ; September 2015',
+          color: '#4ECDC4',
+          is_mainnet: false,
+          is_testnet: true,
+        },
+      }),
+    );
+
+    await page.route('**/api/dashboard/**', (route) =>
+      route.fulfill({
+        json: {
+          kpis: {
+            totalVolume: '$1,234,567',
+            activeCorridors: 42,
+            avgSettlementTime: '3.2s',
+            liquidityDepth: '$890,123',
+          },
+          corridors: [],
+          topAssets: [],
+        },
+      }),
+    );
+
+    await page.route('**/api/corridors**', (route) =>
+      route.fulfill({
+        json: {
+          corridors: [
+            { id: 'c1', name: 'USD → EUR', volume: 500000, health: 'healthy' },
+            { id: 'c2', name: 'USD → NGN', volume: 250000, health: 'degraded' },
+          ],
+        },
+      }),
+    );
+  });
+
+  test('renders dashboard KPI cards', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await expect(page.locator('[class*="col-span"]').first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('testnet badge or indicator is visible on dashboard', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const testnetIndicator = page.getByText(/testnet/i).first();
+    await expect(testnetIndicator).toBeVisible({ timeout: 10000 });
+  });
+
+  test('dashboard updates when new data arrives via polling', async ({ page }) => {
+    let callCount = 0;
+    await page.route('**/api/dashboard/**', async (route) => {
+      callCount++;
+      const volume = callCount === 1 ? '$1,000,000' : '$2,000,000';
+      await route.fulfill({
+        json: {
+          kpis: {
+            totalVolume: volume,
+            activeCorridors: 42,
+            avgSettlementTime: '3.2s',
+            liquidityDepth: '$890,123',
+          },
+          corridors: [],
+          topAssets: [],
+        },
+      });
+    });
+
+    await page.goto('/dashboard');
+
+    await page.waitForTimeout(2000);
+
+    await expect(async () => {
+      expect(callCount).toBeGreaterThanOrEqual(1);
+    }).toPass();
+  });
+
+  test('WebSocket connection status is reflected in UI', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const wsStatus = page.locator(
+      '[class*="connected"], [class*="disconnected"], [data-testid="ws-status"]',
+    );
+
+    if (await wsStatus.count() > 0) {
+      await expect(wsStatus.first()).toBeVisible();
+    }
+  });
+
+  test('dashboard handles API errors gracefully', async ({ page }) => {
+    await page.route('**/api/dashboard/**', (route) =>
+      route.fulfill({ status: 500, json: { error: 'Internal error' } }),
+    );
+
+    await page.goto('/dashboard');
+
+    await page.waitForTimeout(3000);
+
+    const pageContent = await page.textContent('body');
+    expect(pageContent).not.toContain('Unhandled');
+  });
+
+  test('corridor data renders in dashboard view', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await page.waitForTimeout(2000);
+
+    const corridorText = page.getByText(/USD|corridor/i).first();
+    if (await corridorText.isVisible().catch(() => false)) {
+      await expect(corridorText).toBeVisible();
+    }
+  });
+});

--- a/frontend/src/__tests__/e2e/network-switch.test.ts
+++ b/frontend/src/__tests__/e2e/network-switch.test.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+
+const TESTNET_NETWORK = {
+  network: 'testnet',
+  display_name: 'Testnet',
+  rpc_url: 'https://soroban-testnet.stellar.org',
+  horizon_url: 'https://horizon-testnet.stellar.org',
+  network_passphrase: 'Test SDF Network ; September 2015',
+  color: '#4ECDC4',
+  is_mainnet: false,
+  is_testnet: true,
+};
+
+const MAINNET_NETWORK = {
+  network: 'mainnet',
+  display_name: 'Mainnet',
+  rpc_url: 'https://stellar.api.onfinality.io/public',
+  horizon_url: 'https://horizon.stellar.org',
+  network_passphrase: 'Public Global Stellar Network ; September 2015',
+  color: '#2563EB',
+  is_mainnet: true,
+  is_testnet: false,
+};
+
+test.describe('Network Switcher — testnet flows', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/network/info', (route) =>
+      route.fulfill({ json: MAINNET_NETWORK }),
+    );
+    await page.route('**/api/network/available', (route) =>
+      route.fulfill({ json: [MAINNET_NETWORK, TESTNET_NETWORK] }),
+    );
+    await page.route('**/api/network/switch', (route) =>
+      route.fulfill({
+        json: { message: 'Network switched to testnet. Server restart required.' },
+      }),
+    );
+
+    await page.goto('/');
+  });
+
+  test('displays current network and available networks', async ({ page }) => {
+    const switcher = page.getByRole('button', { name: /Network:.*Click to switch/i });
+    await expect(switcher).toBeVisible();
+    await expect(switcher).toContainText('Mainnet');
+
+    await switcher.click();
+
+    const listbox = page.getByRole('listbox', { name: /Available networks/i });
+    await expect(listbox).toBeVisible();
+
+    const mainnetOption = listbox.getByRole('option', { name: /Mainnet/i });
+    const testnetOption = listbox.getByRole('option', { name: /Testnet/i });
+    await expect(mainnetOption).toBeVisible();
+    await expect(testnetOption).toBeVisible();
+    await expect(mainnetOption).toHaveAttribute('aria-selected', 'true');
+    await expect(testnetOption).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('shows confirmation dialog when switching to testnet', async ({ page }) => {
+    const switcher = page.getByRole('button', { name: /Network:.*Click to switch/i });
+    await switcher.click();
+
+    const testnetOption = page.getByRole('option', { name: /Testnet/i });
+    await testnetOption.click();
+
+    const dialog = page.getByRole('dialog', { name: /Switch Network/i });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Mainnet');
+    await expect(dialog).toContainText('Testnet');
+    await expect(dialog).toContainText('testnet');
+  });
+
+  test('cancelling network switch keeps current network', async ({ page }) => {
+    const switcher = page.getByRole('button', { name: /Network:.*Click to switch/i });
+    await switcher.click();
+
+    await page.getByRole('option', { name: /Testnet/i }).click();
+
+    const cancelButton = page.getByRole('button', { name: /Cancel network switch/i });
+    await cancelButton.click();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(switcher).toContainText('Mainnet');
+  });
+
+  test('confirming switch sends POST and updates UI', async ({ page }) => {
+    const switchRequests: string[] = [];
+    await page.route('**/api/network/switch', async (route) => {
+      const body = route.request().postDataJSON();
+      switchRequests.push(body.network);
+      await route.fulfill({
+        json: { message: 'Network switched to testnet.' },
+      });
+    });
+
+    page.on('dialog', (dialog) => dialog.accept());
+
+    const switcher = page.getByRole('button', { name: /Network:.*Click to switch/i });
+    await switcher.click();
+    await page.getByRole('option', { name: /Testnet/i }).click();
+    await page.getByRole('button', { name: /Confirm switch to Testnet/i }).click();
+
+    await expect(async () => {
+      expect(switchRequests).toContain('testnet');
+    }).toPass();
+
+    await expect(switcher).toContainText('Testnet');
+  });
+
+  test('selecting the already-active network closes dropdown without dialog', async ({ page }) => {
+    const switcher = page.getByRole('button', { name: /Network:.*Click to switch/i });
+    await switcher.click();
+    await page.getByRole('option', { name: /Mainnet/i }).click();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(page.getByRole('listbox')).not.toBeVisible();
+  });
+
+  test('shows error state when network info fails', async ({ page }) => {
+    await page.route('**/api/network/info', (route) =>
+      route.fulfill({ status: 500, body: 'Internal Server Error' }),
+    );
+
+    await page.goto('/');
+
+    await expect(page.getByText('Network Error')).toBeVisible();
+  });
+});

--- a/frontend/src/__tests__/e2e/sep24-deposit.test.ts
+++ b/frontend/src/__tests__/e2e/sep24-deposit.test.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_ANCHORS = {
+  anchors: [
+    {
+      name: 'Testnet Anchor',
+      transfer_server: 'https://testnet-anchor.example.com/sep24',
+      home_domain: 'testnet-anchor.example.com',
+    },
+  ],
+};
+
+const MOCK_INFO = {
+  deposit: {
+    USDC: {
+      enabled: true,
+      min_amount: 1,
+      max_amount: 10000,
+      fee_fixed: 0.5,
+      fee_percent: 0.1,
+      authentication_required: false,
+    },
+    XLM: {
+      enabled: true,
+      min_amount: 10,
+      max_amount: 100000,
+      authentication_required: false,
+    },
+  },
+  withdraw: {
+    USDC: {
+      enabled: true,
+      min_amount: 5,
+      max_amount: 5000,
+    },
+  },
+  fee: { enabled: true },
+};
+
+const MOCK_INTERACTIVE = {
+  type: 'interactive_customer_info_needed',
+  url: 'https://testnet-anchor.example.com/interactive/deposit?token=abc123',
+  id: 'tx-001',
+};
+
+const MOCK_TRANSACTIONS = {
+  transactions: [
+    {
+      id: 'tx-001',
+      kind: 'deposit',
+      status: 'completed',
+      amount_in: '100.00',
+      amount_out: '99.50',
+      amount_fee: '0.50',
+      asset_code: 'USDC',
+      started_at: '2026-06-01T12:00:00Z',
+      completed_at: '2026-06-01T12:05:00Z',
+    },
+    {
+      id: 'tx-002',
+      kind: 'deposit',
+      status: 'pending_user_transfer_start',
+      amount_in: '50.00',
+      asset_code: 'XLM',
+      started_at: '2026-06-25T10:00:00Z',
+    },
+  ],
+};
+
+test.describe('SEP-24 Deposit Flow — testnet', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/sep24/anchors', (route) =>
+      route.fulfill({ json: MOCK_ANCHORS }),
+    );
+    await page.route('**/api/sep24/info**', (route) =>
+      route.fulfill({ json: MOCK_INFO }),
+    );
+    await page.route('**/api/sep24/deposit/interactive', (route) =>
+      route.fulfill({ json: MOCK_INTERACTIVE }),
+    );
+    await page.route('**/api/sep24/transactions**', (route) =>
+      route.fulfill({ json: MOCK_TRANSACTIONS }),
+    );
+  });
+
+  test('loads anchor list and shows deposit form', async ({ page }) => {
+    await page.goto('/sep24');
+
+    const anchorSelect = page.locator('select').first();
+    await expect(anchorSelect).toBeVisible();
+
+    await anchorSelect.selectOption({ label: /Testnet Anchor/i });
+
+    await expect(page.getByText('Start flow')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Deposit/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Withdraw/i })).toBeVisible();
+  });
+
+  test('deposit button is active by default', async ({ page }) => {
+    await page.goto('/sep24');
+
+    const depositBtn = page.getByRole('button', { name: /Deposit/i }).first();
+    await expect(depositBtn).toBeVisible();
+  });
+
+  test('starts interactive deposit and gets redirect URL', async ({ page }) => {
+    let depositCalled = false;
+    await page.route('**/api/sep24/deposit/interactive', async (route) => {
+      depositCalled = true;
+      const body = route.request().postDataJSON();
+      expect(body).toHaveProperty('transferServer');
+      await route.fulfill({ json: MOCK_INTERACTIVE });
+    });
+
+    await page.goto('/sep24');
+
+    const anchorSelect = page.locator('select').first();
+    await anchorSelect.selectOption({ label: /Testnet Anchor/i });
+
+    await page.waitForTimeout(500);
+
+    const startButton = page.getByRole('button', { name: /Start deposit/i });
+    if (await startButton.isEnabled()) {
+      await startButton.click();
+      await expect(async () => {
+        expect(depositCalled).toBe(true);
+      }).toPass({ timeout: 5000 });
+    }
+  });
+
+  test('switches between deposit and withdraw tabs', async ({ page }) => {
+    await page.goto('/sep24');
+
+    const anchorSelect = page.locator('select').first();
+    await anchorSelect.selectOption({ label: /Testnet Anchor/i });
+
+    await page.waitForTimeout(500);
+
+    const withdrawBtn = page.getByRole('button', { name: /Withdraw/i }).first();
+    await withdrawBtn.click();
+
+    const depositBtn = page.getByRole('button', { name: /Deposit/i }).first();
+    await depositBtn.click();
+  });
+
+  test('displays transaction history table', async ({ page }) => {
+    await page.goto('/sep24');
+
+    const anchorSelect = page.locator('select').first();
+    await anchorSelect.selectOption({ label: /Testnet Anchor/i });
+
+    const loadHistoryBtn = page.getByRole('button', { name: /Load history/i });
+    if (await loadHistoryBtn.isVisible()) {
+      await loadHistoryBtn.click();
+
+      await expect(page.getByText('completed')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('USDC')).toBeVisible();
+    }
+  });
+
+  test('shows error when anchor fetch fails', async ({ page }) => {
+    await page.route('**/api/sep24/anchors', (route) =>
+      route.fulfill({ status: 500, json: { error: 'Server error' } }),
+    );
+
+    await page.goto('/sep24');
+
+    await expect(
+      page.getByText(/error|failed|could not/i),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('handles 503 with retry on deposit', async ({ page }) => {
+    let callCount = 0;
+    await page.route('**/api/sep24/deposit/interactive', async (route) => {
+      callCount++;
+      if (callCount === 1) {
+        await route.fulfill({
+          status: 503,
+          headers: { 'Retry-After': '1' },
+          body: 'Service Unavailable',
+        });
+      } else {
+        await route.fulfill({ json: MOCK_INTERACTIVE });
+      }
+    });
+
+    await page.goto('/sep24');
+
+    const anchorSelect = page.locator('select').first();
+    await anchorSelect.selectOption({ label: /Testnet Anchor/i });
+
+    await page.waitForTimeout(500);
+
+    const startButton = page.getByRole('button', { name: /Start deposit/i });
+    if (await startButton.isEnabled()) {
+      await startButton.click();
+      await expect(async () => {
+        expect(callCount).toBeGreaterThanOrEqual(2);
+      }).toPass({ timeout: 10000 });
+    }
+  });
+});

--- a/frontend/src/components/RealtimeCollaboration.tsx
+++ b/frontend/src/components/RealtimeCollaboration.tsx
@@ -18,6 +18,13 @@ interface CollaborativeMessage {
   content: string;
   timestamp: Date;
   userColor: string;
+  version?: number;
+}
+
+interface ConflictInfo {
+  rejectedContent: string;
+  serverVersion: number;
+  localVersion: number;
 }
 
 interface RealtimeCollaborationProps {
@@ -46,8 +53,10 @@ export const RealtimeCollaboration: React.FC<RealtimeCollaborationProps> = ({
   const [inputValue, setInputValue] = useState('');
   const [isConnected, setIsConnected] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'disconnected'>('disconnected');
+  const [conflict, setConflict] = useState<ConflictInfo | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  const versionRef = useRef<number>(0);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -79,9 +88,12 @@ export const RealtimeCollaboration: React.FC<RealtimeCollaborationProps> = ({
       wsRef.current.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          
+
           switch (data.type) {
-            case 'message':
+            case 'message': {
+              if (data.version != null) {
+                versionRef.current = data.version;
+              }
               const newMessage: CollaborativeMessage = {
                 id: data.id,
                 userId: data.userId,
@@ -89,6 +101,7 @@ export const RealtimeCollaboration: React.FC<RealtimeCollaborationProps> = ({
                 content: data.content,
                 timestamp: new Date(data.timestamp),
                 userColor: data.userColor,
+                version: data.version,
               };
               setMessages((prev) => {
                 const updated = [...prev, newMessage];
@@ -96,8 +109,21 @@ export const RealtimeCollaboration: React.FC<RealtimeCollaborationProps> = ({
               });
               onMessageReceived?.(newMessage);
               break;
+            }
 
-            case 'user_joined':
+            case 'conflict': {
+              if (data.version != null) {
+                versionRef.current = data.version;
+              }
+              setConflict({
+                rejectedContent: data.rejectedContent ?? '',
+                serverVersion: data.version ?? 0,
+                localVersion: data.localVersion ?? 0,
+              });
+              break;
+            }
+
+            case 'user_joined': {
               const joinedUser: CollaborativeUser = {
                 id: data.userId,
                 name: data.userName,
@@ -108,6 +134,7 @@ export const RealtimeCollaboration: React.FC<RealtimeCollaborationProps> = ({
               setActiveUsers((prev) => [...prev, joinedUser]);
               onUserJoined?.(joinedUser);
               break;
+            }
 
             case 'user_left':
               setActiveUsers((prev) => prev.filter((u) => u.id !== data.userId));
@@ -157,11 +184,13 @@ export const RealtimeCollaboration: React.FC<RealtimeCollaborationProps> = ({
   const sendMessage = useCallback(() => {
     if (!inputValue.trim() || !isConnected || !wsRef.current) return;
 
+    setConflict(null);
     wsRef.current.send(JSON.stringify({
       type: 'message',
       content: inputValue,
       userId,
       userName,
+      version: versionRef.current,
     }));
 
     setInputValue('');
@@ -242,6 +271,23 @@ export const RealtimeCollaboration: React.FC<RealtimeCollaborationProps> = ({
             )}
             <div ref={messagesEndRef} />
           </div>
+
+          {/* Conflict Banner */}
+          {conflict && (
+            <div className="border-t border-amber-300 bg-amber-50 px-4 py-3 flex items-start gap-2" role="alert" aria-label="Write conflict detected">
+              <span className="text-amber-600 font-medium text-sm shrink-0">Conflict:</span>
+              <span className="text-amber-800 text-sm flex-1">
+                Your message was rejected because another change arrived first. Please retry.
+              </span>
+              <button
+                onClick={() => setConflict(null)}
+                className="text-amber-600 hover:text-amber-800 text-sm font-medium shrink-0"
+                aria-label="Dismiss conflict"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
 
           {/* Input Area */}
           <div className="border-t p-4 bg-gray-50">

--- a/frontend/src/services/fetchWithRetry.ts
+++ b/frontend/src/services/fetchWithRetry.ts
@@ -1,0 +1,41 @@
+import { config } from '@/config';
+
+const API_BASE = config.apiUrl;
+
+const MAX_RETRY_DELAY_MS = 5000;
+
+export async function fetchWithRetry<T>(
+  endpoint: string,
+  options: RequestInit = {},
+  ErrorClass: new (message: string, status?: number, data?: unknown) => Error & { status?: number; data?: unknown },
+): Promise<T> {
+  const url = endpoint.startsWith("http") ? endpoint : `${API_BASE}${endpoint}`;
+  const init: RequestInit = {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers as Record<string, string>),
+    },
+  };
+
+  let res = await fetch(url, init);
+
+  if (res.status === 503) {
+    const retryAfterHeader = res.headers.get("Retry-After");
+    const delayMs = retryAfterHeader
+      ? Math.min(parseInt(retryAfterHeader, 10) * 1000 || 1000, MAX_RETRY_DELAY_MS)
+      : 1000;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    res = await fetch(url, init);
+  }
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg =
+      (data as { message?: string })?.message ||
+      (data as { error?: string })?.error ||
+      res.statusText;
+    throw new ErrorClass(msg, res.status, data);
+  }
+  return data as T;
+}

--- a/frontend/src/services/sep24.ts
+++ b/frontend/src/services/sep24.ts
@@ -3,9 +3,7 @@
  * All requests go through the backend proxy to avoid CORS and centralize auth.
  */
 
-import { config } from '@/config';
-
-const API_BASE = config.apiUrl;
+import { fetchWithRetry } from './fetchWithRetry';
 
 export class Sep24Error extends Error {
   constructor(
@@ -22,23 +20,7 @@ async function fetchSep24<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
-  const url = endpoint.startsWith("http") ? endpoint : `${API_BASE}${endpoint}`;
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers as Record<string, string>),
-    },
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const msg =
-      (data as { message?: string })?.message ||
-      (data as { error?: string })?.error ||
-      res.statusText;
-    throw new Sep24Error(msg, res.status, data);
-  }
-  return data as T;
+  return fetchWithRetry<T>(endpoint, options, Sep24Error);
 }
 
 // --- Types (align with SEP-24 and backend proxy) ---

--- a/frontend/src/services/sep31.ts
+++ b/frontend/src/services/sep31.ts
@@ -3,9 +3,7 @@
  * All requests go through the backend proxy.
  */
 
-import { config } from '@/config';
-
-const API_BASE = config.apiUrl;
+import { fetchWithRetry } from './fetchWithRetry';
 
 export class Sep31Error extends Error {
   constructor(
@@ -22,23 +20,7 @@ async function fetchSep31<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
-  const url = endpoint.startsWith("http") ? endpoint : `${API_BASE}${endpoint}`;
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers as Record<string, string>),
-    },
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const msg =
-      (data as { message?: string })?.message ||
-      (data as { error?: string })?.error ||
-      res.statusText;
-    throw new Sep31Error(msg, res.status, data);
-  }
-  return data as T;
+  return fetchWithRetry<T>(endpoint, options, Sep31Error);
 }
 
 // --- Types ---

--- a/frontend/src/services/sep6.ts
+++ b/frontend/src/services/sep6.ts
@@ -3,9 +3,7 @@
  * Programmatic deposit/withdraw flows; requests go through backend proxy when configured.
  */
 
-import { config } from '@/config';
-
-const API_BASE = config.apiUrl;
+import { fetchWithRetry } from './fetchWithRetry';
 
 export class Sep6Error extends Error {
   constructor(
@@ -22,23 +20,7 @@ async function fetchSep6<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
-  const url = endpoint.startsWith("http") ? endpoint : `${API_BASE}${endpoint}`;
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers as Record<string, string>),
-    },
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const msg =
-      (data as { message?: string })?.message ||
-      (data as { error?: string })?.error ||
-      res.statusText;
-    throw new Sep6Error(msg, res.status, data);
-  }
-  return data as T;
+  return fetchWithRetry<T>(endpoint, options, Sep6Error);
 }
 
 // --- Types (align with SEP-6) ---

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -26,6 +26,39 @@ import {
 } from "./sdk-init.js";
 import { ApiClient, BatchApiClient, ApiClientError } from "./api-client.js";
 
+export interface NetworkConfig {
+  rpcUrl: string;
+  horizonUrl: string;
+  networkPassphrase: string;
+  apiBaseUrl: string;
+}
+
+export const NETWORKS: Record<"mainnet" | "testnet", NetworkConfig> = {
+  mainnet: {
+    rpcUrl: "https://stellar.api.onfinality.io/public",
+    horizonUrl: "https://horizon.stellar.org",
+    networkPassphrase: "Public Global Stellar Network ; September 2015",
+    apiBaseUrl: "https://api.stellarinsights.io",
+  },
+  testnet: {
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    apiBaseUrl: "https://testnet-api.stellarinsights.io",
+  },
+};
+
+export function createClient(
+  network: "mainnet" | "testnet",
+  config: Omit<StellarInsightsConfig, "baseUrl"> = {},
+): StellarInsights {
+  const networkConfig = NETWORKS[network];
+  return new StellarInsights({
+    ...config,
+    baseUrl: networkConfig.apiBaseUrl,
+  });
+}
+
 export class StellarInsights {
   readonly anchors: AnchorsResource;
   readonly corridors: CorridorsResource;


### PR DESCRIPTION
…SDK networks

- closes #1657: Add version-based conflict detection to RealtimeCollaboration with conflict banner UI
- closes #1658: Extract shared fetchWithRetry with single 503 retry and Retry-After support for sep24/sep6/sep31 services
- closes #1659: Add Playwright E2E test suite for testnet flows (network-switch, sep24-deposit, dashboard-realtime)
- closes #1660: Export NETWORKS config and createClient(network) factory from SDK package root