### PR TITLE
fix: type navigator.standalone instead of casting to any

### DIFF
--- a/frontend/src/hooks/useProgressiveWebApp.ts
+++ b/frontend/src/hooks/useProgressiveWebApp.ts
@@ -18,6 +18,14 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 /**
+ * `navigator.standalone` is a non-standard, Safari/iOS-only property used to
+ * detect if the PWA was launched from the home screen. Not part of the DOM lib types.
+ */
+interface NavigatorWithStandalone extends Navigator {
+  readonly standalone?: boolean;
+}
+
+/**
  * PWA Installation States
  */
 export enum PWAInstallState {
@@ -78,7 +86,7 @@ export function useProgressiveWebApp(): UseProgressiveWebAppReturn {
     if (typeof window === 'undefined') return false;
     return (
       window.matchMedia('(display-mode: standalone)').matches ||
-      (window.navigator as any).standalone === true
+      (window.navigator as NavigatorWithStandalone).standalone === true
     );
   }, []);
 


### PR DESCRIPTION
## Summary
- Adds a `NavigatorWithStandalone` interface for the non-standard, Safari/iOS-only `navigator.standalone` property, following the same pattern already used for `BeforeInstallPromptEvent` in this file, instead of `(window.navigator as any).standalone`.

Closes #1939