### PR TITLE
fix(frontend): replace any with precise type in ErrorBoundary test mock

### DIFF
--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -13,7 +13,13 @@ vi.mock("@/lib/logger", () => ({
 
 // Mock next/navigation
 vi.mock("@/i18n/navigation", () => ({
-  Link: ({ href, children, ...props }: any) => (
+  Link: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode;
+  }) => (
     <a href={href} {...props}>
       {children}
     </a>


### PR DESCRIPTION
## Summary Resolves the @typescript-eslint/no-explicit-any lint error in rontend/src/components/__tests__/ErrorBoundary.test.tsx. ## Problem The Link mock component in the i.mock('@/i18n/navigation') factory was typed with ny, disabling type checking for all props derived from it. ## Fix Replaced ny with a precise intersection type: \\\	s React.AnchorHTMLAttributes<HTMLAnchorElement> & { children?: React.ReactNode } \\\ This correctly types href and all standard <a> attributes (via AnchorHTMLAttributes), plus children, matching the mock's actual usage. No eslint-disable comment was used. ## Checklist - [x] @typescript-eslint/no-explicit-any error resolved - [x] No blanket eslint-disable suppression - [x] 	sc --noEmit passes with 0 errors - [x] 
pm run lint no longer reports a finding for this file Closes #1911