### PR TITLE
fix: add missing setNotifications dependency in cleanup effect

### DIFF
--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -286,7 +286,7 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
         clearTimeout(cleanupTimeoutRef.current);
       }
     };
-  }, [notifications.length, isClient]);
+  }, [notifications.length, isClient, setNotifications]);
 
   // Show connection status notifications only if WebSocket URL is provided (client-side only)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Adds `setNotifications` to the dependency array of the notification-cleanup `useEffect` in `NotificationContext.tsx`. It's the stable setter from `useLocalStorage`, so this doesn't change behavior, it just satisfies `react-hooks/exhaustive-deps`.

Closes #1936