### PR TITLE
fix: remove eslint any/a11y findings in tests and AssetDistributionChart

### DIFF
--- a/frontend/src/components/__tests__/ProgressiveWebApp.test.tsx
+++ b/frontend/src/components/__tests__/ProgressiveWebApp.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ProgressiveWebApp } from '../ProgressiveWebApp';
 import * as useProgressiveWebAppModule from '@/hooks/useProgressiveWebApp';
@@ -27,7 +27,7 @@ describe('ProgressiveWebApp Component', () => {
       serviceWorkerReady: true,
       cacheSize: 1024 * 1024,
     },
-    installPrompt: {} as any,
+    installPrompt: {} as BeforeInstallPromptEvent,
     install: vi.fn(),
     dismiss: vi.fn(),
     clearCache: vi.fn(),

--- a/frontend/src/components/__tests__/accessibility.a11y.test.tsx
+++ b/frontend/src/components/__tests__/accessibility.a11y.test.tsx
@@ -7,6 +7,8 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
+import Link from 'next/link';
+import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 
@@ -135,7 +137,7 @@ describe('Navigation Accessibility', () => {
       <div>
         <header>
           <nav aria-label="Main navigation">
-            <a href="/">Home</a>
+            <Link href="/">Home</Link>
           </nav>
         </header>
         <main id="main-content">
@@ -166,7 +168,7 @@ describe('Navigation Accessibility', () => {
 describe('Image Accessibility', () => {
   it('should have alt text for meaningful images', async () => {
     const { container } = render(
-      <img src="/test.jpg" alt="Description of image" />
+      <Image src="/test.jpg" alt="Description of image" width={100} height={100} />
     );
     
     const results = await axe(container);
@@ -175,7 +177,7 @@ describe('Image Accessibility', () => {
 
   it('should mark decorative images', async () => {
     const { container } = render(
-      <img src="/decorative.jpg" alt="" role="presentation" />
+      <Image src="/decorative.jpg" alt="" role="presentation" width={100} height={100} />
     );
     
     const results = await axe(container);

--- a/frontend/src/components/__tests__/charts.safari.test.tsx
+++ b/frontend/src/components/__tests__/charts.safari.test.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode, CSSProperties } from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { LiquidityChart } from '@/components/dashboard/LiquidityChart';
 import { SettlementSpeedChart } from '@/components/dashboard/SettlementSpeedChart';
 import { TVLChart } from '@/components/charts/TVLChart';
@@ -13,11 +14,11 @@ vi.mock('recharts', async () => {
   const actual = await vi.importActual('recharts');
   return {
     ...actual,
-    ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-    AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
-    LineChart: ({ children }: any) => <div data-testid="line-chart">{children}</div>,
-    BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
-    Tooltip: ({ contentStyle }: any) => (
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+    AreaChart: ({ children }: { children: ReactNode }) => <div data-testid="area-chart">{children}</div>,
+    LineChart: ({ children }: { children: ReactNode }) => <div data-testid="line-chart">{children}</div>,
+    BarChart: ({ children }: { children: ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+    Tooltip: ({ contentStyle }: { contentStyle?: CSSProperties }) => (
       <div data-testid="tooltip" data-style={JSON.stringify(contentStyle)} />
     ),
   };

--- a/frontend/src/components/anchors/AssetDistributionChart.tsx
+++ b/frontend/src/components/anchors/AssetDistributionChart.tsx
@@ -13,6 +13,17 @@ interface AssetDistributionChartProps {
   assets: IssuedAsset[];
 }
 
+interface AssetChartDatum extends IssuedAsset {
+  value: number;
+  percent: number;
+  fill: string;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload: AssetChartDatum }>;
+}
+
 const COLORS = [
   "#6366f1", // Indigo 500
   "#ec4899", // Pink 500
@@ -24,8 +35,7 @@ const COLORS = [
   "#14b8a6", // Teal 500
 ];
 
-const CustomTooltip = (props: any) => {
-  const { active, payload } = props;
+const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (
@@ -129,7 +139,7 @@ export function AssetDistributionChart({
 
       {/* Legend */}
       <div className="mt-6 flex flex-wrap gap-3 justify-center">
-        {data.map((entry, index) => (
+        {data.map((entry) => (
           <div
             key={entry.asset_code}
             className="flex items-center gap-1.5 text-xs"


### PR DESCRIPTION
Replaces any prop types in chart test mocks and ProgressiveWebApp test fixture with precise types, swaps raw <a>/<img> in the a11y test for next/link and next/image, and types AssetDistributionChart's CustomTooltip instead of using any.

Closes #1912, closes #1913, closes #1914, closes #1915