### PR TITLE
Fix/lint issues 1892 1893 1894

### DIFF
--- a/frontend/src/__tests__/chart-utils.test.ts
+++ b/frontend/src/__tests__/chart-utils.test.ts
@@ -58,7 +58,7 @@ describe('chart-utils', () => {
 
     it('should return false when window is undefined', () => {
       const originalWindow = global.window;
-      // @ts-ignore
+      // @ts-expect-error
       delete global.window;
       expect(isSafari()).toBe(false);
       global.window = originalWindow;

--- a/frontend/src/__tests__/hooks/useSep24.test.tsx
+++ b/frontend/src/__tests__/hooks/useSep24.test.tsx
@@ -88,8 +88,8 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useSep24Anchors(), {
         wrapper: TestWrapper,
       });
-      
-      await waitFor(() => expect(result.current.isSuccess).toBe(true);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(mockGetSep24Anchors().anchors);
     });
 
@@ -97,7 +97,7 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useSep24Anchors(), {
         wrapper: TestWrapper,
       });
-      
+
       expect(result.current.isLoading).toBe(true);
     });
 
@@ -108,8 +108,8 @@ describe('useSep24 Hooks', () => {
           wrapper: TestWrapper,
         }
       );
-      
-      await waitFor(() => expect(result.current.isError).toBe(true);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
     });
   });
 
@@ -121,8 +121,8 @@ describe('useSep24 Hooks', () => {
           wrapper: TestWrapper,
         }
       );
-      
-      await waitFor(() => expect(result.current.isSuccess).toBe(true);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(mockGetSep24Info('https://anchor.example.com'));
     });
 
@@ -130,7 +130,7 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useSep24Info(''), {
         wrapper: TestWrapper,
       });
-      
+
       expect(result.current.fetchStatus).toBe('idle');
     });
 
@@ -141,8 +141,8 @@ describe('useSep24 Hooks', () => {
           wrapper: TestWrapper,
         }
       );
-      
-      await waitFor(() => expect(result.current.isError).toBe(true);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
     });
   });
 
@@ -154,8 +154,8 @@ describe('useSep24 Hooks', () => {
           wrapper: TestWrapper,
         }
       );
-      
-      await waitFor(() => expect(result.current.isSuccess).toBe(true);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(mockGetSep24Transactions().transactions);
     });
 
@@ -163,7 +163,7 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useSep24Transactions('', ''), {
         wrapper: TestWrapper,
       });
-      
+
       expect(result.current.fetchStatus).toBe('idle');
     });
   });
@@ -173,7 +173,7 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useStartDepositFlow(), {
         wrapper: TestWrapper,
       });
-      
+
       act(() => {
         result.current.mutate({
           transferServer: 'https://anchor.example.com',
@@ -181,8 +181,8 @@ describe('useSep24 Hooks', () => {
           amount: '100',
         });
       });
-      
-      await waitFor(() => expect(result.current.isSuccess).toBe(true);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(mockStartDeposit());
     });
 
@@ -190,14 +190,14 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useStartDepositFlow(), {
         wrapper: TestWrapper,
       });
-      
+
       act(() => {
         result.current.mutate({
           transferServer: 'https://invalid.example.com',
         });
       });
-      
-      await waitFor(() => expect(result.current.isError).toBe(true);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
     });
 
     it('should add success notification on success', async () => {
@@ -225,7 +225,7 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useStartWithdrawFlow(), {
         wrapper: TestWrapper,
       });
-      
+
       act(() => {
         result.current.mutate({
           transferServer: 'https://anchor.example.com',
@@ -233,8 +233,8 @@ describe('useSep24 Hooks', () => {
           amount: '100',
         });
       });
-      
-      await waitFor(() => expect(result.current.isSuccess).toBe(true);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(mockStartWithdraw());
     });
 
@@ -242,16 +242,16 @@ describe('useSep24 Hooks', () => {
       const { result } = renderHook(() => useStartWithdrawFlow(), {
         wrapper: TestWrapper,
       });
-      
+
       act(() => {
         result.current.mutate({
           transferServer: 'https://anchor.example.com',
           assetCode: 'USD',
         });
       });
-      
-      await waitFor(() => expect(result.current.isSuccess).toBe(true);
-      
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
       const notifications = useAppStore.getState().notifications;
       expect(notifications).toHaveLength(1);
       expect(notifications[0].type).toBe('success');
@@ -314,13 +314,13 @@ describe('useSep24 Hooks', () => {
       const { result: depositMutation } = renderHook(() => useStartDepositFlow(), {
         wrapper: TestWrapper,
       });
-      
+
       // Set form data
       act(() => {
         flowState.current.setFormDataValue('transferServer', 'https://anchor.example.com');
         flowState.current.setFormDataValue('assetCode', 'USDC');
       });
-      
+
       // Start deposit flow
       act(() => {
         depositMutation.current.mutate({
@@ -329,9 +329,9 @@ describe('useSep24 Hooks', () => {
           amount: '100',
         });
       });
-      
-      await waitFor(() => expect(depositMutation.current.isSuccess).toBe(true);
-      
+
+      await waitFor(() => expect(depositMutation.current.isSuccess).toBe(true));
+
       // Check that notifications were added
       const notifications = useAppStore.getState().notifications;
       expect(notifications).toHaveLength(1);

--- a/frontend/src/__tests__/pwa.test.tsx
+++ b/frontend/src/__tests__/pwa.test.tsx
@@ -24,14 +24,14 @@ beforeEach(() => {
     ready: Promise.resolve({
       active: { state: 'activated' }
     })
-  } as any;
+  } as unknown as ServiceWorkerContainer;
 
   // Mock caches
   globalThis.caches = {
     open: vi.fn(),
     match: vi.fn(),
     delete: vi.fn()
-  } as any;
+  } as unknown as CacheStorage;
 });
 
 afterEach(() => {
@@ -53,9 +53,9 @@ describe('PWA Offline Implementation', () => {
     const { isOffline, getSWStatus, registerSW } = await import('@/lib/pwa');
     
     expect(isOffline()).toBe(false);
-    
+
     // Mock offline
-    (globalThis.navigator as any).onLine = false;
+    (globalThis.navigator as unknown as { onLine: boolean }).onLine = false;
     expect(isOffline()).toBe(true);
     
     // Mock SW status
@@ -68,7 +68,7 @@ describe('PWA Offline Implementation', () => {
 
   it('caches static assets correctly (simulated)', async () => {
     // Simulate CacheFirst for images/fonts
-    (globalThis.caches as any).open.mockResolvedValue({
+    (globalThis.caches as unknown as CacheStorage).open.mockResolvedValue({
       addAll: vi.fn(),
       match: vi.fn().mockResolvedValue({}),
       keys: vi.fn().mockResolvedValue([])


### PR DESCRIPTION
  ## Summary

  Fixes 4 lint findings and 1 parse error across 3 test files from the stabilization follow-up batch (#1891).

  ## Changes

  ### #1894 — Fix 4 ESLint findings in pwa.test.tsx
  - Replaced 4 instances of `as any` with proper type casting (`as unknown as ServiceWorkerContainer | CacheStorage | { onLine: boolean }`)
  - Improved type safety by using precise interface types instead of disabling type checks

  ### #1892 — Fix ESLint finding in chart-utils.test.ts
  - Replaced `@ts-ignore` with `@ts-expect-error` on the `delete global.window` line
  - This ensures the suppression expires once the underlying TypeScript issue is fixed

  ### #1893 — Fix parse error in useSep24.test.tsx
  - Added missing closing parentheses to all `waitFor()` function calls throughout the file
  - Fixed 11 instances where the closing paren was missing, which was causing a parse error that prevented ESLint from analyzing the file

  Closes #1894,  Closes #1892, Closes #1893, Closes #1891
