### PR TITLE
fix: remove explicit any in NotificationsTab lint findings

### DIFF
--- a/frontend/src/components/notifications/NotificationCenter/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter/NotificationCenter.tsx
@@ -87,7 +87,7 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({ isOpen, 
     }
   };
 
-  const handleSelectNotification = (notificationId: string, event: React.MouseEvent) => {
+  const handleSelectNotification = (notificationId: string, event: React.SyntheticEvent) => {
     event.stopPropagation();
     setSelectedNotifications(prev => {
       const newSet = new Set(prev);

--- a/frontend/src/components/notifications/NotificationCenter/NotificationsTab.tsx
+++ b/frontend/src/components/notifications/NotificationCenter/NotificationsTab.tsx
@@ -1,4 +1,5 @@
 import { NotificationPriority, NotificationType } from "@/types/notifications";
+import { NotificationFilter } from "@/services/notificationService";
 import { motion, AnimatePresence } from "framer-motion";
 import { BellOff, Calendar, ChevronDown, ChevronUp, Download, Filter, Search, Trash2 } from "lucide-react";
 import { formatTime, ICON_COLORS, NOTIFICATION_ICONS, NotificationCenterProps, PRIORITY_BADGES } from "./helpers";
@@ -93,7 +94,7 @@ const NotificationsTab = ({
                     </label>
                     <select
                       value={filter.readStatus}
-                      onChange={(e) => updateFilter({ readStatus: e.target.value as any })}
+                      onChange={(e) => updateFilter({ readStatus: e.target.value as NotificationFilter['readStatus'] })}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
                     >
                       <option value="all">All</option>
@@ -251,7 +252,7 @@ const NotificationsTab = ({
                             <input
                               type="checkbox"
                               checked={isSelected}
-                              onChange={(e: any) => handleSelectNotification(notification.id, e)}
+                              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSelectNotification(notification.id, e)}
                               onClick={(e) => e.stopPropagation()}
                               className="mt-1 rounded"
                             />

--- a/frontend/src/components/notifications/NotificationCenter/helpers.tsx
+++ b/frontend/src/components/notifications/NotificationCenter/helpers.tsx
@@ -21,7 +21,7 @@ export interface NotificationCenterProps {
   groupedNotifications:Record<string, BaseNotification[]>;
   unreadCount: number,
   handleNotificationClick: (notification: BaseNotification) => void,
-  handleSelectNotification: (id: string, event: React.MouseEvent) => void,
+  handleSelectNotification: (id: string, event: React.SyntheticEvent) => void,
   filteredNotifications: BaseNotification[],
   clearNotification:(id: string) => void,
 }


### PR DESCRIPTION
## Summary
- Types the read-status `<select>` onChange against `NotificationFilter['readStatus']` instead of `as any`.
- Gives `handleSelectNotification`'s event param a real type (`React.SyntheticEvent`) matching how it's actually invoked (from a checkbox `onChange`, not a `MouseEvent`) and how it's actually used (`event.stopPropagation()`).

Closes #1931