### PR TITLE
lint: fix no-explicit-any / react-hooks findings in 4 components

### DIFF
--- a/frontend/src/components/charts/NetworkGraph.tsx
+++ b/frontend/src/components/charts/NetworkGraph.tsx
@@ -134,8 +134,8 @@ const NetworkGraph: React.FC<NetworkGraphProps> = ({ data }) => {
         linkDirectionalArrowLength={3}
         linkDirectionalArrowRelPos={1}
         linkCurvature={0.25}
-        linkWidth={(link) =>
-          link.type === "corridor" ? (link as any).value : 1
+        linkWidth={(link: Link) =>
+          link.type === "corridor" ? link.value : 1
         }
         onNodeHover={setHoverNode}
         cooldownTicks={100}

--- a/frontend/src/components/charts/ReliabilityTrend.tsx
+++ b/frontend/src/components/charts/ReliabilityTrend.tsx
@@ -8,7 +8,8 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip, ResponsiveContainer
+  Tooltip, ResponsiveContainer,
+  TooltipProps
 } from "recharts";
 
 interface ReliabilityTrendProps {
@@ -17,7 +18,7 @@ interface ReliabilityTrendProps {
 
 type TimeWindow = "7d" | "30d" | "90d";
 
-const CustomTooltip = (props: any) => {
+const CustomTooltip = (props: TooltipProps<number, string>) => {
   const { active, payload, label } = props;
   if (active && payload && payload.length) {
     return (

--- a/frontend/src/components/dashboard/LiquidityChart.tsx
+++ b/frontend/src/components/dashboard/LiquidityChart.tsx
@@ -74,7 +74,7 @@ export const LiquidityChart: React.FC<LiquidityChartProps> = ({ data }) => {
             <YAxis
               axisLine={false}
               tickLine={false}
-              tickFormatter={(value: any) => {
+              tickFormatter={(value: number | string) => {
                 const n = Number(value || 0);
                 return `$${(n / 1000000).toFixed(0)}M`;
               }}

--- a/frontend/src/components/layout/notification-center.tsx
+++ b/frontend/src/components/layout/notification-center.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { Bell, Check, Trash2, X, AlertCircle, Info, CheckCircle2, AlertTriangle, ExternalLink } from "lucide-react";
 import { useNotifications, NotificationType, AppNotification } from "../lib/notification-context";
 
@@ -14,8 +15,10 @@ export function NotificationCenter() {
         clearAll
     } = useNotifications();
 
+    const router = useRouter();
     const [isOpen, setIsOpen] = useState(false);
     const [activeTab, setActiveTab] = useState<"all" | "unread">("all");
+    const [now, setNow] = useState(() => Date.now());
     const dropdownRef = useRef<HTMLDivElement>(null);
 
     // Close dropdown when clicking outside
@@ -29,12 +32,19 @@ export function NotificationCenter() {
         return () => document.removeEventListener("mousedown", handleClickOutside);
     }, []);
 
+    // Track "now" via an effect so relative timestamps refresh without
+    // reading the impure Date.now() clock during render.
+    useEffect(() => {
+        const interval = setInterval(() => setNow(Date.now()), 60000);
+        return () => clearInterval(interval);
+    }, []);
+
     const filteredNotifications = notifications.filter(
         (n) => activeTab === "all" || !n.read
     );
 
     const formatDistanceToNow = (timestamp: number) => {
-        const diff = Date.now() - timestamp;
+        const diff = now - timestamp;
         const minutes = Math.floor(diff / 60000);
         const hours = Math.floor(minutes / 60);
         const days = Math.floor(hours / 24);
@@ -79,7 +89,7 @@ export function NotificationCenter() {
             markAsRead(notification.id);
         }
         if (notification.actionLink) {
-            window.location.href = notification.actionLink;
+            router.push(notification.actionLink);
         }
     };
 


### PR DESCRIPTION
## Summary
- closes #1917 (NetworkGraph.tsx no-explicit-any)
- closes #1918 (ReliabilityTrend.tsx no-explicit-any)
- closes #1920 (LiquidityChart.tsx no-explicit-any)
- closes #1922 (notification-center.tsx react-hooks/purity + react-hooks/immutability)

## Test plan
- [x] `npx eslint` clean for all 4 files (0 errors)
- [ ] `npx tsc --noEmit` / `npm run build` — currently broken on main for unrelated pre-existing reasons (next.config.ts syntax error + ~180 pre-existing TS errors elsewhere in the app), not touched by this PR