### PR TITLE
chore: investigate issue #1636 observability metric labels

### DIFF
--- a/backend/src/observability/tracing.rs
+++ b/backend/src/observability/tracing.rs
@@ -388,6 +388,7 @@ mod tests {
     }
 }
 
+
 /// Re-export redaction utilities for use throughout the application
 pub use crate::logging::redaction::{
     redact_account, redact_amount, redact_email, redact_hash, redact_ip, redact_token,


### PR DESCRIPTION
Closes #1636

---

## Summary

This PR documents the investigation performed for issue #1636 regarding the reported exposure of `user_id` as a Prometheus metric label in the observability pipeline.

## Investigation

I searched the observability module for metric definitions and usages, including:

* `with_label_values(...)`
* `IntCounterVec`
* `HistogramVec`
* `GaugeVec`
* `user_id` references within `backend/src/observability`

The current implementation exposes labels such as:

* `method`
* `endpoint`
* `status_code`
* `error_type`
* `operation`
* `status`
* `reason`
* `anchor`
* `corridor`
* `job_name`

No Prometheus metric was found using `user_id` as a label.

I also searched the broader backend for `user_id` references. Existing usages were found in:

* authentication
* database queries
* API handlers
* audit logging
* analytics persistence
* business logic

The only observability-related reference is the use of `redact_user_id` within tracing/logging, which is already intended to prevent PII exposure.

Additionally, `backend/src/api_analytics_middleware.rs` records `user_id` into the `api_usage_stats` database table for analytics purposes. This middleware does **not** emit Prometheus metrics or attach `user_id` as a metric label.

## Findings

At the current state of the repository, I could not reproduce the issue described in #1636.

## Possible explanations

* The issue has already been fixed in the current codebase but remains open.
* The issue refers to an older commit or revision.
* The report references a different branch or implementation than the current default branch.
* The original report may have confused analytics database storage with Prometheus metric labels.

## Result

No code changes were made because the reported Prometheus `user_id` metric labels could not be found in the current source.

If additional context (such as the original commit, branch, or code path where the issue was observed) is provided, I would be happy to investigate further.
