### PR TITLE
fix(escrow): prevent zero-amount release bypassing lock

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -337,6 +337,10 @@ impl EscrowServiceContract {
             return Err(Error::Unauthorized);
         }
 
+        if escrow.amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
         let token = escrow.token.clone();
         let beneficiary = escrow.beneficiary.clone();
         let amount = escrow.amount;
@@ -387,6 +391,10 @@ impl EscrowServiceContract {
 
         if caller != escrow.depositor {
             return Err(Error::Unauthorized);
+        }
+
+        if escrow.amount <= 0 {
+            return Err(Error::InvalidAmount);
         }
 
         let now = env.ledger().timestamp();
@@ -492,6 +500,10 @@ impl EscrowServiceContract {
 
         if escrow.state != EscrowState::Disputed {
             return Err(Error::NotDisputed);
+        }
+
+        if escrow.amount <= 0 {
+            return Err(Error::InvalidAmount);
         }
 
         let token = escrow.token.clone();

--- a/contracts/tests/Cargo.toml
+++ b/contracts/tests/Cargo.toml
@@ -17,4 +17,4 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 analytics = { path = "../analytics" }
 governance = { path = "../governance" }
 escrow = { path = "../escrow" }
-stellar_insights = { path = "../stellar_insights" }
+stellar-insights = { path = "../stellar_insights" }


### PR DESCRIPTION
Adds validation to reject zero-amount token transfers in release_funds, refund, and resolve_dispute functions. This prevents bypassing the escrow lock by marking funds as released without actual transfer.

Closes #1603 