### PR TITLE
fix(frontend): clear React Query cache on network switch

### DIFF
--- a/frontend/src/__tests__/NetworkSwitcher.test.tsx
+++ b/frontend/src/__tests__/NetworkSwitcher.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { NetworkSwitcher } from '@/components/NetworkSwitcher';
+
+const MAINNET_NETWORK = {
+  network: 'mainnet' as const,
+  display_name: 'Mainnet',
+  rpc_url: 'https://stellar.api.onfinality.io/public',
+  horizon_url: 'https://horizon.stellar.org',
+  network_passphrase: 'Public Global Stellar Network ; September 2015',
+  color: '#2563EB',
+  is_mainnet: true,
+  is_testnet: false,
+};
+
+const TESTNET_NETWORK = {
+  network: 'testnet' as const,
+  display_name: 'Testnet',
+  rpc_url: 'https://soroban-testnet.stellar.org',
+  horizon_url: 'https://horizon-testnet.stellar.org',
+  network_passphrase: 'Test SDF Network ; September 2015',
+  color: '#4ECDC4',
+  is_mainnet: false,
+  is_testnet: true,
+};
+
+function renderWithQueryClient(ui: React.ReactElement, queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('NetworkSwitcher', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (url.includes('/api/network/info')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => MAINNET_NETWORK,
+        });
+      }
+      if (url.includes('/api/network/available')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [MAINNET_NETWORK, TESTNET_NETWORK],
+        });
+      }
+      if (url.includes('/api/network/switch')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ message: 'Network switched to testnet.' }),
+        });
+      }
+      return Promise.reject(new Error(`Unhandled fetch: ${url}`));
+    }));
+
+    vi.stubGlobal('alert', vi.fn());
+  });
+
+  it('clears React Query cache when network switch is confirmed', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const clearSpy = vi.spyOn(queryClient, 'clear');
+
+    queryClient.setQueryData(['anchors'], [{ id: 'stale-mainnet' }]);
+
+    renderWithQueryClient(<NetworkSwitcher />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Network: Mainnet/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Network: Mainnet/i }));
+    fireEvent.click(screen.getByRole('option', { name: /Testnet/i }));
+    fireEvent.click(screen.getByLabelText('Confirm switch to Testnet'));
+
+    await waitFor(() => {
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(queryClient.getQueryData(['anchors'])).toBeUndefined();
+  });
+});

--- a/frontend/src/components/NetworkSwitcher.tsx
+++ b/frontend/src/components/NetworkSwitcher.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, AlertTriangle, Wifi, WifiOff } from 'lucide-react';
 import { logger } from '@/lib/logger';
 
@@ -19,6 +20,7 @@ export interface NetworkSwitcherProps {
 }
 
 export function NetworkSwitcher({ className = '', onNetworkChange }: NetworkSwitcherProps) {
+  const queryClient = useQueryClient();
   const [currentNetwork, setCurrentNetwork] = useState<NetworkInfo | null>(null);
   const [availableNetworks, setAvailableNetworks] = useState<NetworkInfo[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -84,10 +86,13 @@ export function NetworkSwitcher({ className = '', onNetworkChange }: NetworkSwit
 
       if (response.ok) {
         const result = await response.json();
-        
+
         // Show message about server restart requirement
         alert(result.message);
-        
+
+        // Clear stale React Query cache so data refetches for the new network
+        queryClient.clear();
+
         // For now, we'll update the local state to show the intended network
         // In a real implementation, this would trigger a server restart
         setCurrentNetwork(pendingNetwork);


### PR DESCRIPTION
Closes #1642

## Summary

Switching networks (testnet ↔ mainnet) updated the context but left stale React Query cache entries intact. Users saw old network data until the cache expired naturally.

This PR clears the entire React Query cache when a network switch succeeds, forcing all queries to refetch with the new network context.

**Problem**
- `NetworkSwitcher` updated local network state via context
- Cached API responses from the previous network remained in React Query
- Dashboard and other views showed stale testnet/mainnet data after switching

**Fix**
- Call `queryClient.clear()` in `confirmNetworkSwitch()` after a successful `POST /api/network/switch`
- Added unit test confirming cache is cleared on network switch confirmation

## Changes

- `frontend/src/components/NetworkSwitcher.tsx` — `useQueryClient()` + `queryClient.clear()`
- `frontend/src/__tests__/NetworkSwitcher.test.tsx` — cache invalidation test

## Test plan

- [x] `npx vitest run src/__tests__/NetworkSwitcher.test.tsx` — 1/1 passing
- [ ] Switch from mainnet → testnet in the UI
- [ ] Confirm dashboard/anchor data refetches (no stale mainnet values)
- [ ] Switch back testnet → mainnet and verify data updates again
- [ ] Cancel a network switch — cache should **not** be cleared