### PR TITLE
Fix frontend cleanup bugs: unmount leaks and export OOM

### DIFF
--- a/frontend/src/components/ExportDialog.tsx
+++ b/frontend/src/components/ExportDialog.tsx
@@ -74,24 +74,27 @@ export function ExportDialog({ isOpen, onClose, type, title }: ExportDialogProps
         }
       }
 
-      const response = await fetch(`${API_BASE_URL}/export/${type}?${params.toString()}`);
+      const exportUrl = `${API_BASE_URL}/export/${type}?${params.toString()}`;
 
+      // Verify the endpoint is reachable before triggering the download
+      const check = await fetch(exportUrl, { method: "HEAD" });
       clearInterval(progressInterval);
-      setProgress(100);
-
-      if (!response.ok) {
-        throw new Error(`Export failed: ${response.statusText}`);
+      if (!check.ok) {
+        throw new Error(`Export failed: ${check.statusText}`);
       }
 
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
+      setProgress(50);
+
+      // Let the browser handle the download natively — streams to disk
+      // instead of loading the entire response into memory
       const a = document.createElement("a");
-      a.href = url;
-      a.download = `${type}_export_${new Date().toISOString().split('T')[0]}.${format === "excel" ? "xlsx" : format}`;
+      a.href = exportUrl;
+      a.download = `${type}_export_${new Date().toISOString().split('T')[0]}.${format}`;
       document.body.appendChild(a);
       a.click();
-      window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
+
+      setProgress(100);
 
       setSuccess(true);
       setTimeout(() => {

--- a/frontend/src/components/OnChainVerification.tsx
+++ b/frontend/src/components/OnChainVerification.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { logger } from '@/lib/logger';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -30,24 +30,25 @@ export const OnChainVerification = ({ className = '' }: OnChainVerificationProps
     auditTrail: []
   });
   const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
-    fetchVerificationData();
-    const interval = setInterval(fetchVerificationData, 30000); // Refresh every 30 seconds
-    return () => clearInterval(interval);
-  }, []);
+  const fetchVerificationData = useCallback(async () => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
 
-  const fetchVerificationData = async () => {
     try {
       setError(null);
-      const response = await fetch('/api/analytics/verification-summary');
-      
+      const response = await fetch('/api/analytics/verification-summary', {
+        signal: controller.signal,
+      });
+
       if (!response.ok) {
         throw new Error('Failed to fetch verification data');
       }
 
       const data = await response.json();
-      
+
       setVerificationData({
         latestEpoch: data.latestEpoch,
         status: data.latestStatus || 'pending',
@@ -57,11 +58,21 @@ export const OnChainVerification = ({ className = '' }: OnChainVerificationProps
         auditTrail: data.auditTrail || []
       });
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       logger.error('Error fetching verification data:', err instanceof Error ? err : new Error(String(err)));
       setError('Failed to load verification data');
       setVerificationData((prev) => ({ ...prev, status: 'failed' }));
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchVerificationData();
+    const interval = setInterval(fetchVerificationData, 30000);
+    return () => {
+      clearInterval(interval);
+      abortControllerRef.current?.abort();
+    };
+  }, [fetchVerificationData]);
 
   const getStatusBadge = (status: string) => {
     switch (status) {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -65,16 +65,26 @@ export function useWebSocket(
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const shouldReconnectRef = useRef(true);
   const isConnectingRef = useRef(false);
+  const connectionAttemptsRef = useRef(0);
+  const optionsRef = useRef({ onOpen, onClose, onError, onMessage });
+  optionsRef.current = { onOpen, onClose, onError, onMessage };
 
   const connect = useCallback(() => {
-    // Prevent duplicate connections
     if (isConnectingRef.current) {
       return;
     }
 
-    // Check if already connected
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       return;
+    }
+
+    // Close any lingering socket before creating a new one
+    if (wsRef.current && wsRef.current.readyState !== WebSocket.CLOSED) {
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.close();
+      wsRef.current = null;
     }
 
     isConnectingRef.current = true;
@@ -89,9 +99,10 @@ export function useWebSocket(
         setIsConnected(true);
         setIsConnecting(false);
         setConnectionState(ConnectionState.CONNECTED);
+        connectionAttemptsRef.current = 0;
         setConnectionAttempts(0);
         isConnectingRef.current = false;
-        onOpen?.();
+        optionsRef.current.onOpen?.();
       };
 
       ws.onclose = () => {
@@ -99,21 +110,22 @@ export function useWebSocket(
         setIsConnected(false);
         setIsConnecting(false);
         isConnectingRef.current = false;
-        onClose?.();
+        optionsRef.current.onClose?.();
 
-        // Attempt to reconnect if enabled, under max attempts, and not in background
         if (
           shouldReconnectRef.current &&
-          connectionAttempts < maxReconnectAttempts &&
+          connectionAttemptsRef.current < maxReconnectAttempts &&
           appStateRef.current !== "background"
         ) {
-          setConnectionAttempts((prev) => prev + 1);
+          connectionAttemptsRef.current += 1;
+          setConnectionAttempts(connectionAttemptsRef.current);
+          setConnectionState(ConnectionState.RECONNECTING);
           reconnectTimeoutRef.current = setTimeout(
             () => {
               connect();
             },
-            reconnectInterval * Math.pow(1.5, connectionAttempts),
-          ); // Exponential backoff
+            reconnectInterval * Math.pow(1.5, connectionAttemptsRef.current),
+          );
         }
       };
 
@@ -122,14 +134,14 @@ export function useWebSocket(
         setIsConnecting(false);
         isConnectingRef.current = false;
         setConnectionState(ConnectionState.DISCONNECTED);
-        onError?.(error);
+        optionsRef.current.onError?.(error);
       };
 
       ws.onmessage = (event) => {
         try {
           const message: WsMessage = JSON.parse(event.data);
           setLastMessage(message);
-          onMessage?.(message);
+          optionsRef.current.onMessage?.(message);
         } catch (error) {
           logger.error("Failed to parse WebSocket message:", error);
         }
@@ -140,16 +152,7 @@ export function useWebSocket(
       isConnectingRef.current = false;
       setConnectionState(ConnectionState.DISCONNECTED);
     }
-  }, [
-    url,
-    connectionAttempts,
-    maxReconnectAttempts,
-    reconnectInterval,
-    onOpen,
-    onClose,
-    onError,
-    onMessage,
-  ]);
+  }, [url, maxReconnectAttempts, reconnectInterval]);
 
   const disconnect = useCallback(() => {
     shouldReconnectRef.current = false;
@@ -160,12 +163,16 @@ export function useWebSocket(
     }
 
     if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
       wsRef.current.close();
       wsRef.current = null;
     }
 
     setIsConnected(false);
     setIsConnecting(false);
+    isConnectingRef.current = false;
     setConnectionState(ConnectionState.DISCONNECTED);
   }, []);
 
@@ -198,14 +205,12 @@ export function useWebSocket(
   );
 
   const reconnect = useCallback(() => {
-    // Disconnect first
     disconnect();
 
-    // Reset attempts and enable reconnect
     shouldReconnectRef.current = true;
+    connectionAttemptsRef.current = 0;
     setConnectionAttempts(0);
 
-    // Delay slightly before reconnecting
     setTimeout(() => {
       connect();
     }, 100);
@@ -234,14 +239,15 @@ export function useWebSocket(
       if (nextState === "active" && prevState === "background") {
         logger.debug("App active. Resuming WebSocket reconnection with exponential backoff.");
         if (shouldReconnectRef.current && !isConnected && !isConnectingRef.current) {
-          const delay = reconnectInterval * Math.pow(1.5, connectionAttempts);
+          const delay = reconnectInterval * Math.pow(1.5, connectionAttemptsRef.current);
           if (reconnectTimeoutRef.current) {
             clearTimeout(reconnectTimeoutRef.current);
           }
           reconnectTimeoutRef.current = setTimeout(() => {
             connect();
           }, delay);
-          setConnectionAttempts((prev) => prev + 1);
+          connectionAttemptsRef.current += 1;
+          setConnectionAttempts(connectionAttemptsRef.current);
         }
       } else if (nextState === "background") {
         logger.debug("App in background. Pausing WebSocket reconnection.");
@@ -256,7 +262,7 @@ export function useWebSocket(
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [connect, isConnected, connectionAttempts, reconnectInterval]);
+  }, [connect, isConnected, reconnectInterval]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes three frontend resource-leak and crash bugs:

- **closes #1656 — OnChainVerification polling leak**: Added `AbortController` so in-flight fetch requests are cancelled on unmount. The `setInterval` cleanup was already present, but async fetches that were mid-flight would still resolve and set state on an unmounted component.
- **closes #1655 — useWebSocket memory leak on rapid navigation**: Moved `connectionAttempts` and option callbacks (`onOpen`, `onClose`, etc.) to refs, eliminating stale closures and removing them from `connect`'s dependency array. `connect()` now closes any lingering socket (nulling its handlers first) before creating a new one, preventing leaked sockets during rapid route changes.
- **closes #1654 — ExportDialog browser OOM on large datasets**: Replaced `response.blob()` (which loaded the entire payload into memory) with a native browser download via an anchor element. A HEAD request validates the endpoint first, then the browser streams the file directly to disk — no memory accumulation.

**Note on closes #1653 (CommandPalette Ctrl+K)**: The file `CommandPalette.tsx` does not exist in the repo. The Ctrl+K shortcut is handled by the keyboard shortcuts system (`default-shortcuts.ts`), which already sets `preventDefault: true`, and the context handler calls `event.preventDefault()` before the browser can act. No change needed.

Closes #1654, closes #1655, closes #1656

## Test plan

- [ ] Mount and unmount `OnChainVerification` rapidly — verify no console warnings about state updates on unmounted components and no lingering network requests
- [ ] Navigate between routes quickly while a WebSocket connection is active — verify no orphaned sockets in DevTools Network tab
- [ ] Trigger a large data export — verify browser memory stays flat (file streams to disk instead of accumulating in a blob)
- [ ] Verify Ctrl+K opens search/command palette on Windows/Linux without triggering browser address bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)