### PR TITLE
perf: add Lighthouse CI config for dashboard/anchors/network pages

### DIFF
--- a/frontend/docs/lighthouse-audit-2026-07-26.md
+++ b/frontend/docs/lighthouse-audit-2026-07-26.md
@@ -1,0 +1,105 @@
+# Lighthouse / Core Web Vitals audit — 2026-07-26
+
+Addresses stellar-insights#1873.
+
+## What already existed
+
+`.github/workflows/performance-budget.yml` already builds the frontend on
+every PR touching `frontend/**` and runs `scripts/analyze-bundle.mjs`, which
+enforces a 200KB main-bundle budget and a 100KB per-chunk budget across all
+`.next/static/chunks/*.js`. That check is **bundle-size-only** — it has no
+visibility into the three pages called out in this issue individually
+(dashboard, anchors, network graph), and it doesn't measure LCP, CLS, TBT, or
+any other Core Web Vital. It's a real, running check, just not the one this
+issue asks for.
+
+## What was added
+
+- `frontend/lighthouserc.json` — a Lighthouse CI config that:
+  - Boots the production server itself (`startServerCommand: "npm run
+    start"`, waiting for the `next start` "Ready in" log line) — no manual
+    build/start choreography needed.
+  - Runs against the three pages named in the issue's acceptance criteria:
+    `/en/dashboard`, `/en/anchors`, `/en/network` (3 runs each, desktop
+    preset, median taken automatically by `@lhci/cli`).
+  - Asserts on `categories:performance` (warn < 0.8), `categories:accessibility`
+    (error < 0.9), `categories:best-practices` (warn < 0.9), and the
+    Core Web Vitals directly: `largest-contentful-paint` (warn > 2500ms),
+    `cumulative-layout-shift` (warn > 0.1), `total-blocking-time` (warn >
+    300ms), plus `render-blocking-resources` and `unused-javascript` as
+    warn-level hints.
+  - Uploads reports to Lighthouse's temporary public storage so a link to
+    the full trace is available from CI output.
+- `frontend/package.json` — new `audit:lighthouse` script
+  (`next build && npx --yes @lhci/cli@0.15.x autorun`) so this can be run
+  locally or from CI without adding `@lhci/cli` as a persisted
+  `devDependency` (avoids drifting `pnpm-lock.yaml` out of sync with the
+  `pnpm install --frozen-lockfile` step the existing `performance-budget.yml`
+  and other CI workflows rely on — `npx` fetches it on demand instead).
+
+## Why this PR reports no actual Lighthouse scores or bundle numbers
+
+Per this task's current scope, no `npm install`/`pnpm install` or build was
+run to produce this PR. Lighthouse itself requires a real production build
+running on a real server (Chrome-driven page loads, real paint timing) —
+there is no way to fabricate honest LCP/CLS/TBT numbers without executing
+that build, and this audit intentionally does not report fake or guessed
+numbers. Real numbers require one of:
+
+1. A maintainer running `npm run audit:lighthouse` locally, or
+2. The GitHub Actions job below, added to CI (could not be pushed directly
+   in this PR — GitHub rejects pushes to `.github/workflows/**` from this
+   token because it lacks the `workflow` OAuth scope; paste the YAML below
+   into a new file at `.github/workflows/lighthouse-ci.yml` to enable it):
+
+```yaml
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'frontend/**'
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Lighthouse CI
+        run: npm run audit:lighthouse
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-reports-${{ github.sha }}
+          path: frontend/.lighthouseci/
+          retention-days: 14
+```
+
+Once that workflow runs for the first time, its output will supply the
+per-page LCP/CLS/TBT numbers and the largest-chunk-per-page breakdown this
+issue's acceptance criteria ask for; any audit that scores below the
+thresholds in `lighthouserc.json` should get its own follow-up issue rather
+than being fixed inline here, per the issue's own instruction.

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -1,0 +1,33 @@
+{
+  "ci": {
+    "collect": {
+      "startServerCommand": "npm run start",
+      "startServerReadyPattern": "Ready in",
+      "startServerReadyTimeout": 30000,
+      "url": [
+        "http://localhost:3000/en/dashboard",
+        "http://localhost:3000/en/anchors",
+        "http://localhost:3000/en/network"
+      ],
+      "numberOfRuns": 3,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 2500 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 300 }],
+        "render-blocking-resources": "warn",
+        "unused-javascript": "warn"
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "benchmark:save-baseline": "SAVE_BASELINE=true node benchmarks/api.bench.mjs",
     "test:benchmarks": "node --test benchmarks/api.bench.test.mjs",
     "test:i18n": "vitest run src/__tests__/i18n.test.ts",
-    "i18n:coverage": "vitest run src/__tests__/i18n.test.ts --reporter=verbose"
+    "i18n:coverage": "vitest run src/__tests__/i18n.test.ts --reporter=verbose",
+    "audit:lighthouse": "next build && npx --yes @lhci/cli@0.15.x autorun"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",


### PR DESCRIPTION
## Summary

Closes #1873.

The issue asks for a Lighthouse/Core Web Vitals pass against the dashboard, anchors, and network graph pages (the app's chart- and data-fetch-heavy pages), noting bundle size for the largest pages/chunks, and filing follow-ups for anything scoring poorly rather than fixing inline.

**What already existed**: `.github/workflows/performance-budget.yml` builds the app and runs `scripts/analyze-bundle.mjs` on every PR touching `frontend/**` — but that's a bundle-size-only budget check (200KB main bundle / 100KB per chunk across all chunks combined). It has no per-page breakdown and doesn't measure LCP/CLS/TBT at all.

**What this PR adds**:
- `frontend/lighthouserc.json` — Lighthouse CI config that boots `next start` itself and runs against `/en/dashboard`, `/en/anchors`, `/en/network` (3 runs each, desktop preset), asserting on performance/accessibility/best-practices category scores plus the Core Web Vitals directly (LCP, CLS, TBT) and render-blocking-resources/unused-javascript hints.
- `frontend/package.json` — new `audit:lighthouse` script (`next build && npx --yes @lhci/cli@0.15.x autorun`). Deliberately uses `npx` rather than a persisted devDependency so it doesn't drift `pnpm-lock.yaml` out of sync with the `pnpm install --frozen-lockfile` step other CI workflows depend on.
- `frontend/docs/lighthouse-audit-2026-07-26.md` — write-up of the above, plus the full YAML for a `lighthouse-ci.yml` GitHub Actions workflow to wire this into CI on `frontend/**` PRs. That workflow file could **not** be pushed directly in this PR — this token lacks the `workflow` OAuth scope required to create/update files under `.github/workflows/`. A maintainer with that scope can paste the YAML from the doc into a new file to enable it.

**Why no actual Lighthouse scores/bundle numbers are reported here**: per the current task scope, no install or build was run to produce this PR, and Lighthouse needs a real production server + real Chrome page loads to produce honest LCP/CLS/TBT numbers — there's no way to fabricate those credibly, so this PR ships the tooling rather than invented data. Once the config or workflow runs for real (locally via `npm run audit:lighthouse`, or via the CI workflow once added), its output will supply the real per-page numbers; anything scoring below the thresholds in `lighthouserc.json` should get its own follow-up issue rather than being fixed inline, per the issue's own instructions.

## Test plan

- [ ] Maintainer: `cd frontend && npm run audit:lighthouse` locally to get real scores, or add the CI workflow from the doc.
- [ ] File follow-up issues for any category/audit that fails the thresholds in `lighthouserc.json`.