### PR TITLE
fix(frontend): allow Stellar RPC and Horizon in CSP connect-src

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -46,7 +46,7 @@ const securityHeaders = [
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https://*.stellar.org",
       "font-src 'self'",
-      "connect-src 'self' wss: https: https://*.sentry.io",
+      "connect-src 'self' wss: https: https://*.sentry.io https://soroban-testnet.stellar.org https://stellar.api.onfinality.io https://horizon-testnet.stellar.org https://horizon.stellar.org",
       "frame-src 'none'",
       "frame-ancestors 'none'",
       "object-src 'none'",

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -12,7 +12,8 @@ const intlMiddleware = createMiddleware(routing);
  * Notes:
  * - `script-src 'unsafe-inline'` is required by Next.js for inline hydration scripts.
  *   A nonce-based approach can replace this once Next.js nonce support is wired up.
- * - `connect-src` includes wss: for WebSocket and *.sentry.io for error reporting.
+ * - `connect-src` includes wss: for WebSocket, *.sentry.io for error reporting,
+ *   and Stellar RPC/Horizon endpoints for contract calls.
  * - `upgrade-insecure-requests` is omitted in development to avoid breaking http://localhost.
  */
 function buildCsp(isProd: boolean): string {
@@ -22,7 +23,7 @@ function buildCsp(isProd: boolean): string {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https://*.stellar.org",
     "font-src 'self'",
-    "connect-src 'self' wss: https: https://*.sentry.io",
+    "connect-src 'self' wss: https: https://*.sentry.io https://soroban-testnet.stellar.org https://stellar.api.onfinality.io https://horizon-testnet.stellar.org https://horizon.stellar.org",
     "frame-src 'none'",
     "frame-ancestors 'none'",
     "object-src 'none'",


### PR DESCRIPTION
Closes #1643

## Summary

The frontend Content-Security-Policy was blocking browser-side contract calls because Stellar RPC and Horizon endpoints were not listed in `connect-src`. This PR adds the required domains so Soroban RPC and Horizon requests succeed in the browser.

**Problem**
Contract interactions from the frontend were failing with CSP violations — the browser refused `fetch`/XHR connections to Stellar network endpoints.

**Fix**
Extended `connect-src` in `frontend/next.config.ts` to explicitly allow:
- `https://soroban-testnet.stellar.org` — Soroban testnet RPC
- `https://stellar.api.onfinality.io` — OnFinality public RPC
- `https://horizon-testnet.stellar.org` — Horizon testnet
- `https://horizon.stellar.org` — Horizon mainnet

Also updated `frontend/src/proxy.ts` so runtime CSP headers stay consistent with `next.config.ts`.

## Test plan

- [ ] Load the app and open browser DevTools → Network tab
- [ ] Switch to testnet and trigger a contract call
- [ ] Confirm no CSP `connect-src` violations in the console
- [ ] Verify RPC requests reach `soroban-testnet.stellar.org` or `stellar.api.onfinality.io`
- [ ] Verify Horizon requests reach `horizon-testnet.stellar.org` / `horizon.stellar.org`
- [ ] Confirm Sentry error reporting still works (`*.sentry.io` unchanged)