### PR TITLE
Feat/sdk typescript python

### DIFF
--- a/.github/workflows/sdk-bindings.yml
+++ b/.github/workflows/sdk-bindings.yml
@@ -1,0 +1,48 @@
+name: Regenerate SDK Bindings
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "contracts/**/*.rs"
+      - "contracts/**/Cargo.toml"
+  pull_request:
+    paths:
+      - "contracts/**/*.rs"
+      - "contracts/**/Cargo.toml"
+
+jobs:
+  generate-typescript-bindings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Stellar CLI
+        run: |
+          cargo install stellar-cli --locked
+
+      - name: Build contracts
+        working-directory: contracts
+        run: stellar contract build
+
+      - name: Generate TypeScript bindings
+        working-directory: sdk/typescript
+        env:
+          CONTRACT_ID: ${{ vars.SOROBAN_CONTRACT_ID }}
+          NETWORK: ${{ vars.STELLAR_NETWORK }}
+          RPC_URL: ${{ vars.SOROBAN_RPC_URL }}
+        run: bash scripts/generate-bindings.sh
+
+      - name: Check for binding changes
+        id: diff
+        run: |
+          git diff --exit-code sdk/typescript/generated/ || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit updated bindings
+        if: steps.diff.outputs.changed == 'true' && github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add sdk/typescript/generated/
+          git commit -m "chore: regenerate TypeScript SDK bindings"
+          git push

--- a/sdk/typescript/generated/README.md
+++ b/sdk/typescript/generated/README.md
@@ -1,0 +1,22 @@
+# Generated Soroban Bindings
+
+This directory contains auto-generated TypeScript bindings for the Stellar Insights Soroban contracts.
+
+**Do not edit files in this directory manually.** They will be overwritten on the next generation run.
+
+## Regenerating
+
+```bash
+# From the sdk/typescript directory:
+npm run generate -- --contract-id <YOUR_CONTRACT_ID>
+
+# Or directly:
+bash scripts/generate-bindings.sh --contract-id <YOUR_CONTRACT_ID>
+```
+
+See `scripts/generate-bindings.sh --help` for all options.
+
+## CI
+
+Bindings are regenerated automatically in CI whenever contract source files change.
+See `.github/workflows/sdk-bindings.yml`.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -15,6 +15,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
+    "generate": "bash scripts/generate-bindings.sh",
     "test": "vitest run",
     "test:testnet": "vitest run --include 'tests/testnet/**/*.test.ts'",
     "lint": "tsc --noEmit"

--- a/sdk/typescript/scripts/generate-bindings.sh
+++ b/sdk/typescript/scripts/generate-bindings.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SDK_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT_DIR="$SDK_ROOT/generated"
+
+NETWORK="${NETWORK:-testnet}"
+CONTRACT_ID="${CONTRACT_ID:-}"
+RPC_URL="${RPC_URL:-https://soroban-testnet.stellar.org}"
+
+usage() {
+  echo "Usage: $0 [--contract-id <id>] [--network <network>] [--rpc-url <url>]"
+  echo ""
+  echo "Generates TypeScript bindings from deployed Soroban contracts."
+  echo ""
+  echo "Options:"
+  echo "  --contract-id   Deployed contract ID (required unless CONTRACT_ID env var set)"
+  echo "  --network       Stellar network (default: testnet)"
+  echo "  --rpc-url       Soroban RPC URL (default: https://soroban-testnet.stellar.org)"
+  echo ""
+  echo "Environment variables:"
+  echo "  CONTRACT_ID     Alternative to --contract-id flag"
+  echo "  NETWORK         Alternative to --network flag"
+  echo "  RPC_URL         Alternative to --rpc-url flag"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --contract-id) CONTRACT_ID="$2"; shift 2 ;;
+    --network) NETWORK="$2"; shift 2 ;;
+    --rpc-url) RPC_URL="$2"; shift 2 ;;
+    --help|-h) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+if [[ -z "$CONTRACT_ID" ]]; then
+  echo "Error: --contract-id is required (or set CONTRACT_ID env var)"
+  exit 1
+fi
+
+if ! command -v stellar &>/dev/null; then
+  echo "Error: 'stellar' CLI not found. Install from https://soroban.stellar.org/docs/getting-started/setup"
+  exit 1
+fi
+
+echo "Generating TypeScript bindings..."
+echo "  Contract ID: $CONTRACT_ID"
+echo "  Network:     $NETWORK"
+echo "  RPC URL:     $RPC_URL"
+echo "  Output:      $OUTPUT_DIR"
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+stellar contract bindings typescript \
+  --contract-id "$CONTRACT_ID" \
+  --network "$NETWORK" \
+  --rpc-url "$RPC_URL" \
+  --output-dir "$OUTPUT_DIR"
+
+echo "Bindings generated successfully in $OUTPUT_DIR"

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -25,6 +25,12 @@ import {
   EnvironmentDetector,
 } from "./sdk-init.js";
 import { ApiClient, BatchApiClient, ApiClientError } from "./api-client.js";
+import {
+  acquireConnection,
+  releaseConnection,
+  closeAllConnections,
+  type EventHandler,
+} from "./websocket-manager.js";
 
 export interface NetworkConfig {
   rpcUrl: string;
@@ -53,10 +59,12 @@ export function createClient(
   config: Omit<StellarInsightsConfig, "baseUrl"> = {},
 ): StellarInsights {
   const networkConfig = NETWORKS[network];
-  return new StellarInsights({
+  const client = new StellarInsights({
     ...config,
     baseUrl: networkConfig.apiBaseUrl,
   });
+  client.wsNetwork = network;
+  return client;
 }
 
 export class StellarInsights {
@@ -77,6 +85,9 @@ export class StellarInsights {
   readonly apiClient: ApiClient;
 
   private readonly http: HttpClient;
+  private readonly eventHandlers = new Set<EventHandler>();
+  /** @internal */
+  wsNetwork: "mainnet" | "testnet" = "testnet";
 
   constructor(config: StellarInsightsConfig = {}) {
     this.http = new HttpClient(config);
@@ -95,6 +106,26 @@ export class StellarInsights {
     this.ml = new MlResource(this.http);
     this.governance = new GovernanceResource(this.http);
     this.assetVerification = new AssetVerificationResource(this.http);
+  }
+
+  subscribe(handler: EventHandler): void {
+    this.eventHandlers.add(handler);
+    const net = NETWORKS[this.wsNetwork];
+    acquireConnection({ rpcUrl: net.rpcUrl, network: this.wsNetwork }, handler);
+  }
+
+  unsubscribe(handler: EventHandler): void {
+    this.eventHandlers.delete(handler);
+    const net = NETWORKS[this.wsNetwork];
+    releaseConnection({ rpcUrl: net.rpcUrl, network: this.wsNetwork }, handler);
+  }
+
+  disconnect(): void {
+    const net = NETWORKS[this.wsNetwork];
+    for (const handler of this.eventHandlers) {
+      releaseConnection({ rpcUrl: net.rpcUrl, network: this.wsNetwork }, handler);
+    }
+    this.eventHandlers.clear();
   }
 }
 
@@ -117,6 +148,10 @@ export { SDKInitializer, initializeForMobile, initializeForWeb, initializeForBac
 
 // API Client Core exports
 export { ApiClient, BatchApiClient, ApiClientError };
+
+// WebSocket exports
+export { closeAllConnections };
+export type { EventHandler } from "./websocket-manager.js";
 
 export type * from "./types.js";
 export type * from "./api-client.js";

--- a/sdk/typescript/src/websocket-manager.ts
+++ b/sdk/typescript/src/websocket-manager.ts
@@ -1,0 +1,83 @@
+export type EventHandler = (event: unknown) => void;
+
+interface ConnectionKey {
+  rpcUrl: string;
+  network: string;
+}
+
+interface ManagedConnection {
+  ws: WebSocket;
+  refCount: number;
+  handlers: Set<EventHandler>;
+}
+
+function connectionKey(key: ConnectionKey): string {
+  return `${key.rpcUrl}|${key.network}`;
+}
+
+const connections = new Map<string, ManagedConnection>();
+
+export function acquireConnection(
+  key: ConnectionKey,
+  handler: EventHandler,
+): void {
+  const k = connectionKey(key);
+  const existing = connections.get(k);
+
+  if (existing) {
+    existing.refCount++;
+    existing.handlers.add(handler);
+    return;
+  }
+
+  const wsUrl = key.rpcUrl.replace(/^http/, "ws");
+  const ws = new WebSocket(wsUrl);
+
+  const conn: ManagedConnection = {
+    ws,
+    refCount: 1,
+    handlers: new Set([handler]),
+  };
+
+  ws.onmessage = (event) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(String(event.data));
+    } catch {
+      return;
+    }
+    for (const h of conn.handlers) {
+      h(parsed);
+    }
+  };
+
+  ws.onclose = () => {
+    connections.delete(k);
+  };
+
+  connections.set(k, conn);
+}
+
+export function releaseConnection(
+  key: ConnectionKey,
+  handler: EventHandler,
+): void {
+  const k = connectionKey(key);
+  const conn = connections.get(k);
+  if (!conn) return;
+
+  conn.handlers.delete(handler);
+  conn.refCount--;
+
+  if (conn.refCount <= 0) {
+    conn.ws.close();
+    connections.delete(k);
+  }
+}
+
+export function closeAllConnections(): void {
+  for (const conn of connections.values()) {
+    conn.ws.close();
+  }
+  connections.clear();
+}


### PR DESCRIPTION
closes #1661 — TypeScript stale contract bindings → added generate-bindings.sh + CI workflow to auto-regenerate on contract changes
closes #1662 — Python infinite rate limit retries → added max_retries=5 with exponential backoff and Retry-After header support, raises RateLimitError
closes #1663 — TypeScript WebSocket connection leak → singleton WebSocket manager keyed by (rpcUrl, network) with ref counting + client.disconnect()
closes #1664 — Python missing async context manager → implemented __aenter__/__aexit__ for async with support