### PR TITLE
fix: resolve ESLint findings in notification and wallet context compo…

### DIFF
--- a/frontend/src/components/lib/notification-context.tsx
+++ b/frontend/src/components/lib/notification-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import React, { createContext, useContext, useState, useCallback } from "react";
 
 export type NotificationType = "info" | "success" | "warning" | "error";
 
@@ -30,9 +30,39 @@ const NotificationContext = createContext<NotificationContextProps | undefined>(
 // Generate a random ID for notifications
 const generateId = () => Math.random().toString(36).substring(2, 9);
 
+// Demo: Initial mock notifications to visualize the design
+const createMockNotifications = (): AppNotification[] => [
+  {
+    id: generateId(),
+    title: "Network Congestion",
+    message: "High traffic detected on the Stellar network. Settlement times may be slightly delayed.",
+    type: "warning",
+    read: false,
+    createdAt: Date.now() - 1000 * 60 * 5, // 5 mins ago
+  },
+  {
+    id: generateId(),
+    title: "Liquidity Alert",
+    message: "Liquidity pool XLM/USDC is experiencing high volatility.",
+    type: "error",
+    read: false,
+    createdAt: Date.now() - 1000 * 60 * 30, // 30 mins ago
+    actionLink: "/dashboard",
+    actionText: "View Pool",
+  },
+  {
+    id: generateId(),
+    title: "System Update Complete",
+    message: "The analytics engine has been successfully updated to v2.1.0.",
+    type: "success",
+    read: true,
+    createdAt: Date.now() - 1000 * 60 * 60 * 2, // 2 hours ago
+  }
+];
+
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
-  const [notifications, setNotifications] = useState<AppNotification[]>([]);
-  
+  const [notifications, setNotifications] = useState<AppNotification[]>(createMockNotifications);
+
   // Calculate unread count
   const unreadCount = notifications.filter(n => !n.read).length;
 
@@ -65,39 +95,6 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
   const clearAll = useCallback(() => {
     setNotifications([]);
-  }, []);
-
-  // Demo: Add some initial mock notifications to visualize the design
-  useEffect(() => {
-    const mockNotifications: AppNotification[] = [
-      {
-        id: generateId(),
-        title: "Network Congestion",
-        message: "High traffic detected on the Stellar network. Settlement times may be slightly delayed.",
-        type: "warning",
-        read: false,
-        createdAt: Date.now() - 1000 * 60 * 5, // 5 mins ago
-      },
-      {
-        id: generateId(),
-        title: "Liquidity Alert",
-        message: "Liquidity pool XLM/USDC is experiencing high volatility.",
-        type: "error",
-        read: false,
-        createdAt: Date.now() - 1000 * 60 * 30, // 30 mins ago
-        actionLink: "/dashboard",
-        actionText: "View Pool",
-      },
-      {
-        id: generateId(),
-        title: "System Update Complete",
-        message: "The analytics engine has been successfully updated to v2.1.0.",
-        type: "success",
-        read: true,
-        createdAt: Date.now() - 1000 * 60 * 60 * 2, // 2 hours ago
-      }
-    ];
-    setNotifications(mockNotifications);
   }, []);
 
   const value = {

--- a/frontend/src/components/lib/wallet-context.tsx
+++ b/frontend/src/components/lib/wallet-context.tsx
@@ -6,16 +6,32 @@ import { createContext, useContext, useState, useCallback, useEffect } from 'rea
 import { sep10AuthService } from '../../services/sep10Auth'
 import { logger } from "@/lib/logger"
 
+interface FreighterWallet {
+  getPublicKey: () => Promise<string>
+}
+
+interface AlbedoWallet {
+  publicKey: (options?: Record<string, unknown>) => Promise<{ pubkey: string }>
+}
+
+interface XBullSDKWallet {
+  signTransaction: (options: Record<string, unknown>) => Promise<string>
+}
+
+interface RabetWallet {
+  connect: () => Promise<{ publicKey: string }>
+}
+
 // Extend Window interface for Stellar wallets
 declare global {
   interface Window {
     stellar?: {
       requestPublicKey: () => Promise<string>
     }
-    freighter?: any
-    albedo?: any
-    xBullSDK?: any
-    rabet?: any
+    freighter?: FreighterWallet
+    albedo?: AlbedoWallet
+    xBullSDK?: XBullSDKWallet
+    rabet?: RabetWallet
   }
 }
 

--- a/frontend/src/components/notifications/EnhancedNotificationCenter/FiltersTabView.tsx
+++ b/frontend/src/components/notifications/EnhancedNotificationCenter/FiltersTabView.tsx
@@ -207,7 +207,7 @@ const FiltersTabView = ({ selectedFilters, setSelectedFilters, setShowFilters }:
           <div>
             <Label className="text-sm font-medium">Read Status</Label>
             <div className="flex gap-4 mt-2">
-              {['all', 'read', 'unread'].map((status) => (
+              {(['all', 'read', 'unread'] as const).map((status) => (
                 <div key={status} className="flex items-center space-x-2">
                   <input
                     type="radio"
@@ -220,7 +220,7 @@ const FiltersTabView = ({ selectedFilters, setSelectedFilters, setShowFilters }:
                     onChange={() => {
                       setSelectedFilters((prev) => ({
                         ...prev,
-                        readStatus: status as any,
+                        readStatus: status,
                       }));
                     }}
                   />

--- a/frontend/src/components/notifications/EnhancedNotificationCenter/NotificationListView.tsx
+++ b/frontend/src/components/notifications/EnhancedNotificationCenter/NotificationListView.tsx
@@ -1,4 +1,3 @@
-import { motion } from 'framer-motion';
 import {
   Search,
   ChevronUp,
@@ -74,7 +73,7 @@ export const NotificationListView = (props: Partial<IUseEnhancedNotificationCent
           <div className="flex items-center gap-2">
             <Select
               value={groupBy}
-              onValueChange={(value: any) => setGroupBy(value)}
+              onValueChange={(value: 'none' | 'date' | 'type' | 'priority') => setGroupBy(value)}
             >
               <SelectTrigger className="w-32">
                 <SelectValue />
@@ -89,7 +88,7 @@ export const NotificationListView = (props: Partial<IUseEnhancedNotificationCent
 
             <Select
               value={sortBy}
-              onValueChange={(value: any) => setSortBy(value)}
+              onValueChange={(value: 'timestamp' | 'priority' | 'type') => setSortBy(value)}
             >
               <SelectTrigger className="w-32">
                 <SelectValue />
@@ -115,7 +114,7 @@ export const NotificationListView = (props: Partial<IUseEnhancedNotificationCent
 
             <Select
               value={viewMode}
-              onValueChange={(value: any) => setViewMode(value)}
+              onValueChange={(value: 'list' | 'grid' | 'compact') => setViewMode(value)}
             >
               <SelectTrigger className="w-24">
                 <SelectValue />
@@ -205,7 +204,7 @@ export const NotificationListView = (props: Partial<IUseEnhancedNotificationCent
                     : 'space-y-2'
                 }
               >
-                {groupNotifications.map((notification, index) => (
+                {groupNotifications.map((notification) => (
                   <NotificationItem
                     key={notification.id}
                     notification={notification}


### PR DESCRIPTION
…nents

## Summary
- notification-context.tsx: replaced setState-in-effect with a lazy useState initializer for mock notifications
- wallet-context.tsx: replaced 4 `any` Window wallet globals with precise interfaces
- NotificationListView.tsx: replaced 3 `any` onValueChange handlers with the real literal union types
- FiltersTabView.tsx: removed `as any` cast on readStatus via an `as const` literal array

closes #1923
closes #1924
closes #1925
closes #1926 

## Test plan
- [x] `npm run lint` reports 0 findings for all four files
- [x] `npx tsc --noEmit -p tsconfig.json` shows no new errors (same 6 pre-existing unrelated errors as main)
- [x] Confirmed via `git stash` that the pre-existing tsc/build errors already exist on main, unrelated to these changes