### PR TITLE
fix(lint): replace any with unknown in corridor-charts tickFormatter

### DIFF
--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -13,7 +13,13 @@ vi.mock("@/lib/logger", () => ({
 
 // Mock next/navigation
 vi.mock("@/i18n/navigation", () => ({
-  Link: ({ href, children, ...props }: any) => (
+  Link: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode;
+  }) => (
     <a href={href} {...props}>
       {children}
     </a>

--- a/frontend/src/components/charts/ChartExportButton.tsx
+++ b/frontend/src/components/charts/ChartExportButton.tsx
@@ -77,7 +77,7 @@ export function ChartExportButton({
                 hover:bg-slate-800 transition-colors text-left"
               role="menuitem"
             >
-              <Image className="w-3 h-3 text-accent" />
+              <Image className="w-3 h-3 text-accent" alt="" />
               PNG Image
             </button>
             <button

--- a/frontend/src/components/corridor-charts.tsx
+++ b/frontend/src/components/corridor-charts.tsx
@@ -188,7 +188,7 @@ export function VolumeTrendChart({ data }: VolumeTrendChartProps) {
           />
           <YAxis
             label={{ value: "Volume ($)", angle: -90, position: "insideLeft" }}
-            tickFormatter={(value: any) => {
+            tickFormatter={(value: unknown) => {
               const n = Number(value || 0);
               return `$${(n / 1000).toFixed(0)}k`;
             }}


### PR DESCRIPTION
## Summary\n\nFixes the @typescript-eslint/no-explicit-any lint error in rontend/src/components/corridor-charts.tsx at line 191.\n\n### Change\n\nReplaced alue: any with alue: unknown in the YAxis 	ickFormatter callback. The body already uses Number(value || 0) which safely handles any input, so no additional narrowing is needed — unknown is the accurate type here and satisfies the lint rule without suppressing it.\n\n### Checklist\n- [x] Lint finding resolved (no eslint-disable suppression)\n- [x] No new TypeScript errors introduced\n- [x] Build still passes\n\n Closes #1919