### PR TITLE
fix: reduce governance tally cache staleness, add X-Cache-Age and ref…

### DIFF
--- a/backend/src/api/governance.rs
+++ b/backend/src/api/governance.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderName, HeaderValue, StatusCode},
     middleware,
     response::{IntoResponse, Response},
     routing::{get, post, put},
@@ -23,6 +23,7 @@ pub fn routes(service: Arc<GovernanceService>, sep10_service: Arc<Sep10Service>)
         .route("/proposals/:id/vote", post(cast_vote))
         .route("/proposals/:id/comments", post(add_comment))
         .route("/proposals/:id/activate", put(activate_proposal))
+        .route("/proposals/:id/refresh", post(refresh_tally))
         .layer(middleware::from_fn_with_state(
             sep10_service,
             sep10_auth_middleware,
@@ -196,12 +197,47 @@ async fn get_proposal(
     State(service): State<Arc<GovernanceService>>,
     Path(id): Path<String>,
 ) -> Result<Response, GovernanceError> {
-    let response = service
-        .get_proposal(&id)
+    let (proposal, cache_age) = service
+        .get_proposal_cached(&id)
         .await
         .map_err(|e| GovernanceError::NotFound(e.to_string()))?;
 
-    Ok((StatusCode::OK, Json(response)).into_response())
+    let mut response = (StatusCode::OK, Json(proposal)).into_response();
+    let age_str = cache_age.unwrap_or(0).to_string();
+    if let Ok(val) = HeaderValue::from_str(&age_str) {
+        response
+            .headers_mut()
+            .insert(HeaderName::from_static("x-cache-age"), val);
+    }
+    Ok(response)
+}
+
+// POST /api/governance/proposals/:id/refresh - Admin: bust cached vote tally
+#[utoipa::path(
+    post,
+    path = "/api/governance/proposals/{id}/refresh",
+    params(
+        ("id" = String, Path, description = "Proposal ID")
+    ),
+    responses(
+        (status = 200, description = "Cache invalidated"),
+        (status = 401, description = "Unauthorized"),
+        (status = 500, description = "Internal error")
+    ),
+    tag = "Governance"
+)]
+async fn refresh_tally(
+    State(service): State<Arc<GovernanceService>>,
+    Path(id): Path<String>,
+    _sep10_user: axum::Extension<Sep10User>,
+) -> Result<Response, GovernanceError> {
+    service
+        .invalidate_proposal_cache(&id)
+        .await
+        .map_err(|e| GovernanceError::DatabaseError(e.to_string()))?;
+
+    info!("Cache busted for proposal {} by admin request", id);
+    Ok((StatusCode::OK, Json(serde_json::json!({ "invalidated": true }))).into_response())
 }
 
 // POST /api/governance/proposals/:id/vote - Cast a vote on a proposal

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -139,6 +139,7 @@ use utoipa::OpenApi;
         crate::api::governance::has_voted,
         crate::api::governance::add_comment,
         crate::api::governance::get_comments,
+        crate::api::governance::refresh_tally,
         // OAuth
         crate::api::oauth::authorize,
         crate::api::oauth::token,

--- a/backend/src/services/governance.rs
+++ b/backend/src/services/governance.rs
@@ -1,3 +1,4 @@
+use crate::cache::CacheManager;
 use crate::database::Database;
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
@@ -16,7 +17,7 @@ pub struct CreateProposalRequest {
     pub new_wasm_hash: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProposalResponse {
     pub id: String,
     pub title: String,
@@ -37,7 +38,7 @@ pub struct ProposalResponse {
     pub votes_abstain: i64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProposalsListResponse {
     pub proposals: Vec<ProposalResponse>,
     pub total: i64,
@@ -73,14 +74,70 @@ pub struct CommentResponse {
     pub created_at: String,
 }
 
+/// Cached proposal tally stored in Redis/in-memory, including the timestamp
+/// so callers can compute X-Cache-Age.
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedProposal {
+    data: ProposalResponse,
+    cached_at_unix: i64,
+}
+
+const TALLY_TTL_ACTIVE_SECS: usize = 30;
+const TALLY_TTL_DEFAULT_SECS: usize = 300;
+
 pub struct GovernanceService {
     db: Arc<Database>,
+    cache: Arc<CacheManager>,
 }
 
 impl GovernanceService {
     #[must_use]
-    pub const fn new(db: Arc<Database>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<Database>, cache: Arc<CacheManager>) -> Self {
+        Self { db, cache }
+    }
+
+    fn tally_cache_key(proposal_id: &str) -> String {
+        format!("governance:tally:{proposal_id}")
+    }
+
+    fn tally_ttl(status: &str) -> usize {
+        if status == "active" {
+            TALLY_TTL_ACTIVE_SECS
+        } else {
+            TALLY_TTL_DEFAULT_SECS
+        }
+    }
+
+    /// Returns `(proposal, cache_age_secs)`. `cache_age_secs` is `None` on a
+    /// cache miss (the value was just fetched from the DB).
+    pub async fn get_proposal_cached(
+        &self,
+        id: &str,
+    ) -> Result<(ProposalResponse, Option<u64>)> {
+        let key = Self::tally_cache_key(id);
+
+        if let Ok(Some(cached)) = self.cache.get::<CachedProposal>(&key).await {
+            let age = (Utc::now().timestamp() - cached.cached_at_unix).max(0) as u64;
+            return Ok((cached.data, Some(age)));
+        }
+
+        let proposal = self.get_proposal(id).await?;
+        let ttl = Self::tally_ttl(&proposal.status);
+        let entry = CachedProposal {
+            cached_at_unix: Utc::now().timestamp(),
+            data: proposal,
+        };
+        let _ = self.cache.set(&key, &entry, ttl).await;
+        Ok((entry.data, None))
+    }
+
+    /// Delete the cached tally for a proposal so the next request re-fetches
+    /// from the database.
+    pub async fn invalidate_proposal_cache(&self, proposal_id: &str) -> Result<()> {
+        let key = Self::tally_cache_key(proposal_id);
+        self.cache.delete(&key).await?;
+        info!("Invalidated tally cache for proposal {}", proposal_id);
+        Ok(())
     }
 
     pub async fn create_proposal(


### PR DESCRIPTION
…resh endpoint (#1628)

- Add CacheManager to GovernanceService with TTL-aware caching: 30s for active proposals, 300s otherwise, so live vote counts stay fresh
- GET /proposals/:id returns X-Cache-Age header (seconds since cache fill)
- POST /proposals/:id/refresh (SEP-10 auth) invalidates the cached tally
- Derive Deserialize on ProposalResponse/ProposalsListResponse for cache round-trips

Closes #1628