### PR TITLE
fix: resolve 4 ESLint findings (set-state-in-effect, anonymous default export)

### DIFF
--- a/frontend/src/components/notifications/__tests__/notificationCenter.test.ts
+++ b/frontend/src/components/notifications/__tests__/notificationCenter.test.ts
@@ -262,6 +262,8 @@ describe('Notification Center Performance', () => {
   });
 });
 
-export default {
+const notificationCenterTestModule = {
   NotificationService,
 };
+
+export default notificationCenterTestModule;

--- a/frontend/src/components/ui/TimeRangeSelector.tsx
+++ b/frontend/src/components/ui/TimeRangeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { format, subDays, subHours, startOfDay } from "date-fns";
 
 export type Preset = "24h" | "7d" | "30d" | "custom";
@@ -9,25 +9,37 @@ interface TimeRangeSelectorProps {
   onChange: (start: Date | null, end: Date | null) => void;
 }
 
+// Infer a sensible preset from the provided dates.
+function inferPreset(startDate: Date | null, endDate: Date | null): Preset {
+  if (!startDate || !endDate) return "custom";
+  const now = new Date();
+  const diffMs = now.getTime() - startDate.getTime();
+  const diffHours = diffMs / (1000 * 60 * 60);
+
+  if (Math.abs(diffHours - 24) < 1) return "24h";
+  if (Math.abs(diffHours - 24 * 7) < 24) return "7d";
+  if (Math.abs(diffHours - 24 * 30) < 48) return "30d";
+  return "custom";
+}
+
 export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   startDate,
   endDate,
   onChange,
 }) => {
-  const [preset, setPreset] = useState<Preset>("30d");
+  const [preset, setPreset] = useState<Preset>(() =>
+    inferPreset(startDate, endDate),
+  );
 
-  useEffect(() => {
-    // Try to infer a sensible preset from the provided dates.
-    if (!startDate || !endDate) return setPreset("custom");
-    const now = new Date();
-    const diffMs = now.getTime() - startDate.getTime();
-    const diffHours = diffMs / (1000 * 60 * 60);
-
-    if (Math.abs(diffHours - 24) < 1) setPreset("24h");
-    else if (Math.abs(diffHours - 24 * 7) < 24) setPreset("7d");
-    else if (Math.abs(diffHours - 24 * 30) < 48) setPreset("30d");
-    else setPreset("custom");
-  }, [startDate, endDate]);
+  // Track the previous dates so we can re-derive the preset when they change,
+  // without reacting to a render via an effect (see https://react.dev/learn/you-might-not-need-an-effect).
+  const [prevStartDate, setPrevStartDate] = useState(startDate);
+  const [prevEndDate, setPrevEndDate] = useState(endDate);
+  if (startDate !== prevStartDate || endDate !== prevEndDate) {
+    setPrevStartDate(startDate);
+    setPrevEndDate(endDate);
+    setPreset(inferPreset(startDate, endDate));
+  }
 
   const applyPreset = (p: Preset) => {
     const now = new Date();

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -71,12 +71,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     applyThemeToDOM(resolved);
   }, []);
 
-  // On mount, apply the initial theme
+  // On mount, sync the DOM with the already-resolved initial theme
   useEffect(() => {
-    const resolved = resolveTheme(themePreference);
-    setTheme(resolved);
-    applyThemeToDOM(resolved);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    applyThemeToDOM(theme);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Listen for system preference changes when mode is 'system'
   useEffect(() => {

--- a/frontend/src/hooks/useRealtimeCollaboration.ts
+++ b/frontend/src/hooks/useRealtimeCollaboration.ts
@@ -30,16 +30,20 @@ export const useRealtimeCollaboration = (options: UseRealtimeCollaborationOption
   const [messages, setMessages] = useState<CollaborativeMessage[]>([]);
   const [activeUsers, setActiveUsers] = useState<CollaborativeUser[]>([]);
   const [isConnected, setIsConnected] = useState(false);
-  const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'disconnected'>('disconnected');
+  const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'disconnected'>(
+    () => (autoConnect ? 'connecting' : 'disconnected'),
+  );
   const [error, setError] = useState<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
 
-  const connect = useCallback(() => {
-    setConnectionStatus('connecting');
+  // Opens the WebSocket and wires up its listeners. Does not itself set the
+  // 'connecting' status, so it can be called from the mount effect without
+  // triggering a synchronous setState from within the effect body.
+  const openConnection = useCallback(() => {
     try {
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       const wsUrl = `${protocol}//${window.location.host}/api/collaboration/${sessionId}`;
-      
+
       wsRef.current = new WebSocket(wsUrl);
 
       wsRef.current.onopen = () => {
@@ -64,6 +68,11 @@ export const useRealtimeCollaboration = (options: UseRealtimeCollaborationOption
       setConnectionStatus('disconnected');
     }
   }, [sessionId]);
+
+  const connect = useCallback(() => {
+    setConnectionStatus('connecting');
+    openConnection();
+  }, [openConnection]);
 
   const disconnect = useCallback(() => {
     if (wsRef.current) {
@@ -124,13 +133,13 @@ export const useRealtimeCollaboration = (options: UseRealtimeCollaborationOption
 
   useEffect(() => {
     if (autoConnect) {
-      connect();
+      openConnection();
     }
 
     return () => {
       disconnect();
     };
-  }, [autoConnect, connect, disconnect]);
+  }, [autoConnect, openConnection, disconnect]);
 
   return {
     messages,


### PR DESCRIPTION
## Summary
- `notificationCenter.test.ts`: assign the anonymous default export object to a named variable before exporting (`import/no-anonymous-default-export`).
- `TimeRangeSelector.tsx`: derive the `preset` from `startDate`/`endDate` during render (adjusting state via a prev-value comparison) instead of calling `setPreset` synchronously inside a `useEffect`.
- `ThemeContext.tsx`: drop the redundant `setTheme` call in the mount effect — the initial `theme` state is already resolved via lazy `useState` init, so the effect now only syncs the DOM.
- `useRealtimeCollaboration.ts`: split `connect()` into `openConnection()` (the WebSocket side effect) and `connect()` (sets `connecting` status + opens). The mount effect now calls `openConnection()` directly, and the initial `connecting` status is set via a lazy `useState` initializer instead of a synchronous `setState` call inside the effect.

Closes #1932, 
Closes #1934, 
Closes #1937, 
Closes #1940

## Test plan
- [ ] `npm run lint` reports no findings for the four files above
- [ ] `npx tsc --noEmit -p tsconfig.json` reports 0 errors
- [ ] `npm run build` succeeds