### PR TITLE
feat(backend): support multiple contract_ids filter in contract event…

### DIFF
--- a/backend/src/api/contract_events.rs
+++ b/backend/src/api/contract_events.rs
@@ -39,6 +39,8 @@ pub struct EventListQuery {
     pub offset: Option<i64>,
     pub event_type: Option<String>,
     pub verification_status: Option<String>,
+    /// Filter by one or more contract IDs (repeated query param, e.g. contract_ids=a&contract_ids=b)
+    pub contract_ids: Option<Vec<String>>,
 }
 
 /// Handler for GET /api/analytics/verification-summary
@@ -89,7 +91,8 @@ pub async fn get_verification_summary(
         ("limit" = Option<i64>, Query, description = "Maximum number of events to return"),
         ("offset" = Option<i64>, Query, description = "Number of events to skip"),
         ("event_type" = Option<String>, Query, description = "Filter by event type"),
-        ("verification_status" = Option<String>, Query, description = "Filter by verification status")
+        ("verification_status" = Option<String>, Query, description = "Filter by verification status"),
+        ("contract_ids" = Option<Vec<String>>, Query, description = "Filter by one or more contract IDs (repeated query param)")
     ),
     responses(
         (status = 200, description = "List of contract events", body = Vec<crate::services::event_indexer::IndexedEvent>),
@@ -106,6 +109,7 @@ pub async fn list_contract_events(
     let query = EventQuery {
         event_type: params.event_type,
         verification_status: params.verification_status,
+        contract_ids: params.contract_ids.unwrap_or_default(),
         limit: params.limit.or(Some(50)),
         offset: params.offset,
         order_by: Some(EventOrderBy::CreatedAtDesc),

--- a/backend/src/services/event_indexer.rs
+++ b/backend/src/services/event_indexer.rs
@@ -72,7 +72,7 @@ pub struct IndexedEvent {
 /// Event query filters
 #[derive(Debug, Clone, Default)]
 pub struct EventQuery {
-    pub contract_id: Option<String>,
+    pub contract_ids: Vec<String>,
     pub event_type: Option<String>,
     pub epoch: Option<u64>,
     pub hash: Option<String>,
@@ -251,9 +251,10 @@ impl EventIndexer {
         let mut bindings = Vec::new();
 
         // Add filters
-        if let Some(contract_id) = &query.contract_id {
-            sql.push_str(" AND contract_id = ?");
-            bindings.push(contract_id.clone());
+        if !query.contract_ids.is_empty() {
+            let placeholders = query.contract_ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let _ = write!(sql, " AND contract_id IN ({placeholders})");
+            bindings.extend(query.contract_ids.iter().cloned());
         }
 
         if let Some(event_type) = &query.event_type {


### PR DESCRIPTION
## Issue #1639 — Backend: `api/contract_events.rs` filtering only supports single contract ID

### Problem
The `GET /api/analytics/contract-events` endpoint only accepted a single `contract_id` filter. Dashboards monitoring multiple contracts had to make N separate API calls, which is impractical on mainnet.

### Solution
- Changed `EventQuery.contract_id: Option<String>` to `contract_ids: Vec<String>` in `backend/src/services/event_indexer.rs`
- Updated the SQL query from `WHERE contract_id = ?` to `WHERE contract_id IN (?, ?, ...)` with dynamic placeholders
- Added `contract_ids: Option<Vec<String>>` as a repeated query parameter to `EventListQuery` in `backend/src/api/contract_events.rs`
- Updated the utoipa OpenAPI spec to document the new parameter

### Usage
```
GET /api/analytics/contract-events?contract_ids=CA...1&contract_ids=CA...2&contract_ids=CA...3
```

### Backward Compatibility
All existing call sites use `..Default::default()`, so `contract_ids` defaults to an empty `Vec` and the filter is skipped — existing behavior is unchanged.

Closes #1639 