### PR TITLE
fix: resolve ESLint findings in AnchorsTables, select, PWA test, and logger

### DIFF
--- a/frontend/src/components/tables/AnchorsTables.tsx
+++ b/frontend/src/components/tables/AnchorsTables.tsx
@@ -205,7 +205,6 @@ const AnchorTable: React.FC<AnchorTableProps> = ({ anchors, loading = false }) =
               <th
                 onClick={() => handleSort("name")}
                 className="px-6 py-3 text-left text-xs font-medium text-muted-foreground dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
-                role="button"
                 aria-label="Sort by anchor name"
                 aria-sort={getSortDirection("name")}
               >
@@ -220,7 +219,6 @@ const AnchorTable: React.FC<AnchorTableProps> = ({ anchors, loading = false }) =
               <th
                 onClick={() => handleSort("reliability_score")}
                 className="px-6 py-3 text-left text-xs font-medium text-muted-foreground dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
-                role="button"
                 aria-label="Sort by reliability score"
                 aria-sort={getSortDirection("reliability_score")}
               >
@@ -232,7 +230,6 @@ const AnchorTable: React.FC<AnchorTableProps> = ({ anchors, loading = false }) =
               <th
                 onClick={() => handleSort("failure_rate")}
                 className="px-6 py-3 text-left text-xs font-medium text-muted-foreground dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
-                role="button"
                 aria-label="Sort by failure rate"
                 aria-sort={getSortDirection("failure_rate")}
               >

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, Check } from "lucide-react";
 
 interface SelectContextProps {
   value?: string;
-  onValueChange?: (value: any) => void;
+  onValueChange?: (value: string) => void;
   open: boolean;
   setOpen: (open: boolean) => void;
 }
@@ -15,7 +15,7 @@ const SelectContext = React.createContext<SelectContextProps | undefined>(
 export const Select: React.FC<{
   children: React.ReactNode;
   value?: string;
-  onValueChange?: (value: any) => void;
+  onValueChange?: (value: string) => void;
 }> = ({ children, value, onValueChange }) => {
   const [open, setOpen] = useState(false);
   return (

--- a/frontend/src/hooks/__tests__/useProgressiveWebApp.test.ts
+++ b/frontend/src/hooks/__tests__/useProgressiveWebApp.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useProgressiveWebApp, PWAInstallState } from '../useProgressiveWebApp';
+import { useProgressiveWebApp, PWAInstallState, BeforeInstallPromptEvent } from '../useProgressiveWebApp';
 
 describe('useProgressiveWebApp', () => {
   let mockServiceWorkerRegistration: Partial<ServiceWorkerRegistration>;
@@ -111,7 +111,7 @@ describe('useProgressiveWebApp', () => {
       const { result } = renderHook(() => useProgressiveWebApp());
 
       act(() => {
-        const event = new Event('beforeinstallprompt') as any;
+        const event = new Event('beforeinstallprompt') as unknown as BeforeInstallPromptEvent;
         event.preventDefault = vi.fn();
         window.dispatchEvent(event);
       });
@@ -126,7 +126,8 @@ describe('useProgressiveWebApp', () => {
 
       // Manually set install prompt for testing
       act(() => {
-        (result.current as any).installPrompt = mockBeforeInstallPromptEvent;
+        (result.current as unknown as { installPrompt: Partial<BeforeInstallPromptEvent> }).installPrompt =
+          mockBeforeInstallPromptEvent;
       });
 
       await act(async () => {
@@ -219,7 +220,7 @@ describe('useProgressiveWebApp', () => {
     it('should handle cache clear error', async () => {
       const { result } = renderHook(() => useProgressiveWebApp());
 
-      (window.caches.keys as any).mockRejectedValueOnce(new Error('Cache error'));
+      vi.mocked(window.caches.keys).mockRejectedValueOnce(new Error('Cache error'));
 
       await act(async () => {
         await result.current.clearCache();
@@ -284,7 +285,8 @@ describe('useProgressiveWebApp', () => {
 
       // Mock waiting service worker
       const mockWaitingSW = { postMessage: vi.fn() };
-      (mockServiceWorkerRegistration.waiting as any) = mockWaitingSW;
+      (mockServiceWorkerRegistration.waiting as unknown as ServiceWorker) =
+        mockWaitingSW as unknown as ServiceWorker;
 
       await act(async () => {
         result.current.updateApp();

--- a/frontend/src/hooks/useProgressiveWebApp.ts
+++ b/frontend/src/hooks/useProgressiveWebApp.ts
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
  * (it's a non-standard, Chromium-only PWA install event), so TypeScript
  * doesn't know about it out of the box.
  */
-interface BeforeInstallPromptEvent extends Event {
+export interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
   readonly userChoice: Promise<{
     outcome: 'accepted' | 'dismissed';

--- a/frontend/src/lib/react-query/logger.tsx
+++ b/frontend/src/lib/react-query/logger.tsx
@@ -110,14 +110,14 @@ export function useQueryMonitor() {
   // expose debug functions to window for manual debugging
   React.useEffect(() => {
     if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
-      (window as any).__queryMonitor = {
+      (window as unknown as { __queryMonitor: unknown }).__queryMonitor = {
         logStats: logCacheStats,
         logState: () => {
           const cache = queryClient.getQueryCache();
           const queries = cache.getAll();
           logger.info('All Queries', {
             totalQueries: queries.length,
-            queryKeys: queries.map((q: any) => q.queryKey)
+            queryKeys: queries.map((q) => q.queryKey)
           });
         },
       };


### PR DESCRIPTION
## Summary
- `AnchorsTables.tsx`: drop `role="button"` on sortable `<th>` elements so `aria-sort` is applied to a role that supports it (jsx-a11y/role-supports-aria-props)
- `select.tsx`: type `onValueChange` as `(value: string) => void` instead of `any`
- `useProgressiveWebApp.test.ts`: replace `any` casts with typed casts via the now-exported `BeforeInstallPromptEvent` type and `vi.mocked()`
- `logger.tsx`: remove `any` from the `window` augmentation and the query map callback

Closes #1933, 
Closes #1935,
Closes #1938,
Closes #1943

Note: dependencies weren't installed in this environment, so `npm run lint`/`tsc`/`build` were not run locally — changes were verified by manual type review against the existing interfaces.