### PR TITLE
fix: unused import, always-true assertion, legacy feature flag, deploy docs (#1843 #1842 #1834 #1833)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -31,7 +31,6 @@ expect_used = "allow"
 panic = "allow"
 
 [features]
-legacy_sep10_tests = []
 sep-integration = []
 testnet-smoke = []
 

--- a/backend/src/api/analytics_dashboard.rs
+++ b/backend/src/api/analytics_dashboard.rs
@@ -2,7 +2,7 @@ use axum::{extract::State, routing::get, Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::cache::helpers::cached_query;
-use crate::cache::{keys, CacheManager};
+use crate::cache::keys;
 use crate::state::AppState;
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/backend/src/middleware/network_status_endpoint.rs
+++ b/backend/src/middleware/network_status_endpoint.rs
@@ -89,7 +89,7 @@ mod tests {
 
         let status = result.unwrap();
         assert!(status.operational);
-        assert!(status.latency_ms >= 0);
+        assert!(status.latency_ms <= 10_000, "latency sanity check: {}ms exceeds 10s", status.latency_ms);
     }
 
     #[tokio::test]

--- a/docs/TESTNET_SMOKE_DEPLOYMENT.md
+++ b/docs/TESTNET_SMOKE_DEPLOYMENT.md
@@ -1,0 +1,49 @@
+# Testnet Smoke Test Deployment Guide
+
+## Issue #1843: Get a Live Backend Instance for Testnet-Smoke Tests
+
+### Prerequisites
+
+The `testnet-smoke` test suite (`backend/tests/testnet/smoke_test.rs`) requires
+a live, deployed backend instance to exercise real HTTP and WebSocket endpoints.
+
+### Required Environment Variables
+
+| Variable | Description | Where to Set |
+|----------|-------------|--------------|
+| `TESTNET_API_URL` | Base URL of the deployed testnet backend | CI secrets or local env |
+| `TESTNET_API_KEY` | API key for authenticated endpoints | CI secrets or local env |
+
+### Deployment Path
+
+1. **Deploy via CI**: The `deploy-testnet.yml` workflow handles ECR push and
+   K8s deployment. Ensure the pre-flight validation passes (see #1844).
+
+2. **Verify the deployment**: Once deployed, the backend URL is available
+   as the `TESTNET_BACKEND_URL` repository variable.
+
+3. **Run the smoke tests**:
+   ```bash
+   cd backend
+   export TESTNET_API_URL="https://testnet.stellar-insights.example.com"
+   export TESTNET_API_KEY="your-api-key"
+   cargo test --features testnet-smoke --test testnet_smoke
+   ```
+
+4. **In CI**: The `deploy-testnet.yml` workflow already runs the smoke tests
+   as a post-deployment step with the required env vars configured.
+
+### First Run Expectations
+
+This suite has never been exercised against a live instance. Treat a
+first-run failure as expected/likely — fix issues as they surface rather
+than treating them as regressions.
+
+### Test Coverage
+
+The smoke tests exercise:
+- Health endpoint (`/health`)
+- Authentication (`/api/v1/auth`)
+- Transaction endpoints (`/api/v1/transactions`)
+- Analytics endpoints (`/api/v1/analytics`)
+- WebSocket connections


### PR DESCRIPTION
## Summary

Fixes four issues assigned to @faith3310:

### #1834: Remove unused import CacheManager in analytics_dashboard.rs
- Confirmed: `CacheManager` has no remaining usage (`keys` is still used)
- Changed `use crate::cache::{keys, CacheManager}` to `use crate::cache::keys`

### #1833: Fix `status.latency_ms >= 0` always-true comparison
- `latency_ms` is `u64` (unsigned) — `>= 0` is always true
- Replaced with meaningful upper-bound: `assert!(status.latency_ms <= 10_000, ...)`

### #1842: Remove legacy_sep10_tests feature flag
- Removed `legacy_sep10_tests = []` from `backend/Cargo.toml` `[features]`
- The gated tests reference crates that no longer exist in the repo

### #1843: Document testnet-smoke deployment requirements
- Created `docs/TESTNET_SMOKE_DEPLOYMENT.md` with prerequisites, env vars,
  deployment path, and first-run expectations

Closes #1843, closes #1842, closes #1834, closes #1833