### PR TITLE
fix(quests): update progress state after path completion so UI stays in sync

### DIFF
--- a/frontend/src/app/[locale]/quests/page.tsx
+++ b/frontend/src/app/[locale]/quests/page.tsx
@@ -10,9 +10,6 @@ import {
   QUESTS,
   ACHIEVEMENTS,
   getProgress,
-  getTotalXP,
-  getCompletedCount,
-  getUnlockedAchievements,
   getLeaderboard,
   checkPathCompletion,
 } from '@/lib/quests';
@@ -20,16 +17,29 @@ import {
 export default function QuestsPage() {
   const pathname = usePathname();
   const [showLeaderboard, setShowLeaderboard] = useState(true);
+  const [progress, setProgress] = useState<ReturnType<typeof getProgress>>(getProgress);
 
   useEffect(() => {
     checkPathCompletion(pathname);
+    setProgress(getProgress());
   }, [pathname]);
 
-  const progress = getProgress();
-
-  const completedCount = getCompletedCount();
-  const totalXP = getTotalXP();
-  const achievements = getUnlockedAchievements();
+  const completedCount = progress.length;
+  const totalXP = progress.reduce((sum, p) => {
+    const q = QUESTS.find((x) => x.id === p.questId);
+    return sum + (q?.xp ?? 0);
+  }, 0);
+  const achievements = ACHIEVEMENTS.filter((a) => {
+    if (a.condition === 'quests') return completedCount >= a.threshold;
+    if (a.condition === 'explorer') {
+      const defiQuests = QUESTS.filter((q) => q.category === 'defi');
+      const defiCompleted = progress.filter((p) =>
+        defiQuests.some((q) => q.id === p.questId),
+      ).length;
+      return defiCompleted >= a.threshold;
+    }
+    return false;
+  });
   const leaderboard = getLeaderboard();
 
   return (


### PR DESCRIPTION
## Summary

The quests page called `checkPathCompletion(pathname)` in a `useEffect` (which writes to `localStorage`) but derived `completedCount`, `totalXP`, and `achievements` at render time by reading from `localStorage` directly — before the effect had a chance to run. This meant a newly completed quest never appeared until a full page reload.

Fix: hold `progress` in React state (lazy-initialised from `localStorage` on mount), call `setProgress(getProgress())` immediately after `checkPathCompletion` fires, and derive all display values from that state so the UI re-renders correctly on completion.

## Changes

- `frontend/src/app/[locale]/quests/page.tsx` — lazy `useState` for progress, reactive derivations, cleaned up now-unused imports

## Validation

- `npm run lint` — passes
- No unrelated files modified

Closes #1824