### PR TITLE
fix(token-swap): validate slippage with min_out check

### DIFF
--- a/contracts/tests/Cargo.toml
+++ b/contracts/tests/Cargo.toml
@@ -17,4 +17,4 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 analytics = { path = "../analytics" }
 governance = { path = "../governance" }
 escrow = { path = "../escrow" }
-stellar_insights = { path = "../stellar_insights" }
+stellar-insights = { path = "../stellar_insights" }

--- a/contracts/token-swap/src/errors.rs
+++ b/contracts/token-swap/src/errors.rs
@@ -28,4 +28,6 @@ pub enum Error {
     ContractPaused = 11,
     /// Reentrant call detected
     Reentrancy = 12,
+    /// Actual output less than minimum required (slippage exceeded)
+    SlippageExceeded = 13,
 }

--- a/contracts/token-swap/src/lib.rs
+++ b/contracts/token-swap/src/lib.rs
@@ -291,7 +291,14 @@ impl TokenSwapContract {
     /// Accept an open offer. Atomically swaps both sides.
     ///
     /// The taker sends want_token to the maker and receives offer_token from this contract.
-    pub fn accept_offer(env: Env, taker: Address, offer_id: u64) -> Result<(), Error> {
+    /// The `min_out` parameter ensures protection against sandwich attacks and slippage.
+    /// The actual_out (offer_amount) must be >= min_out or the transaction reverts.
+    pub fn accept_offer(
+        env: Env,
+        taker: Address,
+        offer_id: u64,
+        min_out: i128,
+    ) -> Result<(), Error> {
         require_not_locked(&env)?;
 
         let paused: bool = env
@@ -320,6 +327,11 @@ impl TokenSwapContract {
 
         if offer.expiry != 0 && env.ledger().timestamp() > offer.expiry {
             return Err(Error::OfferExpired);
+        }
+
+        // Validate slippage: actual_out must be >= min_out to prevent sandwich attacks
+        if offer.offer_amount < min_out {
+            return Err(Error::SlippageExceeded);
         }
 
         let want_token = offer.want_token.clone();


### PR DESCRIPTION
Adds critical slippage protection to prevent sandwich attacks on mainnet.
The accept_offer function now validates that actual_out (offer_amount) >= 
min_out before committing the swap, protecting against MEV and price slippage.

Closes #1604