### PR TITLE
docs: refresh PROJECT_STRUCTURE.md to match post-cleanup layout

### DIFF
--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -7,17 +7,26 @@ This document outlines the organized structure of the Stellar Insights monorepo.
 ```
 stellar-insights/
 ├── 📱 mobile/           # React Native mobile app
-├── 🌐 frontend/         # Next.js web application  
+├── 🌐 frontend/         # Next.js web application
 ├── ⚙️  backend/          # Rust API server
 ├── 📜 contracts/        # Soroban smart contracts
-├── 📦 sdk/              # TypeScript SDK
+├── 📦 sdk/              # TypeScript + Python client SDKs
 ├── 📚 docs/             # All documentation
-├── 🔧 scripts/          # Build and deployment scripts
+├── 🔧 scripts/          # Build, deployment, and maintenance scripts
 ├── ☁️  k8s/              # Kubernetes configs
 ├── 🐳 terraform/        # Infrastructure as code
-├── 📊 elk/              # ELK stack configs
-└── 📋 README.md         # Main project documentation
+├── 📊 elk/              # ELK stack configs (centralized logging)
+├── 📈 monitoring/       # Prometheus alert rules, Alertmanager config
+├── 🧪 tests/            # Repo-root acceptance, chaos, and e2e tests (Playwright)
+├── 📋 README.md         # Main project documentation
+└── 📋 package.json      # Repo-root tooling only (Playwright + commitlint)
 ```
+
+Note: the repo root used to also have a second, disconnected Vite/React app
+(`src/`, `index.html`, `vite.config.ts`, package name `"awpwrate"`) from a
+single auto-generated commit, unrelated to the real Next.js app in
+`frontend/`. It has been removed; the root `package.json` above is
+repo-root tooling only, not an application.
 
 ## 🏗️ Component Details
 
@@ -40,7 +49,7 @@ Next.js web application with:
 ### ⚙️ Backend (`backend/`)
 Rust API server with:
 - Axum web framework
-- SQLx database integration
+- SQLx database integration (PostgreSQL)
 - Job scheduling
 - Observability/metrics
 - Multi-network support
@@ -53,19 +62,24 @@ Soroban smart contracts for:
 - Security audits
 
 ### 📦 SDK (`sdk/`)
-TypeScript SDK providing:
-- API client
+Client SDKs providing:
+- API client (TypeScript, Python)
 - Type definitions
 - React Native compatibility
 - Authentication helpers
 
 ### 📚 Documentation (`docs/`)
-All project documentation organized by:
+Project documentation organized by:
 - Architecture decisions
-- Development guides
-- Deployment instructions
+- Development guides (e.g. [testnet quickstart](testnet-quickstart.md))
+- Deployment instructions and runbooks
 - Issue tracking
 - API references
+
+Note: `docs/` previously contained ~475 vendored third-party markdown/JSON
+files (Next.js, undici, Recharts, and other unrelated projects' own docs,
+accidentally committed verbatim). Those have been removed; everything
+remaining here is project-specific.
 
 ## 🚀 Getting Started
 
@@ -76,8 +90,12 @@ All project documentation organized by:
 
 ## 🔗 Quick Links
 
-- [Mobile Setup](mobile/README.md)
-- [Backend Setup](backend/README.md)  
-- [Frontend Setup](frontend/README.md)
-- [Full Documentation](docs/README.md)
-- [Contributing Guide](CONTRIBUTING.md)
+- [Mobile status & setup](../mobile/README.md#current-status)
+- [Testnet quickstart](testnet-quickstart.md)
+- [Full documentation index](README.md)
+- [Root README](../README.md)
+
+Note: this document previously linked to `backend/README.md`,
+`frontend/README.md`, and a root-level `CONTRIBUTING.md` — none of those
+files exist in the repo. Removed rather than left dangling; if/when those
+are written, re-add the links here.


### PR DESCRIPTION
Brought the directory tree and links back in line with reality after this session's structural cleanup (verified against the actual commits: 9a963c03 removed the orphaned root Vite app, 930f0a36 purged ~475 vendored third-party doc files from docs/, b4b2c13c replaced root package.json with repo-root tooling only):

- Added a note (and removed the now-invalid root package.json's implicit "app" framing) documenting the removed root-level Vite app -- it was a disconnected, auto-generated "awpwrate" React app with no relation to frontend/.
- Added a note on the docs/ vendor-doc purge so the doc doesn't imply a scope it no longer has.
- Added the two root directories missing from the tree entirely: monitoring/ (Prometheus/Alertmanager config) and tests/ (repo-root Playwright acceptance/chaos/e2e suites).
- Fixed sdk/'s description -- it's TypeScript *and* Python, not TypeScript-only.
- Removed three dead "Quick Links" (backend/README.md, frontend/README.md, CONTRIBUTING.md -- none exist in the repo) and replaced them with links that actually resolve, cross-checked against the root README.md refresh (mobile status anchor, testnet quickstart, docs index).

closes #1880
