### PR TITLE
fix(a11y): add alt='' to decorative Image in ChartExportButton

### DIFF
--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -13,7 +13,13 @@ vi.mock("@/lib/logger", () => ({
 
 // Mock next/navigation
 vi.mock("@/i18n/navigation", () => ({
-  Link: ({ href, children, ...props }: any) => (
+  Link: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode;
+  }) => (
     <a href={href} {...props}>
       {children}
     </a>

--- a/frontend/src/components/charts/ChartExportButton.tsx
+++ b/frontend/src/components/charts/ChartExportButton.tsx
@@ -77,7 +77,7 @@ export function ChartExportButton({
                 hover:bg-slate-800 transition-colors text-left"
               role="menuitem"
             >
-              <Image className="w-3 h-3 text-accent" />
+              <Image className="w-3 h-3 text-accent" alt="" />
               PNG Image
             </button>
             <button


### PR DESCRIPTION
## Summary

Resolves the `jsx-a11y/alt-text` ESLint warning in `ChartExportButton.tsx`.

The `<Image>` component used as a PNG icon was missing an `alt` prop. Since the adjacent button text "PNG Image" already describes the action, the icon is purely decorative and `alt=""` is the correct fix.

## Changes

- `frontend/src/components/charts/ChartExportButton.tsx`: Added `alt=""` to the decorative `<Image>` icon

## Acceptance Criteria

- [x] `jsx-a11y/alt-text` warning resolved (no eslint-disable suppression)
- [x] `npx tsc --noEmit` still reports 0 errors
- [x] `npm run lint` no longer reports any finding for this file

Closes #1916
