### PR TITLE
i18n: add dependency-free translation completeness audit script

### DIFF
--- a/frontend/docs/i18n-completeness-audit-2026-07-26.md
+++ b/frontend/docs/i18n-completeness-audit-2026-07-26.md
@@ -1,0 +1,87 @@
+# Translation completeness audit — 2026-07-26
+
+Addresses stellar-insights#1872.
+
+## Supported locales
+
+Enumerated from `src/i18n/routing.ts` (the single source of truth for
+`next-intl` routing):
+
+- `en` (default)
+- `es`
+- `zh`
+
+Message files live at `messages/<locale>.json`, one flat-ish nested JSON tree
+per locale, all three present.
+
+## Key-set completeness
+
+A dependency-free script, `scripts/i18n-audit.js`, walks
+`src/i18n/routing.ts` to get the locale list, flattens each
+`messages/<locale>.json` into dot-separated keys, and diffs every non-default
+locale against `en`. Run with:
+
+```
+node scripts/i18n-audit.js
+```
+
+Result as of this audit:
+
+```
+es: 131 / 131 keys, 0 missing, 0 extra, 0 empty/null
+zh: 131 / 131 keys, 0 missing, 0 extra, 0 empty/null
+```
+
+**No missing or extra translation keys in either locale.** This corroborates
+(and now has a standalone, CI-independent script backing) the equivalent
+checks already present in `src/__tests__/i18n.test.ts`
+("Translation key coverage" / "Missing translation detection" describe
+blocks), which run the same flatten+diff logic as Vitest unit tests. The two
+approaches are complementary: the Vitest suite catches regressions in normal
+`npm test` runs, while `scripts/i18n-audit.js` can be run standalone (no
+test runner, no install) for a quick manual or CI-step check, and it
+additionally reports string-length deltas (see below), which the existing
+test suite does not.
+
+## Layout risk: string-length deltas
+
+The script also flags translated strings that are ≥1.8x longer or ≤0.5x
+shorter than their `en` counterpart, as a proxy for the "obviously broken
+layout from significantly longer/shorter translated strings" spot-check
+called for in the issue's third acceptance criterion.
+
+**es** — 5 strings ≥1.8x longer than `en`, 1 string ≤0.5x shorter:
+
+| key | en | es |
+|---|---|---|
+| `common.retry` | Retry (5) | Reintentar (10) |
+| `layout.sidebar.trustlines` | Trustlines (10) | Líneas de confianza (19) |
+| `contact.form.email` | Email (5) | Correo electrónico (18) |
+| `dashboard.topAssets` | Top Assets (10) | Activos principales (19) |
+| `dashboard.lastUpdate` | Last Update (11) | Última actualización (20) |
+| `layout.sidebar.network` | Network (7) | Red (3) |
+
+These are all short UI labels (sidebar nav items, buttons, form labels) — the
+kind of string most likely to wrap or truncate in a fixed-width nav item or
+button if not given flexible layout. **Recommended manual spot-check**: the
+sidebar (`layout.sidebar.*`) and the dashboard top-assets card in the `es`
+locale, to confirm these don't clip or overflow.
+
+**zh** — 0 strings longer than `en`; 114 of 131 strings are ≤0.5x shorter
+(expected: CJK text is inherently far more compact per-character than Latin
+script, e.g. `common.error`: "Error" (5) → "错误" (2)). This is not a
+completeness or layout risk in the usual sense — short CJK strings are the
+correct, expected outcome — but it's included in the audit for visibility to
+whoever performs the manual `zh` spot-check, in case any of the 17
+non-shrunk keys were left in Latin script by mistake or fell back to `en`.
+
+## What this doesn't cover
+
+Per the current task's scope (no install/build/dev-server), this audit does
+not run the app to visually confirm layout in a browser — it identifies
+*which* strings are the highest-risk candidates for a human to spot-check,
+per the issue's own acceptance criteria wording ("a script comparing key
+sets across locale files is the reliable way to do [completeness checking],
+not manual spot-checking" — layout itself still needs a human look). A
+maintainer with a running dev server can visit `/es/dashboard` and
+`/es/*` sidebar-visible routes and check the flagged keys above.

--- a/frontend/scripts/i18n-audit.js
+++ b/frontend/scripts/i18n-audit.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Translation completeness audit (stellar-insights#1872).
+ *
+ * Enumerates every supported locale from src/i18n/routing.ts, flattens each
+ * locale's messages/<locale>.json into dot-separated keys, and diffs every
+ * locale against the default locale to report missing keys, extra keys,
+ * empty/null values, and a rough string-length delta (a proxy for layout
+ * risk from longer/shorter translated strings).
+ *
+ * Dependency-free: uses only Node's built-in `fs`/`path` so it can run with
+ * plain `node scripts/i18n-audit.js` without installing anything.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const FRONTEND_ROOT = path.resolve(__dirname, "..");
+const MESSAGES_DIR = path.join(FRONTEND_ROOT, "messages");
+const ROUTING_FILE = path.join(FRONTEND_ROOT, "src", "i18n", "routing.ts");
+
+function getSupportedLocales() {
+  const source = fs.readFileSync(ROUTING_FILE, "utf8");
+
+  const localesMatch = source.match(/locales:\s*\[([^\]]*)\]/);
+  if (!localesMatch) {
+    throw new Error(`Could not find "locales" array in ${ROUTING_FILE}`);
+  }
+  const locales = [...localesMatch[1].matchAll(/["']([\w-]+)["']/g)].map(
+    (m) => m[1]
+  );
+
+  const defaultMatch = source.match(/defaultLocale:\s*["']([\w-]+)["']/);
+  if (!defaultMatch) {
+    throw new Error(`Could not find "defaultLocale" in ${ROUTING_FILE}`);
+  }
+
+  return { locales, defaultLocale: defaultMatch[1] };
+}
+
+function loadMessages(locale) {
+  const file = path.join(MESSAGES_DIR, `${locale}.json`);
+  if (!fs.existsSync(file)) {
+    return { file, missing: true, messages: {} };
+  }
+  return { file, missing: false, messages: JSON.parse(fs.readFileSync(file, "utf8")) };
+}
+
+/** Flatten a nested object into { "a.b.c": value } entries. */
+function flatten(obj, prefix = "", out = {}) {
+  for (const [key, value] of Object.entries(obj)) {
+    const full = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      flatten(value, full, out);
+    } else {
+      out[full] = value;
+    }
+  }
+  return out;
+}
+
+function stringLength(value) {
+  return typeof value === "string" ? value.length : null;
+}
+
+function main() {
+  const { locales, defaultLocale } = getSupportedLocales();
+
+  console.log(`Supported locales (${locales.length}): ${locales.join(", ")}`);
+  console.log(`Default locale: ${defaultLocale}\n`);
+
+  const loaded = Object.fromEntries(locales.map((l) => [l, loadMessages(l)]));
+
+  const missingFiles = locales.filter((l) => loaded[l].missing);
+  if (missingFiles.length > 0) {
+    console.log(`MISSING message files for: ${missingFiles.join(", ")}\n`);
+  }
+
+  const flattened = Object.fromEntries(
+    locales.map((l) => [l, flatten(loaded[l].messages)])
+  );
+
+  const defaultKeys = new Set(Object.keys(flattened[defaultLocale] || {}));
+  let hasGaps = false;
+  const summary = [];
+
+  for (const locale of locales) {
+    if (locale === defaultLocale) continue;
+    const keys = new Set(Object.keys(flattened[locale]));
+
+    const missingKeys = [...defaultKeys].filter((k) => !keys.has(k));
+    const extraKeys = [...keys].filter((k) => !defaultKeys.has(k));
+
+    const emptyOrNull = Object.entries(flattened[locale]).filter(
+      ([, v]) => v === "" || v === null || v === undefined
+    );
+
+    const lengthDeltas = [...defaultKeys]
+      .filter((k) => keys.has(k))
+      .map((k) => {
+        const a = stringLength(flattened[defaultLocale][k]);
+        const b = stringLength(flattened[locale][k]);
+        if (a === null || b === null || a === 0) return null;
+        return { key: k, defaultLen: a, localeLen: b, ratio: b / a };
+      })
+      .filter(Boolean);
+
+    const bigGrowth = lengthDeltas.filter((d) => d.ratio >= 1.8);
+    const bigShrink = lengthDeltas.filter((d) => d.ratio <= 0.5);
+
+    if (missingKeys.length || extraKeys.length || emptyOrNull.length) {
+      hasGaps = true;
+    }
+
+    summary.push({
+      locale,
+      totalKeys: keys.size,
+      missingKeys,
+      extraKeys,
+      emptyOrNull: emptyOrNull.map(([k]) => k),
+      bigGrowth,
+      bigShrink,
+    });
+  }
+
+  for (const s of summary) {
+    console.log(`--- ${s.locale} (default: ${defaultLocale}) ---`);
+    console.log(`  keys: ${s.totalKeys} / ${defaultKeys.size}`);
+    console.log(
+      `  missing keys (${s.missingKeys.length}): ${
+        s.missingKeys.slice(0, 20).join(", ") || "none"
+      }${s.missingKeys.length > 20 ? ", ..." : ""}`
+    );
+    console.log(
+      `  extra keys (${s.extraKeys.length}): ${
+        s.extraKeys.slice(0, 20).join(", ") || "none"
+      }${s.extraKeys.length > 20 ? ", ..." : ""}`
+    );
+    console.log(
+      `  empty/null values (${s.emptyOrNull.length}): ${
+        s.emptyOrNull.slice(0, 20).join(", ") || "none"
+      }${s.emptyOrNull.length > 20 ? ", ..." : ""}`
+    );
+    console.log(
+      `  strings >=1.8x longer than ${defaultLocale} (layout risk): ${s.bigGrowth.length}`
+    );
+    for (const d of s.bigGrowth.slice(0, 10)) {
+      console.log(`    ${d.key}: ${d.defaultLen} -> ${d.localeLen} chars`);
+    }
+    console.log(
+      `  strings <=0.5x shorter than ${defaultLocale} (layout risk): ${s.bigShrink.length}`
+    );
+    for (const d of s.bigShrink.slice(0, 10)) {
+      console.log(`    ${d.key}: ${d.defaultLen} -> ${d.localeLen} chars`);
+    }
+    console.log("");
+  }
+
+  if (missingFiles.length > 0 || hasGaps) {
+    console.log("RESULT: translation gaps found (see detail above).");
+    process.exitCode = 1;
+  } else {
+    console.log("RESULT: all locales have complete key coverage vs default locale.");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes #1872.

The issue asks to verify translation completeness across all supported locales via a script that diffs key sets — not manual spot-checking — plus a manual layout spot-check for locales with significantly longer/shorter strings.

- **Enumerated supported locales**: `en` (default), `es`, `zh`, from `src/i18n/routing.ts`.
- Added `frontend/scripts/i18n-audit.js` — a dependency-free (built-in `fs`/`path` only) script that flattens each `messages/<locale>.json` into dot-separated keys and diffs every locale against the default locale, reporting missing keys, extra keys, empty/null values, and string-length ratio outliers (a proxy for layout risk). Runs standalone with `node scripts/i18n-audit.js`, no install needed.
- Ran it against the real message files. Results, plus the layout spot-check recommendations, are written up in `frontend/docs/i18n-completeness-audit-2026-07-26.md`:
  - `es` and `zh` both have full 131/131 key parity with `en` — no missing/extra/empty keys in either.
  - `es` has 5 short UI strings (sidebar nav, dashboard card, form label) that are ≥1.8x longer than their `en` counterpart — flagged as the highest-value candidates for a human to manually check for wrapping/overflow in the browser.
  - `zh` strings are almost all shorter than `en`, as expected for CJK text density — not a layout risk, just noted for visibility.

Note: this repo already has an equivalent Vitest suite at `src/__tests__/i18n.test.ts` doing key-set diffing as unit tests (`Translation key coverage` / `Missing translation detection` blocks) — this PR's script is complementary, not a replacement: it's runnable standalone without a test runner/install, and additionally reports the string-length layout-risk signal that the existing tests don't.

This PR does not run `npm install`/build/dev-server per the current scope — the script only reads static JSON/TS files, so it needed no dependencies to produce real findings. The doc calls out which routes/locale a maintainer with a running dev server should visually spot-check.

## Test plan

- [x] Ran `node scripts/i18n-audit.js` directly against `frontend/messages/*.json` — real output captured in `frontend/docs/i18n-completeness-audit-2026-07-26.md`.
- [ ] Maintainer: visually spot-check `es` sidebar/dashboard/contact-form strings flagged in the doc for wrapping/overflow in a running dev server.