### PR TITLE
lint: fix 2 ESLint no-explicit-any findings in zustand middleware.ts

### DIFF
--- a/frontend/src/lib/zustand/middleware.ts
+++ b/frontend/src/lib/zustand/middleware.ts
@@ -226,7 +226,7 @@ export const localStorageMiddleware = <T extends object>(
             stateToSave = {} as Partial<T>;
             config.whitelist.forEach(key => {
               if (key in currentState) {
-                (stateToSave as any)[key] = currentState[key];
+                stateToSave[key] = currentState[key];
               }
             });
           }
@@ -235,7 +235,7 @@ export const localStorageMiddleware = <T extends object>(
           if (config.blacklist) {
             const temp = { ...stateToSave };
             config.blacklist.forEach(key => {
-              delete (temp as any)[key];
+              delete temp[key];
             });
             stateToSave = temp;
           }


### PR DESCRIPTION
`stateToSave`/`temp` are already typed `Partial<T>` with `key: keyof T`, so
`(x as any)[key]` was an unnecessary cast — direct indexed access
(`stateToSave[key]`, `delete temp[key]`) type-checks fine on its own.

Closes #1944