### PR TITLE
docs: state the SQLite-only architecture consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,32 +7,42 @@ A lean, production-grade stack for measuring and improving cross-border payment 
 - Backend: Rust analytics engine
 - Frontend: Next.js dashboard
 - Contracts: Soroban smart contracts (optional)
-- DB: PostgreSQL
+- DB: SQLite (WAL mode) — see [Database](#database) below
 
 ## 🔧 Quick start
 
-1. Start Postgres (example):
+No database server to install — SQLite runs in-process and the file is created
+on first start.
 
-```bash
-docker run --name stellar-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=stellar_insights -p 5432:5432 -d postgres:14
-```
-
-2. Run backend
+1. Run backend
 
 ```bash
 cd backend
 cp .env.example .env
-# set DATABASE_URL, STELLAR_RPC_URL, etc.
+# DATABASE_URL already defaults to sqlite:./stellar_insights.db
+# set STELLAR_RPC_URL etc. as needed
 cargo run
 ```
 
-3. Run frontend
+2. Run frontend
 
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
+
+## Database
+
+**SQLite only.** This is a compile-time property, not a configuration one:
+`sqlx` is built with only the `sqlite` feature, `backend/src/database.rs` uses
+`SqlitePool`/`SqliteConnectOptions` directly, and every migration is written in
+SQLite-flavoured SQL.
+
+Setting a `postgresql://` `DATABASE_URL` does **not** switch databases — it
+fails to parse as `SqliteConnectOptions` and the backend refuses to start.
+Adding Postgres support is a code change. Whether to make it is being tracked
+in issue #1876.
 
 ## 🧪 Local safety checks (already built)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,10 +14,18 @@
 # VAULT_SKIP_VERIFY=false
 
 # Database Configuration
-# For SQLite (recommended for development):
+#
+# SQLite only. This is not a preference that can be changed by editing this
+# value — the backend is compiled against SQLite:
+#
+#   * Cargo.toml enables only sqlx's `sqlite` feature
+#   * database.rs uses SqlitePool / SqliteConnectOptions directly
+#   * all migrations are written in SQLite-flavoured SQL
+#
+# A `postgresql://` URL here does not switch databases; it fails to parse as
+# SqliteConnectOptions and the backend refuses to start. Adding Postgres
+# support is a code change, not a config change.
 DATABASE_URL=sqlite:./stellar_insights.db
-# For PostgreSQL (production - use Vault):
-# DATABASE_URL=postgresql://username:password@localhost:5432/stellar_insights
 
 # SQL query logging (optional)
 # Development: all queries logged. Production: only slow queries (see DB_SLOW_QUERY_MS).

--- a/docs/CODE_DOCUMENTATION.md
+++ b/docs/CODE_DOCUMENTATION.md
@@ -77,7 +77,7 @@ stellar-insights/
 |-----------|------------|
 | Language | Rust (edition 2021) |
 | Web Framework | Axum 0.7 with Tower middleware |
-| Database | PostgreSQL (primary), SQLite (dev), accessed via SQLx with compile-time query verification |
+| Database | SQLite (WAL mode) in every environment, accessed via SQLx with compile-time query verification. Postgres is not supported — see issue #1876 for the evaluation |
 | Cache | Redis with in-memory fallback |
 | Async Runtime | Tokio |
 | Observability | OpenTelemetry + Jaeger for distributed tracing, Prometheus for metrics, structured JSON logging via tracing-subscriber |

--- a/docs/PROJECT_DESCRIPTION.md
+++ b/docs/PROJECT_DESCRIPTION.md
@@ -38,7 +38,7 @@ The backend is built in Rust using the **Axum** web framework and is the heart o
 
 - **Language:** Rust (edition 2021)
 - **Web framework:** Axum 0.7 with Tower middleware
-- **Database:** PostgreSQL (primary) with SQLite fallback for local development, accessed via SQLx with compile-time query verification
+- **Database:** SQLite (WAL mode) for every environment, accessed via SQLx with compile-time query verification. Postgres is not currently supported — see issue #1876 for the evaluation
 - **Cache:** Redis with in-memory fallback
 - **Async runtime:** Tokio
 - **Observability:** OpenTelemetry + Jaeger for distributed tracing, Prometheus for metrics, structured JSON logging via tracing-subscriber


### PR DESCRIPTION
Closes #1877

## Problem

`backend/.env.example` advertised a commented PostgreSQL `DATABASE_URL` as the production path. **It is not one.** The backend is compiled against SQLite:

- `sqlx` enables only the `sqlite` feature
- `database.rs` uses `SqlitePool` / `SqliteConnectOptions` directly
- every migration is SQLite-flavoured SQL

Setting a `postgresql://` URL doesn't switch databases — it fails to parse as `SqliteConnectOptions` and the backend refuses to start. Anyone deploying on the strength of that comment would find out at startup, which is the worst possible moment.

## The claim was in four places, not one

Fixing only the env file would have left the contradiction intact:

| File | Said | Now |
|---|---|---|
| `backend/.env.example` | commented `postgresql://` "production" URL | removed, with an explanation of why it can't work |
| `README.md` | "DB: PostgreSQL" + `docker run ... postgres:14` in the quick start | SQLite path (no DB server needed), plus a new **Database** section |
| `docs/PROJECT_DESCRIPTION.md` | Postgres "primary", SQLite a local "fallback" | exactly backwards — corrected |
| `docs/CODE_DOCUMENTATION.md` | same claim in the stack table | corrected |

The README case was the most actively harmful: its quick start told you to start a Postgres container and then set `DATABASE_URL` — a sequence that cannot work. It now leads with SQLite needing no database server at all, and I fixed the step numbering the removal left dangling.

Each location points at **#1876**, so the decision lives in one place rather than being re-litigated per file.

`docs/testnet-quickstart.md` was checked and needed no change.

## Acceptance criteria

- [x] Remove the misleading commented Postgres line — removed, and replaced with an explanation of *why* it isn't switchable, so it doesn't get helpfully re-added
- [x] Cross-reference in `docs/` wherever database setup is documented (testnet-quickstart, README) — README, PROJECT_DESCRIPTION and CODE_DOCUMENTATION all corrected; testnet-quickstart verified clean

## On the "worth checking either way" note in the issue

You asked what `database.rs` actually does with a non-sqlite scheme. It calls `database_url.parse::<SqliteConnectOptions>()` and maps the failure to `anyhow!("Invalid DATABASE_URL: {e}")` — so it's a clean startup error, not silent misbehaviour. Bad, but bad in the safe direction. I've documented it as a refusal to start rather than anything subtler.

## Scope

This touches **only** the database claims in `README.md`. The broader README refresh — testnet contract IDs, the removed Vite app, doc-link validation — is #1878, which I'm doing separately. The two will touch different lines of the same file.

Docs-only; no code changed.