### PR TITLE
a11y: add automated axe-core route scan via root Playwright setup

### DIFF
--- a/frontend/docs/a11y-scan-2026-07-26.md
+++ b/frontend/docs/a11y-scan-2026-07-26.md
@@ -1,0 +1,120 @@
+# Automated accessibility scan — 2026-07-26
+
+Addresses stellar-insights#1871.
+
+## What already existed
+
+- ESLint's `jsx-a11y` plugin (`frontend` `lint:a11y` script) — static analysis
+  only, catches things like missing `alt` text or invalid ARIA attribute
+  values at parse time.
+- `frontend/src/components/__tests__/accessibility.a11y.test.tsx` — `jest-axe`
+  run against individually-rendered components in jsdom, wired into CI via
+  `.github/workflows/accessibility.yml`.
+
+Neither of these renders a full, real page in a real browser. jsdom doesn't
+paint anything, so `jest-axe` in that context can't catch color-contrast
+violations, and testing components in isolation can't catch focus-order,
+landmark-structure, or heading-hierarchy issues that only exist at the
+full-page level — exactly the gap this issue calls out. Also worth noting:
+`.github/workflows/accessibility.yml`'s test-run step passes
+`src/__tests__/a11y` as an extra vitest path filter, but that directory
+doesn't exist in this repo — it's a harmless no-op (vitest still runs the
+one real spec file passed alongside it) but suggests a full route-level a11y
+suite was intended and never landed here.
+
+Separately, there is a **root-level** `playwright.config.ts` (`testDir:
+./tests/acceptance`) with its own `package.json` (`test:acceptance: "playwright
+test"`) — this is the "existing Playwright setup" the issue references. It
+currently has no CI workflow running it at all.
+
+## What this PR adds
+
+- `tests/acceptance/a11y.test.ts` — a new Playwright spec, picked up
+  automatically by the existing root `playwright.config.ts`, that uses
+  `@axe-core/playwright` to scan **every static route** in the app (30
+  localized routes under `/en/...`, 8 non-localized routes) against the
+  `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa` rule tags. Dynamic-segment
+  routes (`anchors/[address]`, `corridors/[pair]`, `governance/[id]`) are
+  intentionally excluded for now — they need seeded fixture data to render
+  real content instead of a not-found/error state, which is a natural
+  follow-up rather than something to fake here.
+- `package.json` (root) — added `@axe-core/playwright` as a devDependency.
+- Findings are **triaged by severity** per the issue's second acceptance
+  criterion: violations of `critical`/`serious` impact fail the test
+  (`expect(blocking).toEqual([])`); `minor`/`moderate` findings are logged
+  to the console (visible in the Playwright HTML report / CI log) but don't
+  fail the build, since those are typically judgment calls or low-priority
+  polish rather than a blocker — they should get filed as follow-up issues
+  once the scan actually runs and produces real findings, rather than being
+  guessed at here.
+
+## Why this PR doesn't report actual violations found
+
+No install or build was run for this change (out of scope for this task —
+scanning real pages with real axe-core requires `npm i`/`pnpm i`,
+`playwright install --with-deps chromium`, a running `next dev`/`next
+start`, and a live browser session, none of which happened here). Rather
+than guess at what a real scan would find, this PR ships the real,
+runnable scan; a maintainer or CI running it will get real findings.
+
+## CI wiring
+
+Could not push a new/updated file under `.github/workflows/**` directly in
+this PR — this token lacks the `workflow` OAuth scope GitHub requires for
+that. A maintainer with that scope should add the following as
+`.github/workflows/a11y-route-scan.yml` (or as an extra job appended to the
+existing `.github/workflows/accessibility.yml`) to satisfy the issue's third
+acceptance criterion ("Add this as a CI check going forward"):
+
+```yaml
+name: Accessibility Route Scan
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+
+jobs:
+  axe-route-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install root tooling (Playwright + axe-core)
+        run: npm install
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build and start the app
+        working-directory: frontend
+        run: |
+          pnpm build
+          pnpm start &
+          npx wait-on http://localhost:3000
+
+      - name: Run axe-core route scan
+        run: npm run test:acceptance -- a11y.test.ts
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-route-scan-report
+          path: playwright-report/
+          retention-days: 14
+```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check:folder-size": "bash scripts/check_folder_size.sh"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.1",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@playwright/test": "^1.48.0"

--- a/tests/acceptance/a11y.test.ts
+++ b/tests/acceptance/a11y.test.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * Automated accessibility scan (stellar-insights#1871).
+ *
+ * Static jsdom-rendered component tests (frontend/src/components/__tests__/accessibility.a11y.test.tsx)
+ * and ESLint's jsx-a11y plugin only catch a fraction of real accessibility issues — they never
+ * render real CSS (no color-contrast checking), never lay out a full page (no landmark/heading
+ * structure or focus-order checking), and don't exercise live-region announcements for dynamic
+ * content. This suite runs axe-core against every real route in a real browser via the existing
+ * root Playwright setup (playwright.config.ts), which is the setup this issue calls for.
+ *
+ * Routes are every static (non-dynamic-segment) page under src/app, scanned in the default
+ * locale (`en`). Dynamic-segment routes (anchors/[address], corridors/[pair], governance/[id])
+ * are intentionally excluded — they need a real, valid identifier to render meaningful content
+ * rather than a not-found/error state, so scanning them requires seeding fixture data first;
+ * that's a natural follow-up once this baseline is in CI.
+ */
+
+const LOCALE = 'en';
+
+const LOCALIZED_ROUTES = [
+  '',
+  'about',
+  'analytics',
+  'analytics/api',
+  'analytics/export',
+  'anchors',
+  'calculator',
+  'contact',
+  'corridors',
+  'corridors/compare',
+  'dashboard',
+  'deposit-withdraw',
+  'developer/keys',
+  'governance',
+  'health',
+  'how-to-use',
+  'internal/monitoring',
+  'liquidity',
+  'liquidity-pools',
+  'network',
+  'notifications',
+  'performance',
+  'prediction',
+  'quests',
+  'send-payment',
+  'sep10-demo',
+  'sep6',
+  'settings',
+  'transactions/builder',
+  'trustlines',
+].map((route) => `/${LOCALE}${route ? `/${route}` : ''}`);
+
+const UNLOCALIZED_ROUTES = [
+  '/alerts',
+  '/api-docs',
+  '/api-docs/examples',
+  '/api-docs/playground',
+  '/components/time-range',
+  '/demo/notifications',
+  '/offline',
+  '/settings/gdpr',
+];
+
+const ROUTES = [...LOCALIZED_ROUTES, ...UNLOCALIZED_ROUTES];
+
+// Impact levels that fail the build outright. "minor"/"moderate" findings are reported but
+// don't fail CI — see the triage note in frontend/docs/a11y-scan-2026-07-26.md.
+const BLOCKING_IMPACTS = ['critical', 'serious'];
+
+for (const route of ROUTES) {
+  test(`axe-core scan: ${route}`, async ({ page }) => {
+    await page.goto(route);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    const blocking = results.violations.filter((v) =>
+      BLOCKING_IMPACTS.includes(v.impact ?? 'minor')
+    );
+
+    if (results.violations.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[a11y] ${route}: ${results.violations.length} violation(s) — ` +
+          results.violations
+            .map((v) => `${v.id} (${v.impact}, ${v.nodes.length} node(s))`)
+            .join(', ')
+      );
+    }
+
+    expect(
+      blocking,
+      `${route} has ${blocking.length} critical/serious axe violation(s): ` +
+        blocking.map((v) => `${v.id}: ${v.help}`).join('; ')
+    ).toEqual([]);
+  });
+}


### PR DESCRIPTION
## Summary

Closes #1871.

The issue asks to wire up axe-core (or equivalent) against every route via the existing Playwright setup, triage findings by severity with follow-ups filed for anything non-trivial, and add this as a CI check going forward.

**What already existed**:
- `jsx-a11y` ESLint plugin — static analysis only.
- `frontend/src/components/__tests__/accessibility.a11y.test.tsx` — `jest-axe` against individually-rendered components in jsdom, wired into `.github/workflows/accessibility.yml`.

Neither renders a full real page in a real browser, so neither can catch color contrast, focus order, or landmark/heading structure at the page level — the exact gap called out in the issue body. (Side note found while investigating: that workflow's test step also passes `src/__tests__/a11y` as a vitest path filter, but that directory doesn't exist in this repo — harmless no-op today, but a sign a broader a11y suite was planned and never landed.)

There's also a **root-level** `playwright.config.ts` + `package.json` (`test:acceptance: "playwright test"`, `testDir: ./tests/acceptance`) — the "existing Playwright setup" this issue points at — with no CI workflow currently running it at all.

**What this PR adds**:
- `tests/acceptance/a11y.test.ts` — new Playwright spec (auto-picked-up by the existing root config) that scans every static route with `@axe-core/playwright` against `wcag2a`/`wcag2aa`/`wcag21a`/`wcag21aa`: 30 localized routes (`/en/...`) + 8 non-localized routes. Dynamic-segment routes (`anchors/[address]`, `corridors/[pair]`, `governance/[id]`) are excluded until there's fixture data to render real content there instead of a not-found/error state.
- `package.json` (root) — added `@axe-core/playwright` devDependency.
- **Severity triage**: `critical`/`serious` violations fail the test; `minor`/`moderate` are logged (visible in the Playwright report/CI log) rather than failing the build, per the issue's ask to triage by severity and only file follow-ups for non-trivial findings.
- `frontend/docs/a11y-scan-2026-07-26.md` — write-up of the above, plus the full CI workflow YAML needed to wire this into GitHub Actions.

**Why no violations are reported here**: no install/browser/build was run for this change, so there's no real scan output to report — this PR ships the real, runnable scan rather than a guessed findings list. The CI workflow YAML (in the doc, below) could not be pushed directly — this token lacks the `workflow` OAuth scope required for `.github/workflows/**`. A maintainer should add it to get real findings and satisfy the "CI check going forward" criterion.

```yaml
name: Accessibility Route Scan

on:
  push:
    branches: [main, develop]
  pull_request:

jobs:
  axe-route-scan:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: 20
          cache: npm
      - name: Install root tooling (Playwright + axe-core)
        run: npm install
      - uses: pnpm/action-setup@v4
        with:
          version: 10
      - name: Install frontend dependencies
        working-directory: frontend
        run: pnpm install --frozen-lockfile
      - name: Install Playwright browsers
        run: npx playwright install --with-deps chromium
      - name: Build and start the app
        working-directory: frontend
        run: |
          pnpm build
          pnpm start &
          npx wait-on http://localhost:3000
      - name: Run axe-core route scan
        run: npm run test:acceptance -- a11y.test.ts
      - name: Upload Playwright report
        if: always()
        uses: actions/upload-artifact@v4
        with:
          name: a11y-route-scan-report
          path: playwright-report/
          retention-days: 14
```

## Test plan

- [ ] Maintainer: `npm install && npx playwright install --with-deps chromium`, build+start the frontend, then `npm run test:acceptance -- a11y.test.ts` to get real findings.
- [ ] File follow-up issues for any critical/serious violations found; minor/moderate are logged but non-blocking.
- [ ] Add the workflow YAML above to enable this as an ongoing CI check.