### PR TITLE
docs: record the SQLite vs PostgreSQL decision, and set busy_timeout

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -118,11 +118,20 @@ RPC_PAGINATION_DELAY_MS=100
 
 # Database Connection Pool Configuration
 # Tuned for high-load resilience (#1497): larger max, shorter acquire timeout.
+#
+# Note: this sizing is a *read-side* number. SQLite permits one writer at a
+# time, so additional connections do not increase write throughput — they only
+# add contenders for the same lock. See docs/adr/0001-sqlite-vs-postgres.md.
 DB_POOL_MAX_CONNECTIONS=100
 DB_POOL_MIN_CONNECTIONS=5
 DB_POOL_CONNECT_TIMEOUT_SECONDS=10
 DB_POOL_IDLE_TIMEOUT_SECONDS=600
 DB_POOL_MAX_LIFETIME_SECONDS=1800
+
+# How long a connection waits for SQLite's single write lock before failing
+# with SQLITE_BUSY. SQLite's own default is 0 — an immediate error rather than
+# a wait — which turns write contention into spurious 500s. Default here: 5000.
+# DB_BUSY_TIMEOUT_MS=5000
 
 # Network Configuration (mainnet/testnet)
 STELLAR_NETWORK=mainnet

--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -136,6 +136,21 @@ impl PoolConfig {
 
     /// Create a configured `SQLite` pool with these settings.
     /// Uses WAL journal mode and configurable SQL query logging (all in dev, slow-only in prod).
+    /// How long a connection waits for SQLite's single write lock before
+    /// giving up with `SQLITE_BUSY`.
+    ///
+    /// Five seconds by default: long enough to absorb the short write bursts the
+    /// ingestion pipeline produces, short enough that a genuinely stuck writer
+    /// still surfaces rather than hanging the request indefinitely.
+    fn busy_timeout_ms_inner() -> u64 {
+        const DEFAULT_BUSY_TIMEOUT_MS: u64 = 5_000;
+        std::env::var("DB_BUSY_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|ms| *ms > 0)
+            .unwrap_or(DEFAULT_BUSY_TIMEOUT_MS)
+    }
+
     pub async fn create_pool(&self, database_url: &str) -> Result<SqlitePool> {
         let sql_log = SqlLogConfig::from_env();
 
@@ -145,6 +160,16 @@ impl PoolConfig {
             .context("Failed to parse DATABASE_URL for SQLite connection")?;
 
         opts = opts.journal_mode(SqliteJournalMode::Wal);
+
+        // SQLite allows exactly one writer at a time. Its default busy_timeout
+        // is 0, meaning a connection that finds the write lock held returns
+        // SQLITE_BUSY *immediately* rather than waiting for it — so concurrent
+        // writes fail outright instead of queueing, surfacing as spurious 500s
+        // under exactly the load where the system should degrade gracefully.
+        //
+        // With a timeout set, contention becomes a bounded wait. See
+        // docs/adr/0001-sqlite-vs-postgres.md.
+        opts = opts.busy_timeout(Duration::from_millis(Self::busy_timeout_ms_inner()));
 
         if sql_log.level != log::LevelFilter::Off {
             if sql_log.log_all_in_dev {

--- a/docs/adr/0001-sqlite-vs-postgres.md
+++ b/docs/adr/0001-sqlite-vs-postgres.md
@@ -1,0 +1,117 @@
+# ADR 0001 — SQLite vs PostgreSQL for production write concurrency
+
+- **Status:** Accepted
+- **Decision:** Stay on SQLite. Do not add PostgreSQL support at this time.
+- **Issue:** #1876
+- **Supersedes:** the implicit assumption, visible in `.env.example`, `README.md`,
+  `PROJECT_DESCRIPTION.md` and `CODE_DOCUMENTATION.md`, that Postgres was the
+  production database. It never was — see #1877.
+
+---
+
+## Context
+
+The backend is hard-wired to SQLite, and not by configuration:
+
+| Evidence | Detail |
+|---|---|
+| `backend/Cargo.toml` | `sqlx` enables only the `sqlite` feature |
+| `backend/src/database.rs` | `SqlitePool`, `SqliteConnectOptions`, `SqliteJournalMode` used directly |
+| `backend/migrations/` | 37 migrations, **29 of which** use SQLite-specific SQL |
+
+A `postgresql://` `DATABASE_URL` does not select Postgres. It fails to parse as
+`SqliteConnectOptions`, and the backend refuses to start with
+`Invalid DATABASE_URL`. Switching is a code change, not a config change.
+
+The concern raised in #1876 is real: SQLite permits exactly one writer at a
+time. Readers don't block under WAL, but writes serialise globally, which is a
+fundamentally different model from Postgres MVCC.
+
+## What actually limits us today
+
+The single-writer lock is the *theoretical* limit. Before it is reached, two
+concrete properties of the current configuration matter more:
+
+### 1. No `busy_timeout` is set
+
+`create_pool` configures WAL, pool sizes, timeouts and statement logging — but
+never `busy_timeout`. SQLite's default is **0**: a connection that finds the
+write lock held returns `SQLITE_BUSY` **immediately** rather than waiting.
+
+So under concurrent writes the failure mode is not "slow", it is "errors" — and
+they surface as spurious 500s under exactly the load where the system should be
+degrading gracefully.
+
+### 2. The pool is sized as though writes were parallel
+
+`.env.example` ships `DB_POOL_MAX_CONNECTIONS=100`. Against a database with one
+write lock, 100 connections do not buy write throughput; they buy 100 ways to
+contend for the same lock. For reads the pool is useful and 100 is fine.
+
+**Neither of these is an argument for Postgres.** They are an argument that
+SQLite here has not yet been configured like a production SQLite deployment.
+Migrating to Postgres to fix an unset `busy_timeout` would be replacing a
+one-line change with a multi-week one.
+
+## Decision
+
+**Stay on SQLite**, for this workload, with the hardening below.
+
+### Why SQLite fits this workload
+
+The write path is not user-driven. Writes come from RPC ingestion, corridor
+aggregation, and backfill jobs — background pipelines whose throughput is
+already bounded upstream by `RPC_RATE_LIMIT_REQUESTS_PER_MINUTE=90` and
+`RPC_MAX_TOTAL_RECORDS`. The API surface is overwhelmingly read-heavy
+(corridors, anchors, network stats, analytics, exports), and reads under WAL do
+not block on the writer.
+
+An analytics platform ingesting at ~90 requests/minute is nowhere near SQLite's
+write ceiling. The operational simplicity — no separate server, no connection
+tuning across a network boundary, trivial backup as a file copy — is worth
+keeping until there is measured evidence of write pressure.
+
+### Why not Postgres now
+
+- 29 of 37 migrations use SQLite-flavoured SQL (`INSERT OR IGNORE`,
+  `AUTOINCREMENT`, `CURRENT_TIMESTAMP` defaults, `datetime()`). None of these
+  translate 1:1, so this is a migration rewrite, not a feature flag.
+- `sqlx` compile-time query verification is bound to the database backend;
+  supporting both means every `query!` invocation must typecheck against both,
+  or the macros must be abandoned for runtime queries.
+- It buys nothing measurable until the write path is demonstrably contended,
+  and we do not currently measure that (see below).
+
+## Consequences
+
+### Required hardening (SQLite as a production database)
+
+- [x] **Set `busy_timeout`.** Included in this change: 5 s by default,
+      overridable via `DB_BUSY_TIMEOUT_MS`. Turns lock contention from an
+      immediate error into a bounded wait.
+- [ ] **Right-size the write pool.** 100 connections is a read-side number.
+      Worth splitting reader and writer pools if contention appears.
+- [ ] **Durability story.** SQLite's backup is a file copy, but a *consistent*
+      one needs care under WAL. Litestream (or an equivalent) gives continuous
+      replication; `backup.rs` currently schedules snapshots without it.
+
+### Revisit this decision when
+
+Any of these is a trigger to reopen, and they are deliberately measurable rather
+than a matter of taste:
+
+1. `SQLITE_BUSY` / lock-timeout errors appear in production logs at all — with
+   `busy_timeout` set, seeing them means waits are exceeding 5 s.
+2. Sustained write volume exceeds roughly 50 writes/second, or ingestion rate
+   limits are raised by an order of magnitude.
+3. A second writer process is introduced (a separate indexer or worker binary
+   holding its own connection to the same file).
+4. Horizontal scaling of the backend becomes a requirement — multiple backend
+   instances cannot share a SQLite file across hosts, and this is the trigger
+   most likely to actually force the change.
+
+### Documentation
+
+`.env.example`, `README.md`, `PROJECT_DESCRIPTION.md` and
+`CODE_DOCUMENTATION.md` were corrected in #1877 to describe SQLite accurately.
+This ADR is the single source of truth for *why*.


### PR DESCRIPTION
Closes #1876

Adds `docs/adr/0001-sqlite-vs-postgres.md`. **Decision: stay on SQLite.**

## Why SQLite fits this workload

The write path isn't user-driven. Writes come from RPC ingestion, corridor aggregation and backfill jobs — background pipelines already bounded upstream by `RPC_RATE_LIMIT_REQUESTS_PER_MINUTE=90` and `RPC_MAX_TOTAL_RECORDS`. The API surface is overwhelmingly read-heavy, and reads under WAL don't block on the writer.

An analytics platform ingesting at ~90 requests/minute is nowhere near SQLite's write ceiling.

**Why not Postgres now:** 29 of the 37 migrations use SQLite-flavoured SQL (`INSERT OR IGNORE`, `AUTOINCREMENT`, `CURRENT_TIMESTAMP` defaults, `datetime()`) — none translate 1:1, so this is a migration rewrite, not a feature flag. And `sqlx`'s compile-time verification is bound to the backend, so supporting both means every `query!` typechecks against both or the macros get dropped.

## The finding that actually matters

While evaluating, the single-writer lock turned out **not to be the binding constraint yet**. Two properties of the current configuration are:

**1. `create_pool` never set `busy_timeout`.** SQLite's default is `0` — a connection that finds the write lock held returns `SQLITE_BUSY` **immediately** rather than waiting. So under concurrent writes the failure mode wasn't "slow", it was "errors": spurious 500s under exactly the load where the system should degrade gracefully.

**2. `DB_POOL_MAX_CONNECTIONS=100` is a read-side number.** Against one write lock, 100 connections buy no write throughput — only 100 contenders for it.

Neither is an argument for Postgres. They're an argument that SQLite here hadn't been configured like a *production* SQLite deployment. **Migrating databases to fix an unset `busy_timeout` would replace a one-line change with a multi-week one.**

## So this PR also sets it

`busy_timeout` now defaults to 5s (`DB_BUSY_TIMEOUT_MS` to override), turning lock contention from an immediate error into a bounded wait. The ADR's conclusion depends on this being true, so it ships with the ADR rather than as a follow-up.

Five seconds is chosen to absorb the short write bursts ingestion produces while still surfacing a genuinely stuck writer rather than hanging a request indefinitely.

## Acceptance criteria

- [x] Decide, and document why — ADR 0001, with the reasoning above
- [x] Update `.env.example`'s misleading Postgres line — done in #1877; this PR adds the pool-sizing caveat and the new `DB_BUSY_TIMEOUT_MS` knob

## Left open, deliberately

The ADR lists what's still needed to call SQLite production-hardened — right-sizing the write pool, and a real durability story (`backup.rs` schedules snapshots but there's no continuous replication; Litestream or equivalent is the gap). Both are follow-ups rather than blockers.

It also gives **four measurable triggers** to revisit, rather than leaving it to taste. The sharpest: multiple backend instances can't share a SQLite file across hosts, so horizontal scaling forces the decision.

## Verification

Docs plus a ~10-line config change. I have not run `cargo build` here — `SqliteConnectOptions::busy_timeout` is stable API in `sqlx` 0.8, but worth a compile check on review.