### PR TITLE
fix(prediction): surface mock-data fallback to the user

### DIFF
--- a/frontend/src/components/prediction/prediction-form.tsx
+++ b/frontend/src/components/prediction/prediction-form.tsx
@@ -489,6 +489,15 @@ const PredictionForm = () => {
                   exit={{ opacity: 0 }}
                   className="space-y-6"
                 >
+                  {/* Mock data notice */}
+                  {prediction.is_mock && (
+                    <div className="flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs text-amber-400">
+                      <AlertTriangle className="h-4 w-4 shrink-0" />
+                      <span>
+                        Backend unavailable — showing locally generated estimates. Connect to a real backend for live predictions.
+                      </span>
+                    </div>
+                  )}
                   {/* Success Gauge */}
                   <SuccessGauge
                     probability={prediction.success_probability}

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -222,6 +222,7 @@ function generateMockPrediction(
     recommendation: recommendations[riskLevel],
     alternative_routes: alternativeRoutes,
     model_version: "1.0.0",
+    is_mock: true,
   };
 }
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -37,6 +37,8 @@ export interface PredictionResponse {
   recommendation: string;
   alternative_routes: AlternativeRoute[];
   model_version: string;
+  /** True when the backend was unreachable and the result is locally generated. */
+  is_mock?: boolean;
 }
 
 // =========================


### PR DESCRIPTION
## Summary

The prediction page was silently falling back to locally generated estimates when the backend was unreachable, with no indication shown to the user. This adds an `is_mock` flag to `PredictionResponse`, sets it in `generateMockPrediction`, and renders an amber warning banner in the results panel when the flag is true — so users always know whether they are looking at live model output or local heuristics.

## Changes

- `frontend/src/lib/api/types.ts` — added optional `is_mock?: boolean` to `PredictionResponse`
- `frontend/src/lib/api/api.ts` — set `is_mock: true` in the mock return value
- `frontend/src/components/prediction/prediction-form.tsx` — render mock-data notice banner

## Validation

- `npm run lint` — passes
- No unrelated files modified

Closes #1823