### PR TITLE
fix: events, CEI reentrancy guard, token revocation, mainnet deploy s…

### DIFF
--- a/backend/migrations/034_add_token_revocations.sql
+++ b/backend/migrations/034_add_token_revocations.sql
@@ -1,0 +1,20 @@
+-- Token revocation table.
+-- Each row represents an access token (identified by its jti claim) that has
+-- been explicitly invalidated before natural expiry — e.g. after a password
+-- change or key rotation.  The middleware rejects any token whose jti appears
+-- here and whose expires_at has not yet passed.
+--
+-- Rows can be safely pruned once expires_at < strftime('%s','now').
+
+CREATE TABLE IF NOT EXISTS token_revocations (
+    jti        TEXT    NOT NULL PRIMARY KEY,
+    user_id    TEXT    NOT NULL,
+    revoked_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_token_revocations_user_id
+    ON token_revocations (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_token_revocations_expires_at
+    ON token_revocations (expires_at);

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
 // Token expiry constants
 const ACCESS_TOKEN_EXPIRY_HOURS: i64 = 1;
@@ -73,6 +74,8 @@ pub struct Claims {
     pub exp: i64,           // Expiry timestamp
     pub iat: i64,           // Issued at timestamp
     pub token_type: String, // "access" or "refresh"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jti: Option<String>, // JWT ID — present on access tokens for revocation checks
 }
 
 /// Authentication service
@@ -148,6 +151,7 @@ impl AuthService {
             exp: expiration,
             iat: Utc::now().timestamp(),
             token_type: "access".to_string(),
+            jti: Some(Uuid::new_v4().to_string()),
         };
 
         encode(
@@ -171,6 +175,7 @@ impl AuthService {
             exp: expiration,
             iat: Utc::now().timestamp(),
             token_type: "refresh".to_string(),
+            jti: None,
         };
 
         encode(

--- a/backend/src/auth_middleware.rs
+++ b/backend/src/auth_middleware.rs
@@ -4,7 +4,9 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use chrono::Utc;
 use serde_json::json;
+use sqlx::SqlitePool;
 use std::sync::Arc;
 
 use crate::auth::Claims;
@@ -12,6 +14,10 @@ use crate::auth::Claims;
 /// JWT secret shared via extension
 #[derive(Clone)]
 pub struct JwtSecret(pub Arc<str>);
+
+/// SQLite pool for token revocation lookups, shared via extension
+#[derive(Clone)]
+pub struct TokenRevocationStore(pub Arc<SqlitePool>);
 
 /// Extract user from authenticated request
 #[derive(Debug, Clone)]
@@ -39,28 +45,35 @@ where
     }
 }
 
-/// Auth middleware - validates JWT from Authorization header
+/// Auth middleware - validates JWT and checks token revocation
 pub async fn auth_middleware(
     Extension(JwtSecret(jwt_secret)): Extension<JwtSecret>,
+    Extension(revocation_store): Extension<TokenRevocationStore>,
     mut req: Request,
     next: Next,
 ) -> Result<Response, AuthError> {
-    // Extract Authorization header
     let auth_header = req
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
         .ok_or(AuthError::MissingToken)?;
 
-    // Extract Bearer token
     let token = auth_header
         .strip_prefix("Bearer ")
         .ok_or(AuthError::InvalidToken)?;
 
-    // Validate token
     let claims = validate_access_token(token, jwt_secret.as_ref())?;
 
-    // Attach user to request extensions
+    // Check revocation table if the token carries a jti
+    if let Some(ref jti) = claims.jti {
+        if is_token_revoked(&revocation_store, jti)
+            .await
+            .map_err(|_| AuthError::InvalidToken)?
+        {
+            return Err(AuthError::InvalidToken);
+        }
+    }
+
     let auth_user = AuthUser {
         user_id: claims.sub,
         username: claims.username,
@@ -68,6 +81,48 @@ pub async fn auth_middleware(
     req.extensions_mut().insert(auth_user);
 
     Ok(next.run(req).await)
+}
+
+/// Returns true when the jti is in the revocations table and has not yet expired.
+async fn is_token_revoked(
+    store: &TokenRevocationStore,
+    jti: &str,
+) -> Result<bool, sqlx::Error> {
+    let revoked: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM token_revocations
+            WHERE jti = ? AND expires_at > strftime('%s', 'now')
+        )",
+    )
+    .bind(jti)
+    .fetch_one(store.0.as_ref())
+    .await?;
+
+    Ok(revoked)
+}
+
+/// Insert a revocation record so the given jti is rejected until expires_at.
+/// Call this on password change or key rotation, passing the old token's jti
+/// and the token's original exp timestamp as expires_at.
+pub async fn revoke_token(
+    store: &TokenRevocationStore,
+    jti: &str,
+    user_id: &str,
+    expires_at: i64,
+) -> Result<(), sqlx::Error> {
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        "INSERT OR IGNORE INTO token_revocations (jti, user_id, revoked_at, expires_at)
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(jti)
+    .bind(user_id)
+    .bind(now)
+    .bind(expires_at)
+    .execute(store.0.as_ref())
+    .await?;
+
+    Ok(())
 }
 
 /// Validate access token
@@ -82,7 +137,6 @@ fn validate_access_token(token: &str, secret: &str) -> Result<Claims, AuthError>
         &validation,
     )
     .map(|data| {
-        // Verify it's an access token
         if data.claims.token_type != "access" {
             return Err(AuthError::InvalidToken);
         }

--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -34,4 +34,6 @@ pub enum Error {
     TransferFailed = 14,
     /// Contract is paused
     ContractPaused = 15,
+    /// Reentrant call detected
+    Reentrancy = 16,
 }

--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -52,3 +52,11 @@ pub fn emit_cancelled(env: &Env, escrow_id: u64, cancelled_by: Address) {
         (escrow_id, cancelled_by),
     );
 }
+
+pub fn emit_paused(env: &Env, admin: Address) {
+    env.events().publish((symbol_short!("ESC_PAU"),), admin);
+}
+
+pub fn emit_unpaused(env: &Env, admin: Address) {
+    env.events().publish((symbol_short!("ESC_UNP"),), admin);
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -6,7 +6,8 @@ mod events;
 use errors::Error;
 use events::{
     emit_cancelled, emit_dispute_raised, emit_dispute_resolved, emit_escrow_created,
-    emit_escrow_funded, emit_funds_released, emit_initialized, emit_refunded,
+    emit_escrow_funded, emit_funds_released, emit_initialized, emit_paused, emit_refunded,
+    emit_unpaused,
 };
 use soroban_sdk::{
     contract, contractimpl, contracttype, token, Address, Env, String,
@@ -23,6 +24,26 @@ fn bump_instance(env: &Env) {
     env.storage()
         .instance()
         .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND);
+}
+
+fn require_not_locked(env: &Env) -> Result<(), Error> {
+    if env
+        .storage()
+        .instance()
+        .get::<DataKey, bool>(&DataKey::Locked)
+        .unwrap_or(false)
+    {
+        return Err(Error::Reentrancy);
+    }
+    Ok(())
+}
+
+fn set_locked(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &true);
+}
+
+fn set_unlocked(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &false);
 }
 
 // ============================================================================
@@ -80,6 +101,7 @@ pub enum DataKey {
     Paused,
     Version,
     Escrow(u64),
+    Locked,
 }
 
 // ============================================================================
@@ -137,6 +159,7 @@ impl EscrowServiceContract {
         }
         env.storage().instance().set(&DataKey::Paused, &true);
         bump_instance(&env);
+        emit_paused(&env, caller);
         Ok(())
     }
 
@@ -152,6 +175,7 @@ impl EscrowServiceContract {
         }
         env.storage().instance().set(&DataKey::Paused, &false);
         bump_instance(&env);
+        emit_unpaused(&env, caller);
         Ok(())
     }
 
@@ -232,6 +256,8 @@ impl EscrowServiceContract {
     /// The depositor transfers the agreed amount to this contract.
     /// Can only be called when the escrow is in the `Created` state.
     pub fn fund_escrow(env: Env, caller: Address, escrow_id: u64) -> Result<(), Error> {
+        require_not_locked(&env)?;
+
         let paused: bool = env
             .storage()
             .instance()
@@ -262,12 +288,13 @@ impl EscrowServiceContract {
             return Err(Error::DeadlineExpired);
         }
 
-        let token_client = token::Client::new(&env, &escrow.token);
-        token_client.transfer(&caller, &env.current_contract_address(), &escrow.amount);
-
-        escrow.state = EscrowState::Funded;
+        // Save values before mutating escrow
         let depositor = escrow.depositor.clone();
         let amount = escrow.amount;
+        let token = escrow.token.clone();
+
+        // Effect: update state before external call (CEI)
+        escrow.state = EscrowState::Funded;
         env.storage()
             .persistent()
             .set(&DataKey::Escrow(escrow_id), &escrow);
@@ -276,6 +303,11 @@ impl EscrowServiceContract {
             ESCROW_TTL_THRESHOLD,
             ESCROW_TTL_EXTEND,
         );
+
+        // Interaction: external token call under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &token).transfer(&caller, &env.current_contract_address(), &amount);
+        set_unlocked(&env);
 
         emit_escrow_funded(&env, escrow_id, depositor, amount);
 
@@ -287,6 +319,8 @@ impl EscrowServiceContract {
     /// Only the depositor can release funds. The escrow must be in the `Funded`
     /// state (not disputed).
     pub fn release_funds(env: Env, caller: Address, escrow_id: u64) -> Result<(), Error> {
+        require_not_locked(&env)?;
+
         caller.require_auth();
 
         let mut escrow: Escrow = env
@@ -303,16 +337,12 @@ impl EscrowServiceContract {
             return Err(Error::Unauthorized);
         }
 
-        let token_client = token::Client::new(&env, &escrow.token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &escrow.beneficiary,
-            &escrow.amount,
-        );
-
-        escrow.state = EscrowState::Released;
+        let token = escrow.token.clone();
         let beneficiary = escrow.beneficiary.clone();
         let amount = escrow.amount;
+
+        // Effect: update state before external call (CEI)
+        escrow.state = EscrowState::Released;
         env.storage()
             .persistent()
             .set(&DataKey::Escrow(escrow_id), &escrow);
@@ -321,6 +351,15 @@ impl EscrowServiceContract {
             ESCROW_TTL_THRESHOLD,
             ESCROW_TTL_EXTEND,
         );
+
+        // Interaction: external token call under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &beneficiary,
+            &amount,
+        );
+        set_unlocked(&env);
 
         emit_funds_released(&env, escrow_id, beneficiary, amount);
 
@@ -332,6 +371,8 @@ impl EscrowServiceContract {
     /// Only the depositor can call this. The escrow must be `Funded` and the
     /// deadline must have passed.
     pub fn refund(env: Env, caller: Address, escrow_id: u64) -> Result<(), Error> {
+        require_not_locked(&env)?;
+
         caller.require_auth();
 
         let mut escrow: Escrow = env
@@ -353,16 +394,12 @@ impl EscrowServiceContract {
             return Err(Error::DeadlineNotExpired);
         }
 
-        let token_client = token::Client::new(&env, &escrow.token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &escrow.depositor,
-            &escrow.amount,
-        );
-
-        escrow.state = EscrowState::Refunded;
+        let token = escrow.token.clone();
         let depositor = escrow.depositor.clone();
         let amount = escrow.amount;
+
+        // Effect: update state before external call (CEI)
+        escrow.state = EscrowState::Refunded;
         env.storage()
             .persistent()
             .set(&DataKey::Escrow(escrow_id), &escrow);
@@ -371,6 +408,15 @@ impl EscrowServiceContract {
             ESCROW_TTL_THRESHOLD,
             ESCROW_TTL_EXTEND,
         );
+
+        // Interaction: external token call under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &depositor,
+            &amount,
+        );
+        set_unlocked(&env);
 
         emit_refunded(&env, escrow_id, depositor, amount);
 
@@ -424,6 +470,8 @@ impl EscrowServiceContract {
         escrow_id: u64,
         release_to_beneficiary: bool,
     ) -> Result<(), Error> {
+        require_not_locked(&env)?;
+
         caller.require_auth();
 
         let admin: Address = env
@@ -446,21 +494,16 @@ impl EscrowServiceContract {
             return Err(Error::NotDisputed);
         }
 
-        let token_client = token::Client::new(&env, &escrow.token);
+        let token = escrow.token.clone();
         let (recipient, new_state) = if release_to_beneficiary {
             (escrow.beneficiary.clone(), EscrowState::Released)
         } else {
             (escrow.depositor.clone(), EscrowState::Refunded)
         };
-
-        token_client.transfer(
-            &env.current_contract_address(),
-            &recipient,
-            &escrow.amount,
-        );
-
         let winner = recipient.clone();
         let amount = escrow.amount;
+
+        // Effect: update state before external call (CEI)
         escrow.state = new_state;
         env.storage()
             .persistent()
@@ -470,6 +513,15 @@ impl EscrowServiceContract {
             ESCROW_TTL_THRESHOLD,
             ESCROW_TTL_EXTEND,
         );
+
+        // Interaction: external token call under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &amount,
+        );
+        set_unlocked(&env);
 
         emit_dispute_resolved(&env, escrow_id, winner, amount);
 

--- a/contracts/multi-sig-wallet/src/errors.rs
+++ b/contracts/multi-sig-wallet/src/errors.rs
@@ -32,4 +32,6 @@ pub enum Error {
     TxIdOverflow = 13,
     /// Duplicate address in owners list
     DuplicateOwner = 14,
+    /// Reentrant call detected
+    Reentrancy = 15,
 }

--- a/contracts/multi-sig-wallet/src/events.rs
+++ b/contracts/multi-sig-wallet/src/events.rs
@@ -1,7 +1,8 @@
-use soroban_sdk::{symbol_short, Address, Env};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
 
-pub fn emit_initialized(env: &Env, threshold: u32) {
-    env.events().publish((symbol_short!("MSW_INI"),), threshold);
+pub fn emit_initialized(env: &Env, owners: &Vec<Address>, threshold: u32) {
+    env.events()
+        .publish((symbol_short!("MSW_INI"),), (owners.clone(), threshold));
 }
 
 pub fn emit_tx_proposed(env: &Env, tx_id: u64, proposer: Address, amount: i128) {

--- a/contracts/multi-sig-wallet/src/lib.rs
+++ b/contracts/multi-sig-wallet/src/lib.rs
@@ -23,6 +23,26 @@ fn bump_instance(env: &Env) {
         .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND);
 }
 
+fn require_not_locked(env: &Env) -> Result<(), Error> {
+    if env
+        .storage()
+        .instance()
+        .get::<DataKey, bool>(&DataKey::Locked)
+        .unwrap_or(false)
+    {
+        return Err(Error::Reentrancy);
+    }
+    Ok(())
+}
+
+fn set_locked(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &true);
+}
+
+fn set_unlocked(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &false);
+}
+
 // ============================================================================
 // Data Types
 // ============================================================================
@@ -73,6 +93,7 @@ pub enum DataKey {
     Version,
     Tx(u64),
     Confirmers(u64),
+    Locked,
 }
 
 // ============================================================================
@@ -123,7 +144,7 @@ impl MultiSigWalletContract {
             .instance()
             .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND);
 
-        emit_initialized(&env, threshold);
+        emit_initialized(&env, &owners, threshold);
         Ok(())
     }
 
@@ -376,6 +397,8 @@ impl MultiSigWalletContract {
     ///
     /// Transfers tokens held by this contract to the recipient.
     pub fn execute_tx(env: Env, caller: Address, tx_id: u64) -> Result<(), Error> {
+        require_not_locked(&env)?;
+
         caller.require_auth();
         Self::require_owner(&env, &caller)?;
 
@@ -402,17 +425,23 @@ impl MultiSigWalletContract {
             return Err(Error::ThresholdNotMet);
         }
 
-        let token_client = token::Client::new(&env, &tx.token);
-        token_client.transfer(&env.current_contract_address(), &tx.to, &tx.amount);
-
+        let token = tx.token.clone();
+        let to = tx.to.clone();
         let amount = tx.amount;
+
+        // Effect: mark executed before external call (CEI)
         tx.state = TxState::Executed;
         env.storage().persistent().set(&DataKey::Tx(tx_id), &tx);
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::Tx(tx_id), TX_TTL_THRESHOLD, TX_TTL_EXTEND);
-
         bump_instance(&env);
+
+        // Interaction: token transfer under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &token).transfer(&env.current_contract_address(), &to, &amount);
+        set_unlocked(&env);
+
         emit_tx_executed(&env, tx_id, caller, amount);
         Ok(())
     }

--- a/contracts/time-locked-transactions/src/events.rs
+++ b/contracts/time-locked-transactions/src/events.rs
@@ -27,3 +27,11 @@ pub fn emit_cancelled(env: &Env, tx_id: u64, cancelled_by: Address) {
     env.events()
         .publish((symbol_short!("TLT_CAN"),), (tx_id, cancelled_by));
 }
+
+pub fn emit_paused(env: &Env, admin: Address) {
+    env.events().publish((symbol_short!("TLT_PAU"),), admin);
+}
+
+pub fn emit_unpaused(env: &Env, admin: Address) {
+    env.events().publish((symbol_short!("TLT_UNP"),), admin);
+}

--- a/contracts/time-locked-transactions/src/lib.rs
+++ b/contracts/time-locked-transactions/src/lib.rs
@@ -4,7 +4,7 @@ mod errors;
 mod events;
 
 use errors::Error;
-use events::{emit_cancelled, emit_executed, emit_initialized, emit_scheduled};
+use events::{emit_cancelled, emit_executed, emit_initialized, emit_paused, emit_scheduled, emit_unpaused};
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -133,6 +133,7 @@ impl TimeLockedTransactionsContract {
         }
         env.storage().instance().set(&DataKey::Paused, &true);
         bump_instance(&env);
+        emit_paused(&env, caller);
         Ok(())
     }
 
@@ -148,6 +149,7 @@ impl TimeLockedTransactionsContract {
         }
         env.storage().instance().set(&DataKey::Paused, &false);
         bump_instance(&env);
+        emit_unpaused(&env, caller);
         Ok(())
     }
 

--- a/contracts/token-swap/src/errors.rs
+++ b/contracts/token-swap/src/errors.rs
@@ -26,4 +26,6 @@ pub enum Error {
     SameToken = 10,
     /// Contract is paused
     ContractPaused = 11,
+    /// Reentrant call detected
+    Reentrancy = 12,
 }

--- a/contracts/token-swap/src/events.rs
+++ b/contracts/token-swap/src/events.rs
@@ -26,3 +26,11 @@ pub fn emit_offer_cancelled(env: &Env, offer_id: u64, cancelled_by: Address) {
     env.events()
         .publish((symbol_short!("TSW_CAN"),), (offer_id, cancelled_by));
 }
+
+pub fn emit_paused(env: &Env, admin: Address) {
+    env.events().publish((symbol_short!("TSW_PAU"),), admin);
+}
+
+pub fn emit_unpaused(env: &Env, admin: Address) {
+    env.events().publish((symbol_short!("TSW_UNP"),), admin);
+}

--- a/contracts/token-swap/src/lib.rs
+++ b/contracts/token-swap/src/lib.rs
@@ -4,7 +4,10 @@ mod errors;
 mod events;
 
 use errors::Error;
-use events::{emit_initialized, emit_offer_accepted, emit_offer_cancelled, emit_offer_created};
+use events::{
+    emit_initialized, emit_offer_accepted, emit_offer_cancelled, emit_offer_created, emit_paused,
+    emit_unpaused,
+};
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -18,6 +21,26 @@ fn bump_instance(env: &Env) {
     env.storage()
         .instance()
         .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND);
+}
+
+fn require_not_locked(env: &Env) -> Result<(), Error> {
+    if env
+        .storage()
+        .instance()
+        .get::<DataKey, bool>(&DataKey::Locked)
+        .unwrap_or(false)
+    {
+        return Err(Error::Reentrancy);
+    }
+    Ok(())
+}
+
+fn set_locked(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &true);
+}
+
+fn set_unlocked(env: &Env) {
+    env.storage().instance().set(&DataKey::Locked, &false);
 }
 
 // ============================================================================
@@ -71,6 +94,7 @@ pub enum DataKey {
     Paused,
     Version,
     Offer(u64),
+    Locked,
 }
 
 // ============================================================================
@@ -135,6 +159,7 @@ impl TokenSwapContract {
         }
         env.storage().instance().set(&DataKey::Paused, &true);
         bump_instance(&env);
+        emit_paused(&env, caller);
         Ok(())
     }
 
@@ -150,6 +175,7 @@ impl TokenSwapContract {
         }
         env.storage().instance().set(&DataKey::Paused, &false);
         bump_instance(&env);
+        emit_unpaused(&env, caller);
         Ok(())
     }
 
@@ -191,6 +217,8 @@ impl TokenSwapContract {
         want_amount: i128,
         expiry: u64,
     ) -> Result<u64, Error> {
+        require_not_locked(&env)?;
+
         let paused: bool = env
             .storage()
             .instance()
@@ -212,7 +240,6 @@ impl TokenSwapContract {
             return Err(Error::SameToken);
         }
 
-        // Validate expiry if set
         if expiry != 0 && expiry <= env.ledger().timestamp() {
             return Err(Error::OfferExpired);
         }
@@ -224,14 +251,10 @@ impl TokenSwapContract {
             .unwrap_or(0);
         count = count.checked_add(1).ok_or(Error::OfferIdOverflow)?;
 
-        // Deposit offer tokens from maker into this contract
-        let offer_token_client = token::Client::new(&env, &offer_token);
-        offer_token_client.transfer(&maker, &env.current_contract_address(), &offer_amount);
-
         let offer = Offer {
             id: count,
             maker: maker.clone(),
-            offer_token,
+            offer_token: offer_token.clone(),
             offer_amount,
             want_token,
             want_amount,
@@ -240,6 +263,7 @@ impl TokenSwapContract {
             created_at: env.ledger().timestamp(),
         };
 
+        // Effect: record offer before external call (CEI)
         env.storage()
             .persistent()
             .set(&DataKey::Offer(count), &offer);
@@ -248,9 +272,17 @@ impl TokenSwapContract {
             OFFER_TTL_THRESHOLD,
             OFFER_TTL_EXTEND,
         );
-
         env.storage().instance().set(&DataKey::OfferCount, &count);
         bump_instance(&env);
+
+        // Interaction: pull offer tokens from maker under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &offer_token).transfer(
+            &maker,
+            &env.current_contract_address(),
+            &offer_amount,
+        );
+        set_unlocked(&env);
 
         emit_offer_created(&env, count, maker, offer_amount, want_amount);
         Ok(count)
@@ -260,6 +292,8 @@ impl TokenSwapContract {
     ///
     /// The taker sends want_token to the maker and receives offer_token from this contract.
     pub fn accept_offer(env: Env, taker: Address, offer_id: u64) -> Result<(), Error> {
+        require_not_locked(&env)?;
+
         let paused: bool = env
             .storage()
             .instance()
@@ -284,23 +318,17 @@ impl TokenSwapContract {
             return Err(Error::AlreadyCancelled);
         }
 
-        // Enforce expiry if set
         if offer.expiry != 0 && env.ledger().timestamp() > offer.expiry {
             return Err(Error::OfferExpired);
         }
 
-        // Taker sends want_token directly to maker
-        let want_token_client = token::Client::new(&env, &offer.want_token);
-        want_token_client.transfer(&taker, &offer.maker, &offer.want_amount);
+        let want_token = offer.want_token.clone();
+        let offer_token = offer.offer_token.clone();
+        let maker = offer.maker.clone();
+        let want_amount = offer.want_amount;
+        let offer_amount = offer.offer_amount;
 
-        // Contract sends offer_token to taker
-        let offer_token_client = token::Client::new(&env, &offer.offer_token);
-        offer_token_client.transfer(
-            &env.current_contract_address(),
-            &taker,
-            &offer.offer_amount,
-        );
-
+        // Effect: mark filled before external calls (CEI)
         offer.state = OfferState::Filled;
         env.storage()
             .persistent()
@@ -310,8 +338,18 @@ impl TokenSwapContract {
             OFFER_TTL_THRESHOLD,
             OFFER_TTL_EXTEND,
         );
-
         bump_instance(&env);
+
+        // Interaction: atomic swap under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &want_token).transfer(&taker, &maker, &want_amount);
+        token::Client::new(&env, &offer_token).transfer(
+            &env.current_contract_address(),
+            &taker,
+            &offer_amount,
+        );
+        set_unlocked(&env);
+
         emit_offer_accepted(&env, offer_id, taker);
         Ok(())
     }
@@ -321,6 +359,8 @@ impl TokenSwapContract {
     /// The maker may cancel at any time. The admin may cancel for emergency.
     /// After expiry, any caller may trigger a cancel on behalf of the maker.
     pub fn cancel_offer(env: Env, caller: Address, offer_id: u64) -> Result<(), Error> {
+        require_not_locked(&env)?;
+
         caller.require_auth();
 
         let admin: Address = env
@@ -345,19 +385,15 @@ impl TokenSwapContract {
         let now = env.ledger().timestamp();
         let expired = offer.expiry != 0 && now > offer.expiry;
 
-        // Allow: maker, admin, or anyone after expiry
         if caller != offer.maker && caller != admin && !expired {
             return Err(Error::Unauthorized);
         }
 
-        // Return offer tokens to maker
-        let offer_token_client = token::Client::new(&env, &offer.offer_token);
-        offer_token_client.transfer(
-            &env.current_contract_address(),
-            &offer.maker,
-            &offer.offer_amount,
-        );
+        let offer_token = offer.offer_token.clone();
+        let maker = offer.maker.clone();
+        let offer_amount = offer.offer_amount;
 
+        // Effect: mark cancelled before external call (CEI)
         offer.state = OfferState::Cancelled;
         env.storage()
             .persistent()
@@ -367,8 +403,17 @@ impl TokenSwapContract {
             OFFER_TTL_THRESHOLD,
             OFFER_TTL_EXTEND,
         );
-
         bump_instance(&env);
+
+        // Interaction: return tokens to maker under reentrancy lock
+        set_locked(&env);
+        token::Client::new(&env, &offer_token).transfer(
+            &env.current_contract_address(),
+            &maker,
+            &offer_amount,
+        );
+        set_unlocked(&env);
+
         emit_offer_cancelled(&env, offer_id, caller);
         Ok(())
     }

--- a/scripts/deploy-contracts-mainnet.sh
+++ b/scripts/deploy-contracts-mainnet.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Deploy all Soroban contracts to mainnet with step-by-step human approval gates.
+#
+# Usage:
+#   ./scripts/deploy-contracts-mainnet.sh [--source <identity>] [--fee <stroop>] [--dry-run]
+#
+# Prerequisites:
+#   - stellar CLI installed and authenticated (stellar keys list)
+#   - STELLAR_ACCOUNT env var set, or pass --source <identity>
+#   - Network: mainnet (https://horizon.stellar.org)
+#   - All contracts built for release first:
+#       cd contracts && cargo build --release --target wasm32-unknown-unknown
+#
+# Deploy order (respects contract dependencies):
+#   access-control → stellar_insights → analytics → governance →
+#   escrow → token-swap → multi-sig-wallet → time-locked-transactions → upgrade
+#
+# Each contract is deployed only after the operator presses Enter.
+# Ctrl-C at any gate aborts the run without deploying subsequent contracts.
+
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+CONTRACTS_DIR="$(cd "$(dirname "$0")/../contracts" && pwd)"
+ENV_FILE="${CONTRACTS_DIR}/.env.mainnet"
+NETWORK="mainnet"
+RPC_URL="https://mainnet.sorobanrpc.com"
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+FEE="${STELLAR_FEE:-1000}"
+
+# ── Parse arguments ────────────────────────────────────────────────────────────
+
+SOURCE="${STELLAR_ACCOUNT:-}"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --source)  SOURCE="$2";   shift 2 ;;
+        --fee)     FEE="$2";      shift 2 ;;
+        --dry-run) DRY_RUN=true;  shift   ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+if [[ -z "${SOURCE}" ]]; then
+    echo "Error: deployer identity not set."
+    echo "  Set STELLAR_ACCOUNT env var or pass --source <identity>"
+    exit 1
+fi
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+YEL='\033[1;33m'
+GRN='\033[0;32m'
+NC='\033[0m'
+
+log()   { echo "[$(date -u +%H:%M:%S)] $*"; }
+info()  { echo "  $*"; }
+warn()  { echo -e "  ${YEL}WARNING:${NC} $*"; }
+success(){ echo -e "  ${GRN}OK${NC} $*"; }
+
+# Print a prominent gate and wait for operator confirmation.
+approval_gate() {
+    local label="$1"
+    echo ""
+    echo -e "${YEL}──────────────────────────────────────────────────────────${NC}"
+    echo -e "${YEL}  APPROVAL GATE — ${label}${NC}"
+    echo -e "${YEL}──────────────────────────────────────────────────────────${NC}"
+    echo "  Review the deployment above before continuing."
+    echo "  Press ENTER to proceed or Ctrl-C to abort."
+    read -r
+}
+
+deploy_contract() {
+    local name="$1"
+    local wasm="$2"
+    local alias="$3"
+
+    log "Deploying ${name}..."
+
+    if [[ ! -f "${wasm}" ]]; then
+        echo "  Error: wasm not found at ${wasm}"
+        echo "  Run 'cd contracts && cargo build --release --target wasm32-unknown-unknown' first."
+        exit 1
+    fi
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        local fake_id="DRYRUN_${alias}"
+        info "[dry-run] would deploy ${name} → ${alias}=${fake_id}"
+        echo "${alias}=${fake_id}" >> "${ENV_FILE}"
+        echo "${fake_id}"
+        return
+    fi
+
+    local contract_id
+    contract_id=$(stellar contract deploy \
+        --wasm "${wasm}" \
+        --source "${SOURCE}" \
+        --network "${NETWORK}" \
+        --rpc-url "${RPC_URL}" \
+        --network-passphrase "${NETWORK_PASSPHRASE}" \
+        --fee "${FEE}" \
+        2>&1 | grep -E '^[A-Z0-9]{56}$' | tail -1)
+
+    if [[ -z "${contract_id}" ]]; then
+        echo "  Error: failed to deploy ${name} — no contract ID returned."
+        exit 1
+    fi
+
+    success "${name} deployed: ${contract_id}"
+    info "${alias}=${contract_id}"
+    echo "${alias}=${contract_id}" >> "${ENV_FILE}"
+    echo "${contract_id}"
+}
+
+# ── Pre-flight checks ──────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${RED}╔══════════════════════════════════════════════════════════╗${NC}"
+echo -e "${RED}║        MAINNET DEPLOYMENT — IRREVERSIBLE OPERATION       ║${NC}"
+echo -e "${RED}╚══════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo "  Network:   ${NETWORK}"
+echo "  RPC URL:   ${RPC_URL}"
+echo "  Deployer:  ${SOURCE}"
+echo "  Fee:       ${FEE} stroops per operation"
+echo "  Env file:  ${ENV_FILE}"
+if [[ "${DRY_RUN}" == "true" ]]; then
+    warn "DRY-RUN mode — no transactions will be submitted"
+fi
+echo ""
+warn "Mainnet deployments cannot be undone."
+warn "Ensure all contracts have passed security review and testnet verification."
+warn "Ensure the deployer account is funded with sufficient XLM."
+echo ""
+echo "  Press ENTER to begin or Ctrl-C to abort."
+read -r
+
+# Verify stellar CLI is available
+if ! command -v stellar &>/dev/null; then
+    echo "Error: 'stellar' CLI not found. Install it and try again."
+    exit 1
+fi
+
+# Verify deployer identity exists
+if ! stellar keys show "${SOURCE}" &>/dev/null; then
+    echo "Error: identity '${SOURCE}' not found. Run 'stellar keys list' to see available keys."
+    exit 1
+fi
+
+# ── Build ──────────────────────────────────────────────────────────────────────
+
+log "Building all contracts for release..."
+(cd "${CONTRACTS_DIR}" && cargo build --release --target wasm32-unknown-unknown 2>&1 | tail -5)
+log "Build complete."
+echo ""
+
+# ── Start fresh env file ───────────────────────────────────────────────────────
+
+WASM_DIR="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release"
+
+cat > "${ENV_FILE}" <<EOF
+# Mainnet contract IDs — generated by deploy-contracts-mainnet.sh
+# Network:    ${NETWORK}
+# RPC URL:    ${RPC_URL}
+# Passphrase: ${NETWORK_PASSPHRASE}
+# Deployer:   ${SOURCE}
+# Deployed:   $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+EOF
+
+# ── Deploy with approval gates ─────────────────────────────────────────────────
+
+log "Starting mainnet deployment..."
+
+# 1. access-control — no dependencies
+echo ""
+info "Contract 1/9: access-control (no dependencies)"
+approval_gate "access-control"
+ACCESS_CONTROL_ID=$(deploy_contract \
+    "access-control" \
+    "${WASM_DIR}/access_control.wasm" \
+    "ACCESS_CONTROL_CONTRACT_ID")
+
+# 2. stellar_insights — depends on access-control
+echo ""
+info "Contract 2/9: stellar_insights (depends on access-control)"
+info "  ACCESS_CONTROL_CONTRACT_ID=${ACCESS_CONTROL_ID}"
+approval_gate "stellar_insights"
+STELLAR_INSIGHTS_ID=$(deploy_contract \
+    "stellar_insights" \
+    "${WASM_DIR}/stellar_insights.wasm" \
+    "STELLAR_INSIGHTS_CONTRACT_ID")
+
+# 3. analytics — depends on stellar_insights
+echo ""
+info "Contract 3/9: analytics (depends on stellar_insights)"
+info "  STELLAR_INSIGHTS_CONTRACT_ID=${STELLAR_INSIGHTS_ID}"
+approval_gate "analytics"
+ANALYTICS_ID=$(deploy_contract \
+    "analytics" \
+    "${WASM_DIR}/analytics.wasm" \
+    "ANALYTICS_CONTRACT_ID")
+
+# 4. governance — depends on analytics
+echo ""
+info "Contract 4/9: governance (depends on analytics)"
+info "  ANALYTICS_CONTRACT_ID=${ANALYTICS_ID}"
+approval_gate "governance"
+GOVERNANCE_ID=$(deploy_contract \
+    "governance" \
+    "${WASM_DIR}/governance.wasm" \
+    "GOVERNANCE_CONTRACT_ID")
+
+# 5. escrow — depends on stellar_insights
+echo ""
+info "Contract 5/9: escrow (depends on stellar_insights)"
+approval_gate "escrow"
+ESCROW_ID=$(deploy_contract \
+    "escrow" \
+    "${WASM_DIR}/escrow.wasm" \
+    "ESCROW_CONTRACT_ID")
+
+# 6. token-swap — depends on stellar_insights
+echo ""
+info "Contract 6/9: token-swap (depends on stellar_insights)"
+approval_gate "token-swap"
+TOKEN_SWAP_ID=$(deploy_contract \
+    "token-swap" \
+    "${WASM_DIR}/token_swap.wasm" \
+    "TOKEN_SWAP_CONTRACT_ID")
+
+# 7. multi-sig-wallet — depends on access-control
+echo ""
+info "Contract 7/9: multi-sig-wallet (depends on access-control)"
+approval_gate "multi-sig-wallet"
+MULTI_SIG_ID=$(deploy_contract \
+    "multi-sig-wallet" \
+    "${WASM_DIR}/multi_sig_wallet.wasm" \
+    "MULTI_SIG_WALLET_CONTRACT_ID")
+
+# 8. time-locked-transactions — depends on access-control
+echo ""
+info "Contract 8/9: time-locked-transactions (depends on access-control)"
+approval_gate "time-locked-transactions"
+TIME_LOCKED_ID=$(deploy_contract \
+    "time-locked-transactions" \
+    "${WASM_DIR}/time_locked_transactions.wasm" \
+    "TIME_LOCKED_TRANSACTIONS_CONTRACT_ID")
+
+# 9. upgrade — depends on governance
+echo ""
+info "Contract 9/9: upgrade (depends on governance)"
+info "  GOVERNANCE_CONTRACT_ID=${GOVERNANCE_ID}"
+approval_gate "upgrade"
+UPGRADE_ID=$(deploy_contract \
+    "upgrade" \
+    "${WASM_DIR}/upgrade.wasm" \
+    "UPGRADE_CONTRACT_ID")
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GRN}══════════════════════════════════════════════════════════${NC}"
+log "All contracts deployed successfully."
+log "Contract IDs written to: ${ENV_FILE}"
+echo ""
+echo "  ACCESS_CONTROL_CONTRACT_ID=${ACCESS_CONTROL_ID}"
+echo "  STELLAR_INSIGHTS_CONTRACT_ID=${STELLAR_INSIGHTS_ID}"
+echo "  ANALYTICS_CONTRACT_ID=${ANALYTICS_ID}"
+echo "  GOVERNANCE_CONTRACT_ID=${GOVERNANCE_ID}"
+echo "  ESCROW_CONTRACT_ID=${ESCROW_ID}"
+echo "  TOKEN_SWAP_CONTRACT_ID=${TOKEN_SWAP_ID}"
+echo "  MULTI_SIG_WALLET_CONTRACT_ID=${MULTI_SIG_ID}"
+echo "  TIME_LOCKED_TRANSACTIONS_CONTRACT_ID=${TIME_LOCKED_ID}"
+echo "  UPGRADE_CONTRACT_ID=${UPGRADE_ID}"
+echo ""
+log "Source the env file with: source ${ENV_FILE}"
+log "Run verification:         ./scripts/verify-contract-mainnet.sh"
+echo -e "${GRN}══════════════════════════════════════════════════════════${NC}"

--- a/scripts/verify-contract-mainnet.sh
+++ b/scripts/verify-contract-mainnet.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Verify deployed mainnet contracts by fetching their on-chain version string.
+#
+# Usage:
+#   ./scripts/verify-contract-mainnet.sh [--env <path>] [--source <identity>]
+#
+# Prerequisites:
+#   - stellar CLI installed
+#   - contracts/.env.mainnet present (produced by deploy-contracts-mainnet.sh)
+#   - STELLAR_ACCOUNT env var set, or pass --source <identity>
+
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+CONTRACTS_DIR="$(cd "$(dirname "$0")/../contracts" && pwd)"
+ENV_FILE="${CONTRACTS_DIR}/.env.mainnet"
+NETWORK="mainnet"
+RPC_URL="https://mainnet.sorobanrpc.com"
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+
+# ── Parse arguments ────────────────────────────────────────────────────────────
+
+SOURCE="${STELLAR_ACCOUNT:-}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --env)    ENV_FILE="$2"; shift 2 ;;
+        --source) SOURCE="$2";   shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+if [[ -z "${SOURCE}" ]]; then
+    echo "Error: source identity not set."
+    echo "  Set STELLAR_ACCOUNT env var or pass --source <identity>"
+    exit 1
+fi
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+GRN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log()     { echo "[$(date -u +%H:%M:%S)] $*"; }
+pass()    { echo -e "  ${GRN}PASS${NC}  $*"; }
+fail()    { echo -e "  ${RED}FAIL${NC}  $*"; FAILURES=$((FAILURES + 1)); }
+FAILURES=0
+
+# Load env file
+if [[ ! -f "${ENV_FILE}" ]]; then
+    echo "Error: env file not found: ${ENV_FILE}"
+    echo "  Run deploy-contracts-mainnet.sh first."
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+
+invoke_view() {
+    local contract_id="$1"
+    local fn_name="$2"
+
+    stellar contract invoke \
+        --id "${contract_id}" \
+        --source "${SOURCE}" \
+        --network "${NETWORK}" \
+        --rpc-url "${RPC_URL}" \
+        --network-passphrase "${NETWORK_PASSPHRASE}" \
+        -- "${fn_name}" 2>/dev/null || true
+}
+
+verify_contract() {
+    local name="$1"
+    local contract_id_var="$2"
+    local fn_name="${3:-get_version}"
+
+    local contract_id="${!contract_id_var:-}"
+    if [[ -z "${contract_id}" ]]; then
+        fail "${name}: ${contract_id_var} not set in env file"
+        return
+    fi
+
+    local result
+    result=$(invoke_view "${contract_id}" "${fn_name}" 2>&1)
+
+    if [[ -n "${result}" && "${result}" != *"error"* && "${result}" != *"Error"* ]]; then
+        pass "${name} (${contract_id}): ${result}"
+    else
+        fail "${name} (${contract_id}): no version returned — ${result}"
+    fi
+}
+
+# ── Verify each contract ───────────────────────────────────────────────────────
+
+echo ""
+log "Verifying mainnet contracts from: ${ENV_FILE}"
+echo ""
+
+verify_contract "access-control"          "ACCESS_CONTROL_CONTRACT_ID"
+verify_contract "stellar_insights"        "STELLAR_INSIGHTS_CONTRACT_ID"
+verify_contract "analytics"               "ANALYTICS_CONTRACT_ID"
+verify_contract "governance"              "GOVERNANCE_CONTRACT_ID"
+verify_contract "escrow"                  "ESCROW_CONTRACT_ID"
+verify_contract "token-swap"              "TOKEN_SWAP_CONTRACT_ID"
+verify_contract "multi-sig-wallet"        "MULTI_SIG_WALLET_CONTRACT_ID"
+verify_contract "time-locked-transactions" "TIME_LOCKED_TRANSACTIONS_CONTRACT_ID"
+verify_contract "upgrade"                 "UPGRADE_CONTRACT_ID"
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+
+echo ""
+if [[ "${FAILURES}" -eq 0 ]]; then
+    echo -e "${GRN}All contracts verified successfully.${NC}"
+else
+    echo -e "${RED}${FAILURES} contract(s) failed verification. Review output above.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Fixes closes #1610 closes #1613 closes #1615 closes #1621

- Contracts (escrow, token-swap, time-locked-transactions): emit paused/unpaused events on pause() / unpause(); multi-sig-wallet emit_initialized now includes owners list in the event payload.
- Contracts (escrow, multi-sig-wallet, token-swap): apply Checks-Effects-Interactions pattern on all external token transfers; add per-contract reentrancy lock via instance storage DataKey::Locked to catch reentrant calls.
- Backend: add jti (JWT ID) claim to access tokens backed by a new token_revocations SQLite table (migration 034); auth middleware checks revocation before accepting a request; expose revoke_token() helper for password-change / key-rotation flows.
- Scripts: add deploy-contracts-mainnet.sh (ordered deployment with human approval gates) and verify-contract-mainnet.sh for post-deploy validation.