### PR TITLE
fix(frontend): refresh CSRF token on 401 and retry request once

### DIFF
--- a/frontend/src/__tests__/api-client.test.ts
+++ b/frontend/src/__tests__/api-client.test.ts
@@ -151,9 +151,48 @@ describe('API Client', () => {
         json: async () => ({ error: 'Invalid CSRF token' }),
       });
 
-      await expect(apiPost('/api/test', { data: 'test' })).rejects.toThrow(
-        'Security validation failed'
-      );
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'refreshed-token' },
+      } as Response);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      const result = await apiPost('/api/test', { data: 'test' });
+
+      expect(result).toEqual({ success: true });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should refresh CSRF token and retry once on 401', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'new-csrf-token' },
+      } as Response);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      const result = await apiPost('/api/test', { data: 'test' });
+
+      expect(result).toEqual({ success: true });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFetch.mock.calls[2][1]).toMatchObject({
+        headers: expect.objectContaining({
+          'X-CSRF-Token': 'new-csrf-token',
+        }),
+      });
     });
 
     it('should handle general API errors', async () => {

--- a/frontend/src/__tests__/csrf-client.test.ts
+++ b/frontend/src/__tests__/csrf-client.test.ts
@@ -1,0 +1,80 @@
+/**
+ * CSRF client utility tests
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  CSRF_TOKEN_REFRESHED_EVENT,
+  CSRF_REFRESH_PATH,
+  getCsrfToken,
+  refreshCsrfToken,
+  updateCsrfTokenMeta,
+} from '../lib/csrf-client';
+
+global.fetch = vi.fn();
+const mockFetch = vi.mocked(global.fetch);
+
+describe('csrf-client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.head.innerHTML = '';
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'csrf-token=cookie-token',
+    });
+  });
+
+  it('updateCsrfTokenMeta sets meta tag content', () => {
+    updateCsrfTokenMeta('meta-token-123');
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    expect(meta?.getAttribute('content')).toBe('meta-token-123');
+  });
+
+  it('getCsrfToken prefers meta tag over cookie', () => {
+    updateCsrfTokenMeta('meta-token');
+    expect(getCsrfToken()).toBe('meta-token');
+  });
+
+  it('refreshCsrfToken fetches token from response header', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: {
+        get: (name: string) => (name === 'X-CSRF-Token' ? 'fresh-token' : null),
+      },
+    } as Response);
+
+    const token = await refreshCsrfToken();
+
+    expect(token).toBe('fresh-token');
+    expect(mockFetch).toHaveBeenCalledWith(CSRF_REFRESH_PATH, {
+      method: 'GET',
+      credentials: 'same-origin',
+    });
+    expect(getCsrfToken()).toBe('fresh-token');
+  });
+
+  it('refreshCsrfToken dispatches refresh event', async () => {
+    const listener = vi.fn();
+    window.addEventListener(CSRF_TOKEN_REFRESHED_EVENT, listener);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: {
+        get: () => 'event-token',
+      },
+    } as Response);
+
+    await refreshCsrfToken();
+    expect(listener).toHaveBeenCalled();
+    window.removeEventListener(CSRF_TOKEN_REFRESHED_EVENT, listener);
+  });
+
+  it('refreshCsrfToken throws when header is missing', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => null },
+    } as Response);
+
+    await expect(refreshCsrfToken()).rejects.toThrow('CSRF token missing');
+  });
+});

--- a/frontend/src/components/CsrfTokenProvider.tsx
+++ b/frontend/src/components/CsrfTokenProvider.tsx
@@ -2,31 +2,48 @@
 
 /**
  * CSRF Token Provider Component
- * 
- * Injects CSRF token into the page as a meta tag for client-side access.
- * Should be included in the root layout.
+ *
+ * Fetches a fresh CSRF token on mount and keeps the meta tag in sync when
+ * the API client refreshes the token after session expiry (401).
  */
 
 import { useEffect, useState } from 'react';
+import {
+  CSRF_TOKEN_REFRESHED_EVENT,
+  getCsrfTokenFromCookie,
+  refreshCsrfToken,
+} from '@/lib/csrf-client';
 
 export function CsrfTokenProvider() {
   const [token, setToken] = useState<string | null>(null);
 
   useEffect(() => {
-    // Extract token from cookie
-    const cookies = document.cookie.split(';');
-    for (const cookie of cookies) {
-      const [name, value] = cookie.trim().split('=');
-      if (name === 'csrf-token') {
-        setToken(decodeURIComponent(value));
-        break;
+    let mounted = true;
+
+    refreshCsrfToken()
+      .then((freshToken) => {
+        if (mounted) setToken(freshToken);
+      })
+      .catch(() => {
+        const fallback = getCsrfTokenFromCookie();
+        if (mounted && fallback) setToken(fallback);
+      });
+
+    const handleTokenRefresh = (event: Event) => {
+      const detail = (event as CustomEvent<{ token: string }>).detail;
+      if (detail?.token) {
+        setToken(detail.token);
       }
-    }
+    };
+
+    window.addEventListener(CSRF_TOKEN_REFRESHED_EVENT, handleTokenRefresh);
+    return () => {
+      mounted = false;
+      window.removeEventListener(CSRF_TOKEN_REFRESHED_EVENT, handleTokenRefresh);
+    };
   }, []);
 
   if (!token) return null;
 
-  return (
-    <meta name="csrf-token" content={token} />
-  );
+  return <meta name="csrf-token" content={token} />;
 }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,45 +1,31 @@
 /**
  * API Client with CSRF Protection
- * 
+ *
  * Provides type-safe API methods with automatic CSRF token handling
  * for all state-changing operations.
  */
+
+import { getCsrfToken, refreshCsrfToken } from './csrf-client';
 
 interface ApiOptions extends RequestInit {
   skipCsrf?: boolean;
 }
 
-/**
- * Get CSRF token from meta tag or cookie
- */
-function getCsrfToken(): string | null {
-  // Try meta tag first (for SSR pages)
-  const metaToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
-  if (metaToken) return metaToken;
-  
-  // Fallback to cookie
-  const cookies = document.cookie.split(';');
-  for (const cookie of cookies) {
-    const [name, value] = cookie.trim().split('=');
-    if (name === 'csrf-token') {
-      return decodeURIComponent(value);
-    }
-  }
-  
-  return null;
+interface ApiFetchOptions extends ApiOptions {
+  _retried?: boolean;
 }
 
 /**
  * Base fetch wrapper with CSRF protection
  */
-async function apiFetch(url: string, options: ApiOptions = {}): Promise<Response> {
-  const { skipCsrf = false, headers = {}, ...restOptions } = options;
-  
+async function apiFetch(url: string, options: ApiFetchOptions = {}): Promise<Response> {
+  const { skipCsrf = false, headers = {}, _retried = false, ...restOptions } = options;
+
   const requestHeaders: HeadersInit = {
     'Content-Type': 'application/json',
     ...headers,
   };
-  
+
   // Add CSRF token for state-changing methods
   const method = options.method?.toUpperCase();
   if (!skipCsrf && method && ['POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
@@ -49,100 +35,111 @@ async function apiFetch(url: string, options: ApiOptions = {}): Promise<Response
     }
     requestHeaders['X-CSRF-Token'] = csrfToken;
   }
-  
+
   const response = await fetch(url, {
     ...restOptions,
     method,
     headers: requestHeaders,
+    credentials: restOptions.credentials ?? 'same-origin',
   });
-  
-  // Handle CSRF token errors
-  if (response.status === 403) {
+
+  // Re-fetch CSRF token after session expiry, then retry once
+  if (response.status === 401 && !_retried) {
+    await refreshCsrfToken();
+    return apiFetch(url, { ...options, _retried: true });
+  }
+
+  // Handle CSRF token errors — refresh and retry once
+  if (response.status === 403 && !_retried) {
     const data = await response.json().catch(() => ({}));
     if (data.error?.includes('CSRF')) {
-      throw new Error('Security validation failed. Please refresh the page and try again.');
+      await refreshCsrfToken();
+      return apiFetch(url, { ...options, _retried: true });
     }
+    throw new Error('Security validation failed. Please refresh the page and try again.');
   }
-  
+
   return response;
 }
 
 /**
  * GET request
  */
-export async function apiGet<T = any>(url: string, options?: ApiOptions): Promise<T> {
+export async function apiGet<T = unknown>(url: string, options?: ApiOptions): Promise<T> {
   const response = await apiFetch(url, { ...options, method: 'GET' });
-  
+
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);
   }
-  
+
   return response.json();
 }
 
 /**
  * POST request with CSRF protection
  */
-export async function apiPost<T = any>(url: string, data?: any, options?: ApiOptions): Promise<T> {
+export async function apiPost<T = unknown>(url: string, data?: unknown, options?: ApiOptions): Promise<T> {
   const response = await apiFetch(url, {
     ...options,
     method: 'POST',
     body: data ? JSON.stringify(data) : undefined,
   });
-  
+
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);
   }
-  
+
   return response.json();
 }
 
 /**
  * PUT request with CSRF protection
  */
-export async function apiPut<T = any>(url: string, data?: any, options?: ApiOptions): Promise<T> {
+export async function apiPut<T = unknown>(url: string, data?: unknown, options?: ApiOptions): Promise<T> {
   const response = await apiFetch(url, {
     ...options,
     method: 'PUT',
     body: data ? JSON.stringify(data) : undefined,
   });
-  
+
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);
   }
-  
+
   return response.json();
 }
 
 /**
  * PATCH request with CSRF protection
  */
-export async function apiPatch<T = any>(url: string, data?: any, options?: ApiOptions): Promise<T> {
+export async function apiPatch<T = unknown>(url: string, data?: unknown, options?: ApiOptions): Promise<T> {
   const response = await apiFetch(url, {
     ...options,
     method: 'PATCH',
     body: data ? JSON.stringify(data) : undefined,
   });
-  
+
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);
   }
-  
+
   return response.json();
 }
 
 /**
  * DELETE request with CSRF protection
  */
-export async function apiDelete<T = any>(url: string, options?: ApiOptions): Promise<T> {
+export async function apiDelete<T = unknown>(url: string, options?: ApiOptions): Promise<T> {
   const response = await apiFetch(url, {
     ...options,
     method: 'DELETE',
   });
-  
+
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);
   }
-  
+
   return response.json();
 }
+
+export { refreshCsrfToken } from './csrf-client';

--- a/frontend/src/lib/csrf-client.ts
+++ b/frontend/src/lib/csrf-client.ts
@@ -1,0 +1,59 @@
+/**
+ * Client-side CSRF token utilities.
+ *
+ * The server sets an httpOnly cookie; the readable copy lives in a meta tag
+ * and the X-CSRF-Token response header on GET /api/* requests.
+ */
+
+export const CSRF_TOKEN_REFRESHED_EVENT = 'csrf-token-refreshed';
+export const CSRF_REFRESH_PATH = '/api/example';
+
+export function getCsrfTokenFromMeta(): string | null {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? null;
+}
+
+export function getCsrfTokenFromCookie(): string | null {
+  const cookies = document.cookie.split(';');
+  for (const cookie of cookies) {
+    const [name, value] = cookie.trim().split('=');
+    if (name === 'csrf-token') {
+      return decodeURIComponent(value);
+    }
+  }
+  return null;
+}
+
+export function getCsrfToken(): string | null {
+  return getCsrfTokenFromMeta() ?? getCsrfTokenFromCookie();
+}
+
+export function updateCsrfTokenMeta(token: string): void {
+  let meta = document.querySelector('meta[name="csrf-token"]');
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.setAttribute('name', 'csrf-token');
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute('content', token);
+  window.dispatchEvent(new CustomEvent(CSRF_TOKEN_REFRESHED_EVENT, { detail: { token } }));
+}
+
+/** Fetch a fresh CSRF token from the server via a lightweight GET request. */
+export async function refreshCsrfToken(): Promise<string> {
+  const response = await fetch(CSRF_REFRESH_PATH, {
+    method: 'GET',
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to refresh CSRF token');
+  }
+
+  const token = response.headers.get('X-CSRF-Token');
+  if (!token) {
+    throw new Error('CSRF token missing from refresh response');
+  }
+
+  updateCsrfTokenMeta(token);
+  return token;
+}


### PR DESCRIPTION
Closes #1644

## Summary

After a session expires (401), the frontend kept using a stale CSRF token from the initial page load. Subsequent POST/PUT/PATCH/DELETE requests failed with CSRF mismatches until the user did a full page reload.

This PR fixes that by automatically refreshing the CSRF token and retrying the failed request once.

**Problem**
- `CsrfTokenProvider` only read the token once on mount
- After 401 session expiry, the meta tag token no longer matched the server's httpOnly cookie
- Users had to hard-refresh to recover

**Solution**
- Added `csrf-client.ts` with `refreshCsrfToken()` — fetches a new token via `GET /api/example` and reads `X-CSRF-Token`
- API client intercepts 401 responses, refreshes the token, and retries the original request once
- Also retries once on 403 CSRF validation failures
- `CsrfTokenProvider` fetches a fresh token on mount and stays in sync via a `csrf-token-refreshed` event

## Changes

- `frontend/src/lib/csrf-client.ts` — token refresh utilities
- `frontend/src/lib/api-client.ts` — 401/403 intercept + single retry
- `frontend/src/components/CsrfTokenProvider.tsx` — mount refresh + event listener
- `frontend/src/__tests__/csrf-client.test.ts` — 5 tests
- `frontend/src/__tests__/api-client.test.ts` — 401/403 retry coverage

## Test plan

- [x] `npx vitest run src/__tests__/csrf-client.test.ts src/__tests__/api-client.test.ts` — 14/14 passing
- [ ] Log in, wait for session to expire (or simulate 401)
- [ ] Submit a form / POST request without reloading
- [ ] Confirm request succeeds after automatic token refresh
- [ ] Confirm `<meta name="csrf-token">` updates without page reload
- [ ] Confirm no infinite retry loop (only one retry per request)