### PR TITLE
security: add credential detection and a token rotation runbook

### DIFF
--- a/.github/workflows/credential-scan.yml
+++ b/.github/workflows/credential-scan.yml
@@ -1,0 +1,35 @@
+name: Credential Scan
+
+# Catches credentials committed to tracked files (issue #1875).
+#
+# Deliberately does NOT check remote URLs: remotes are local state, and CI
+# checks out a fresh clone with its own remote, so the check would always pass
+# regardless of what a developer has configured. Run
+# `scripts/check-git-credentials.sh` locally — or install the pre-push hook —
+# for that half. See docs/runbooks/credential-rotation.md.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan tracked files for embedded credentials
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # git grep only sees the checked-out tree, so a shallow clone is
+          # enough — this catches a token being introduced, not one already
+          # buried in history. GitHub secret scanning covers the latter.
+          fetch-depth: 1
+
+      - name: Run credential check
+        run: |
+          chmod +x scripts/check-git-credentials.sh
+          scripts/check-git-credentials.sh --tracked

--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -1,0 +1,120 @@
+# Runbook — rotating a leaked GitHub token
+
+Applies when a personal access token has been embedded in a git remote URL,
+committed to a tracked file, or otherwise exposed.
+
+> **Rotate first, clean up second.** Removing a token from a config file or
+> rewriting history does not invalidate it. Until it is revoked on GitHub, a
+> copy captured from a log, a shell history, or a screen share still works.
+
+---
+
+## 1. Revoke and reissue
+
+1. <https://github.com/settings/tokens> (classic) or
+   <https://github.com/settings/personal-access-tokens> (fine-grained).
+2. **Delete** the exposed token. Do not merely regenerate — deletion is what
+   invalidates existing copies immediately.
+3. Create a replacement with the narrowest scopes that still work. For pushing
+   to this repository that is `repo` alone; `workflow` only if you edit files
+   under `.github/workflows/`.
+4. Set an expiry. A token that expires bounds the damage of the next leak.
+
+Repeat for **every** exposed token. Issue #1875 concerns two: `origin` and
+`stellar-org`.
+
+## 2. Stop embedding it in the remote
+
+Embedding a token in the URL is what caused the exposure — a credential helper
+keeps it out of `.git/config` entirely.
+
+```bash
+# Confirm what is currently configured (output includes the token, so do not
+# paste this anywhere):
+git remote -v
+
+# Rewrite each remote without credentials:
+git remote set-url origin https://github.com/<owner>/<repo>.git
+git remote set-url stellar-org https://github.com/<owner>/<repo>.git
+```
+
+Then pick one credential source:
+
+```bash
+# GitHub CLI — stores the token in the OS keychain
+gh auth login
+gh auth setup-git
+
+# or the OS keychain directly
+git config --global credential.helper osxkeychain   # macOS
+git config --global credential.helper libsecret     # Linux
+git config --global credential.helper manager       # Windows
+```
+
+SSH avoids tokens for git operations altogether:
+
+```bash
+git remote set-url origin git@github.com:<owner>/<repo>.git
+```
+
+## 3. Hunt the remaining copies
+
+Revoking makes these harmless, but they should still be cleaned — and finding
+one you did not expect tells you the blast radius was larger than assumed.
+
+```bash
+# This repository's config, and any worktrees
+grep -rn '@github.com' .git/config .git/worktrees/*/config 2>/dev/null
+
+# Other clones on the same machine
+find ~ -name config -path '*/.git/*' -exec grep -l '@github.com' {} + 2>/dev/null
+
+# Shell history
+grep -nE '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}' ~/.bash_history ~/.zsh_history 2>/dev/null
+
+# Tracked files and remotes in this repo
+scripts/check-git-credentials.sh
+```
+
+Also check, in order of how often they are forgotten:
+
+- CI secret stores (GitHub Actions secrets, and any self-hosted runner env)
+- `.env` files not covered by `.gitignore`
+- Container images or `docker history` layers built with the token as a build arg
+- Editor/IDE settings that cache remote credentials
+
+## 4. If the token was committed
+
+Rotation is sufficient to make it harmless. Purging history is optional and
+disruptive — it rewrites every commit hash and forces every collaborator to
+re-clone.
+
+```bash
+git filter-repo --replace-text <(echo 'ghp_theLeakedToken==><REMOVED>')
+```
+
+Do this only for a token that was never rotated, or where the commit is public
+and the audit trail matters. Otherwise rotation plus prevention is enough.
+
+## 5. Prevention
+
+`scripts/check-git-credentials.sh` covers both exposures. Wire it into a
+pre-push hook so a token cannot leave the machine:
+
+```bash
+cat > .git/hooks/pre-push <<'EOF'
+#!/usr/bin/env bash
+exec scripts/check-git-credentials.sh --tracked
+EOF
+chmod +x .git/hooks/pre-push
+```
+
+The `--tracked` half also runs in CI (`.github/workflows/credential-scan.yml`).
+The `--remotes` half **cannot** run in CI — remotes are local state, and CI
+checks out a fresh clone with its own remote. That check is only meaningful on
+a developer machine, which is exactly why the original exposure went unnoticed.
+
+Enable [GitHub secret scanning with push
+protection](https://docs.github.com/code-security/secret-scanning/push-protection-for-repositories-and-organizations)
+on the repository as well; it blocks a recognised token at push time, before it
+ever reaches the remote.

--- a/scripts/check-git-credentials.sh
+++ b/scripts/check-git-credentials.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# check-git-credentials.sh — fail if credentials are embedded where they will leak.
+#
+# Two distinct exposures, because they leak through different channels:
+#
+#   1. Remote URLs (`git remote -v`, `.git/config`). A token here is captured by
+#      anything that dumps remotes: CI logs, shell history, `git config --list`,
+#      bug reports, screen shares. This is local-only state and is NOT fixed by
+#      a commit — see docs/runbooks/credential-rotation.md.
+#
+#   2. Tracked files. A token committed here is in the history permanently and
+#      is public the moment the repository is.
+#
+# Exit codes: 0 clean, 1 credentials found, 2 usage error.
+#
+# Usage:
+#   scripts/check-git-credentials.sh            # check remotes + tracked files
+#   scripts/check-git-credentials.sh --tracked  # tracked files only (CI)
+#   scripts/check-git-credentials.sh --remotes  # remotes only (local)
+
+set -euo pipefail
+
+MODE="${1:-all}"
+FOUND=0
+
+# GitHub token prefixes, all followed by 36 base62 chars:
+#   ghp_ personal access    gho_ oauth       ghu_ user-to-server
+#   ghs_ server-to-server   ghr_ refresh     github_pat_ fine-grained
+TOKEN_RE='((ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{22,})'
+# Any userinfo in an https remote — covers tokens that do not match the
+# prefixes above, including other forges.
+URL_CRED_RE='https://[^/[:space:]@]+:[^/[:space:]@]+@'
+
+# Never print a matched secret. Redaction is the whole point of a checker that
+# runs in CI, where the output is itself a log that persists.
+redact() { sed -E "s/${TOKEN_RE}/<REDACTED-TOKEN>/g; s#${URL_CRED_RE}#https://<REDACTED-CREDENTIALS>@#g"; }
+
+check_remotes() {
+  echo "→ Checking git remote URLs..."
+  local hits
+  hits="$(git remote -v 2>/dev/null | grep -nE "${TOKEN_RE}|${URL_CRED_RE}" || true)"
+
+  if [[ -n "${hits}" ]]; then
+    echo "✗ Credentials embedded in remote URLs:"
+    echo "${hits}" | redact | sed 's/^/    /'
+    echo
+    echo "  These are visible to anything that reads .git/config or runs"
+    echo "  'git remote -v'. Rotate the token, then switch to a credential"
+    echo "  helper: docs/runbooks/credential-rotation.md"
+    FOUND=1
+  else
+    echo "  ✓ no credentials in remote URLs"
+  fi
+}
+
+check_tracked() {
+  echo "→ Checking tracked files..."
+  local hits
+  # This script necessarily contains the patterns it searches for, so exclude
+  # itself — otherwise the checker fails on its own source.
+  hits="$(git grep -nE "${TOKEN_RE}|${URL_CRED_RE}" -- . \
+            ":(exclude)scripts/check-git-credentials.sh" \
+            ":(exclude)docs/runbooks/credential-rotation.md" 2>/dev/null || true)"
+
+  if [[ -n "${hits}" ]]; then
+    echo "✗ Credentials found in tracked files:"
+    echo "${hits}" | redact | sed 's/^/    /'
+    echo
+    echo "  A committed token is in the history permanently. Rotate it first,"
+    echo "  then purge: docs/runbooks/credential-rotation.md"
+    FOUND=1
+  else
+    echo "  ✓ no credentials in tracked files"
+  fi
+}
+
+case "${MODE}" in
+  all)      check_remotes; check_tracked ;;
+  --remotes) check_remotes ;;
+  --tracked) check_tracked ;;
+  *) echo "usage: $0 [--remotes|--tracked]" >&2; exit 2 ;;
+esac
+
+if [[ "${FOUND}" -ne 0 ]]; then
+  echo
+  echo "Credential check FAILED."
+  exit 1
+fi
+
+echo
+echo "Credential check passed."


### PR DESCRIPTION
Closes #1875 
The issue's first acceptance criterion is *"rotate both tokens"*. That requires access to the GitHub account holding them — I can't do it, and neither can any pull request. **The tokens described in #1875 are still live until someone revokes them at <https://github.com/settings/tokens>.**

That's the actual fix. Everything here is the supporting work around it.

## What I could verify

**Nothing is leaked in the repository itself.** I scanned every tracked file for GitHub token prefixes (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`) and for userinfo in https remote URLs — no matches. The exposure is in the maintainer's local `.git/config`, which isn't committed and isn't reachable from a PR.

Good news as far as it goes: the blast radius is one machine, not the public history.

## `scripts/check-git-credentials.sh`

Covers the two exposures separately, because they leak through different channels:

| Exposure | Leaks via |
|---|---|
| Remote URLs | CI logs, shell history, `git config --list`, bug reports, screen shares |
| Tracked files | Permanent in history; public the moment the repo is |

**Output is redacted.** A checker that runs in CI writes to a log that persists — printing the secret it just found would create a second copy of the leak.

## `.github/workflows/credential-scan.yml`

Runs the `--tracked` half on push and PR.

**Deliberately not the `--remotes` half.** Remotes are local state, and CI checks out a fresh clone with its own remote — that check would always pass regardless of what any developer has configured, which is worse than not having it, because it would look like coverage. It's only meaningful on a developer machine, which is precisely why the original exposure went unnoticed. The runbook gives a pre-push hook for that half instead.

## `docs/runbooks/credential-rotation.md`

Ordered so the first step is the one that actually matters:

1. **Revoke and reissue** — removing a token from a config file or rewriting history does *not* invalidate it. Until it's deleted on GitHub, any copy captured from a log still works.
2. Reconfigure remotes to a credential helper (`gh auth setup-git`, OS keychain) or SSH
3. Hunt remaining copies — other clones, shell history, CI secret stores, container build args
4. History purging, marked optional and disruptive, with the honest tradeoff: rotation alone makes the token harmless, and `filter-repo` forces every collaborator to re-clone
5. Prevention — the pre-push hook, plus enabling GitHub secret scanning with push protection

## Verification

The checker passes clean on this repo, and I ran a negative test with a synthetic token in a throwaway repository to confirm it exits `1` and redacts the match rather than echoing it:

```
✗ Credentials found in tracked files:
    leaked.txt:1:token = <REDACTED-TOKEN>
```