### PR TITLE
fix(docs): implement API docs portal and wire playground to live backend (#1826)

### DIFF
--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -1,0 +1,819 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Stellar Insights API",
+    "description": "API for Stellar network analytics, anchor monitoring, and payment corridor insights",
+    "contact": {
+      "name": "Stellar Insights Team",
+      "email": "support@stellarinsights.io"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Local development server"
+    },
+    {
+      "url": "https://api.stellarinsights.io",
+      "description": "Production server"
+    }
+  ],
+  "paths": {
+    "/api/anchors": {
+      "get": {
+        "tags": ["Anchors"],
+        "summary": "List anchors",
+        "operationId": "get_anchors",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of anchors",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnchorsResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/anchors/{anchor_id}": {
+      "get": {
+        "tags": ["Anchors"],
+        "summary": "Get anchor by ID",
+        "operationId": "get_anchor",
+        "parameters": [
+          {
+            "name": "anchor_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Anchor details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnchorMetricsResponse" }
+              }
+            }
+          },
+          "404": { "description": "Anchor not found" }
+        }
+      }
+    },
+    "/api/anchors/account/{account_id}": {
+      "get": {
+        "tags": ["Anchors"],
+        "summary": "Get anchor by Stellar account ID",
+        "operationId": "get_anchor_by_account",
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Anchor details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnchorMetricsResponse" }
+              }
+            }
+          },
+          "404": { "description": "Anchor not found" }
+        }
+      }
+    },
+    "/api/corridors": {
+      "get": {
+        "tags": ["Corridors"],
+        "summary": "List payment corridors",
+        "operationId": "list_corridors",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of corridors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CorridorResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/corridors/{corridor_id}": {
+      "get": {
+        "tags": ["Corridors"],
+        "summary": "Get corridor detail",
+        "operationId": "get_corridor_detail",
+        "parameters": [
+          {
+            "name": "corridor_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Corridor details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CorridorDetailResponse" }
+              }
+            }
+          },
+          "404": { "description": "Corridor not found" }
+        }
+      }
+    },
+    "/api/price/{asset}": {
+      "get": {
+        "tags": ["Prices"],
+        "summary": "Get price for a single asset",
+        "operationId": "get_price",
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset price",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PriceResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prices": {
+      "get": {
+        "tags": ["Prices"],
+        "summary": "Get prices for multiple assets",
+        "operationId": "get_prices",
+        "parameters": [
+          {
+            "name": "assets",
+            "in": "query",
+            "schema": { "type": "string", "description": "Comma-separated asset codes" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset prices",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PricesResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/cost/estimate": {
+      "post": {
+        "tags": ["Cost Calculator"],
+        "summary": "Estimate cross-border payment costs",
+        "operationId": "estimate_costs",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CostCalculationRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cost estimation result",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CostCalculationResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/alerts/rules": {
+      "get": {
+        "tags": ["Alerts"],
+        "summary": "List alert rules",
+        "operationId": "list_rules",
+        "responses": {
+          "200": { "description": "List of alert rules" }
+        }
+      },
+      "post": {
+        "tags": ["Alerts"],
+        "summary": "Create an alert rule",
+        "operationId": "create_rule",
+        "responses": {
+          "201": { "description": "Alert rule created" }
+        }
+      }
+    },
+    "/api/alerts/rules/{rule_id}": {
+      "put": {
+        "tags": ["Alerts"],
+        "summary": "Update an alert rule",
+        "operationId": "update_rule",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Alert rule updated" }
+        }
+      },
+      "delete": {
+        "tags": ["Alerts"],
+        "summary": "Delete an alert rule",
+        "operationId": "delete_rule",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Alert rule deleted" }
+        }
+      }
+    },
+    "/api/alerts/history": {
+      "get": {
+        "tags": ["Alerts"],
+        "summary": "List alert history",
+        "operationId": "list_history",
+        "responses": {
+          "200": { "description": "Alert history" }
+        }
+      }
+    },
+    "/api/transactions": {
+      "post": {
+        "tags": ["Transactions"],
+        "summary": "Create a transaction",
+        "operationId": "create_transaction",
+        "responses": {
+          "200": { "description": "Transaction created" }
+        }
+      }
+    },
+    "/api/transactions/{transaction_id}": {
+      "get": {
+        "tags": ["Transactions"],
+        "summary": "Get transaction by ID",
+        "operationId": "get_transaction",
+        "parameters": [
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Transaction details" },
+          "404": { "description": "Transaction not found" }
+        }
+      }
+    },
+    "/api/metrics": {
+      "get": {
+        "tags": ["Metrics"],
+        "summary": "Get system metrics overview",
+        "operationId": "metrics_overview",
+        "responses": {
+          "200": { "description": "Metrics overview" }
+        }
+      }
+    },
+    "/api/network": {
+      "get": {
+        "tags": ["Network"],
+        "summary": "Get network info",
+        "operationId": "get_network_info",
+        "responses": {
+          "200": { "description": "Network information" }
+        }
+      }
+    },
+    "/api/rpc/health": {
+      "get": {
+        "tags": ["RPC"],
+        "summary": "RPC health check",
+        "operationId": "rpc_health_check",
+        "responses": {
+          "200": { "description": "RPC is healthy" }
+        }
+      }
+    },
+    "/api/rpc/ledger/latest": {
+      "get": {
+        "tags": ["RPC"],
+        "summary": "Get latest ledger",
+        "operationId": "get_latest_ledger",
+        "responses": {
+          "200": { "description": "Latest ledger info" }
+        }
+      }
+    },
+    "/api/rpc/payments": {
+      "get": {
+        "tags": ["RPC"],
+        "summary": "Get payments",
+        "operationId": "get_payments",
+        "responses": {
+          "200": { "description": "Payment list" }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Login",
+        "operationId": "login",
+        "responses": {
+          "200": { "description": "Authentication token" }
+        }
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Refresh token",
+        "operationId": "refresh",
+        "responses": {
+          "200": { "description": "Refreshed token" }
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Logout",
+        "operationId": "logout",
+        "responses": {
+          "204": { "description": "Logged out" }
+        }
+      }
+    },
+    "/api/webhooks": {
+      "get": {
+        "tags": ["Webhooks"],
+        "summary": "List webhooks",
+        "operationId": "list_webhooks",
+        "responses": {
+          "200": { "description": "Webhook list" }
+        }
+      },
+      "post": {
+        "tags": ["Webhooks"],
+        "summary": "Register a webhook",
+        "operationId": "register_webhook",
+        "responses": {
+          "201": { "description": "Webhook registered" }
+        }
+      }
+    },
+    "/api/webhooks/{webhook_id}": {
+      "get": {
+        "tags": ["Webhooks"],
+        "summary": "Get webhook",
+        "operationId": "get_webhook",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Webhook details" }
+        }
+      },
+      "delete": {
+        "tags": ["Webhooks"],
+        "summary": "Delete webhook",
+        "operationId": "delete_webhook",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Webhook deleted" }
+        }
+      }
+    },
+    "/api/governance/proposals": {
+      "get": {
+        "tags": ["Governance"],
+        "summary": "List governance proposals",
+        "operationId": "list_proposals",
+        "responses": {
+          "200": { "description": "Proposals list" }
+        }
+      },
+      "post": {
+        "tags": ["Governance"],
+        "summary": "Create governance proposal",
+        "operationId": "create_proposal",
+        "responses": {
+          "201": { "description": "Proposal created" }
+        }
+      }
+    },
+    "/api/sep10/info": {
+      "get": {
+        "tags": ["SEP-10"],
+        "summary": "SEP-10 info",
+        "operationId": "sep10_get_info",
+        "responses": {
+          "200": { "description": "SEP-10 server info" }
+        }
+      }
+    },
+    "/api/sep10/challenge": {
+      "get": {
+        "tags": ["SEP-10"],
+        "summary": "Request SEP-10 challenge",
+        "operationId": "request_challenge",
+        "responses": {
+          "200": { "description": "Challenge transaction" }
+        }
+      }
+    },
+    "/api/liquidity-pools": {
+      "get": {
+        "tags": ["Liquidity Pools"],
+        "summary": "List liquidity pools",
+        "operationId": "list_pools",
+        "responses": {
+          "200": { "description": "Liquidity pool list" }
+        }
+      }
+    },
+    "/api/api-keys": {
+      "get": {
+        "tags": ["API Keys"],
+        "summary": "List API keys",
+        "operationId": "list_api_keys",
+        "responses": {
+          "200": { "description": "API key list" }
+        }
+      },
+      "post": {
+        "tags": ["API Keys"],
+        "summary": "Create API key",
+        "operationId": "create_api_key",
+        "responses": {
+          "201": { "description": "API key created" }
+        }
+      }
+    },
+    "/api/assets/verify": {
+      "post": {
+        "tags": ["Asset Verification"],
+        "summary": "Verify an asset",
+        "operationId": "verify_asset",
+        "responses": {
+          "200": { "description": "Verification result" }
+        }
+      }
+    },
+    "/api/assets/verified": {
+      "get": {
+        "tags": ["Asset Verification"],
+        "summary": "List verified assets",
+        "operationId": "list_verified_assets",
+        "responses": {
+          "200": { "description": "Verified asset list" }
+        }
+      }
+    },
+    "/api/ml/predict": {
+      "post": {
+        "tags": ["ML"],
+        "summary": "Predict payment success",
+        "operationId": "predict_payment_success",
+        "responses": {
+          "200": { "description": "Prediction result" }
+        }
+      }
+    },
+    "/api/ml/status": {
+      "get": {
+        "tags": ["ML"],
+        "summary": "Get ML model status",
+        "operationId": "get_model_status",
+        "responses": {
+          "200": { "description": "Model status" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AnchorsResponse": {
+        "type": "object",
+        "properties": {
+          "anchors": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AnchorMetricsResponse" }
+          },
+          "total": { "type": "integer" }
+        }
+      },
+      "AnchorMetricsResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "home_domain": { "type": "string" },
+          "account_id": { "type": "string" },
+          "success_rate": { "type": "number", "format": "double" },
+          "total_transactions": { "type": "integer", "format": "int64" },
+          "volume_usd": { "type": "number", "format": "double" },
+          "avg_latency_ms": { "type": "number", "format": "double" }
+        }
+      },
+      "CorridorResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" },
+          "success_rate": { "type": "number", "format": "double" },
+          "volume_usd": { "type": "number", "format": "double" },
+          "avg_latency_ms": { "type": "number", "format": "double" }
+        }
+      },
+      "CorridorDetailResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" },
+          "success_rate": { "type": "number", "format": "double" },
+          "volume_usd": { "type": "number", "format": "double" },
+          "avg_latency_ms": { "type": "number", "format": "double" },
+          "success_rate_history": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/SuccessRateDataPoint" }
+          },
+          "latency_history": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/LatencyDataPoint" }
+          },
+          "liquidity_history": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/LiquidityDataPoint" }
+          }
+        }
+      },
+      "SuccessRateDataPoint": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "value": { "type": "number", "format": "double" }
+        }
+      },
+      "LatencyDataPoint": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "value_ms": { "type": "number", "format": "double" }
+        }
+      },
+      "LiquidityDataPoint": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "value_usd": { "type": "number", "format": "double" }
+        }
+      },
+      "PriceResponse": {
+        "type": "object",
+        "properties": {
+          "asset": { "type": "string" },
+          "price_usd": { "type": "number", "format": "double" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "PricesResponse": {
+        "type": "object",
+        "properties": {
+          "prices": {
+            "type": "object",
+            "additionalProperties": { "type": "number", "format": "double" }
+          },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "ConvertResponse": {
+        "type": "object",
+        "properties": {
+          "from_asset": { "type": "string" },
+          "from_amount": { "type": "number", "format": "double" },
+          "usd_amount": { "type": "number", "format": "double" }
+        }
+      },
+      "CacheStatsResponse": {
+        "type": "object",
+        "properties": {
+          "hits": { "type": "integer", "format": "int64" },
+          "misses": { "type": "integer", "format": "int64" },
+          "hit_rate": { "type": "number", "format": "double" }
+        }
+      },
+      "PaymentRoute": {
+        "type": "object",
+        "properties": {
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" },
+          "anchor_id": { "type": "string" }
+        }
+      },
+      "CostCalculationRequest": {
+        "type": "object",
+        "required": ["amount_usd", "source_asset", "destination_asset"],
+        "properties": {
+          "amount_usd": { "type": "number", "format": "double" },
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" }
+        }
+      },
+      "RouteCostBreakdown": {
+        "type": "object",
+        "properties": {
+          "anchor_fee_usd": { "type": "number", "format": "double" },
+          "network_fee_xlm": { "type": "number", "format": "double" },
+          "network_fee_usd": { "type": "number", "format": "double" },
+          "spread_usd": { "type": "number", "format": "double" },
+          "total_cost_usd": { "type": "number", "format": "double" }
+        }
+      },
+      "RouteEstimate": {
+        "type": "object",
+        "properties": {
+          "route": { "$ref": "#/components/schemas/PaymentRoute" },
+          "cost": { "$ref": "#/components/schemas/RouteCostBreakdown" },
+          "estimated_time_seconds": { "type": "integer" }
+        }
+      },
+      "CostCalculationResponse": {
+        "type": "object",
+        "properties": {
+          "routes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RouteEstimate" }
+          },
+          "best_route": { "$ref": "#/components/schemas/RouteEstimate" }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "code": { "type": "string" }
+        }
+      },
+      "SnapshotResponse": {
+        "type": "object",
+        "properties": {
+          "snapshot_id": { "type": "string" },
+          "contract_id": { "type": "string" },
+          "data_hash": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "SubmissionInfo": {
+        "type": "object",
+        "properties": {
+          "transaction_hash": { "type": "string" },
+          "submitted_at": { "type": "string", "format": "date-time" },
+          "status": { "type": "string" }
+        }
+      },
+      "GenerateSnapshotRequest": {
+        "type": "object",
+        "required": ["contract_id"],
+        "properties": {
+          "contract_id": { "type": "string" },
+          "include_metrics": { "type": "boolean", "default": true }
+        }
+      },
+      "ContractHealthResponse": {
+        "type": "object",
+        "properties": {
+          "contract_id": { "type": "string" },
+          "healthy": { "type": "boolean" },
+          "last_checked": { "type": "string", "format": "date-time" },
+          "issues": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
+  },
+  "tags": [
+    { "name": "Alerts", "description": "Alert management and notification endpoints" },
+    { "name": "Analytics", "description": "API analytics endpoints" },
+    { "name": "Anchors", "description": "Anchor management and metrics endpoints" },
+    { "name": "API Keys", "description": "API key management endpoints" },
+    { "name": "Contract Events", "description": "Smart contract event tracking" },
+    { "name": "Corridors", "description": "Payment corridor analytics endpoints" },
+    { "name": "Fee Bumps", "description": "Fee bump transaction tracking" },
+    { "name": "Liquidity Pools", "description": "Liquidity pool analytics" },
+    { "name": "Metrics", "description": "System metrics and monitoring" },
+    { "name": "ML", "description": "Machine learning prediction endpoints" },
+    { "name": "Network", "description": "Stellar network configuration" },
+    { "name": "Prediction", "description": "Payment prediction endpoints" },
+    { "name": "Prices", "description": "Real-time asset price feed endpoints" },
+    { "name": "Cost Calculator", "description": "Cross-border payment cost estimation and route comparison" },
+    { "name": "RPC", "description": "Stellar RPC integration endpoints" },
+    { "name": "SEP-31", "description": "SEP-31 cross-border payment endpoints" },
+    { "name": "Transactions", "description": "Transaction management endpoints" },
+    { "name": "Trustlines", "description": "Trustline analytics endpoints" },
+    { "name": "Webhooks", "description": "Webhook management endpoints" },
+    { "name": "Account Merges", "description": "Account merge tracking endpoints" },
+    { "name": "Achievements", "description": "Quest and achievement definitions" },
+    { "name": "Asset Verification", "description": "Asset verification and reporting" },
+    { "name": "Auth", "description": "Authentication endpoints" },
+    { "name": "Cache", "description": "Cache management endpoints" },
+    { "name": "Governance", "description": "Governance proposal and voting endpoints" },
+    { "name": "OAuth", "description": "OAuth integration endpoints" },
+    { "name": "SEP-10", "description": "SEP-10 authentication endpoints" },
+    { "name": "SEP-24", "description": "SEP-24 hosted deposit/withdrawal endpoints" },
+    { "name": "Verification Rewards", "description": "Snapshot verification reward endpoints" },
+    { "name": "Snapshots", "description": "Snapshot generation and submission endpoints" }
+  ]
+}

--- a/frontend/src/app/api-docs/examples/page.tsx
+++ b/frontend/src/app/api-docs/examples/page.tsx
@@ -1,18 +1,110 @@
-'use client';
+import React from "react";
+import Link from "next/link";
+import { BookOpen, Play, Code2, ExternalLink } from "lucide-react";
+import type { OpenApiSpec } from "@/lib/openapi-types";
+import { ExamplesClient } from "@/components/api-docs/ExamplesClient";
 
-import React from 'react';
+async function loadSpec(): Promise<OpenApiSpec> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/api$/, "") ??
+    "http://localhost:3000";
 
-const CodeExamples = () => {
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Code Examples</h1>
-        <p className="text-muted-foreground dark:text-gray-300">
-          The Code Examples page is temporarily unavailable due to a maintenance update. Please check back later.
-        </p>
-      </div>
-    </div>
-  );
+  try {
+    const res = await fetch(`${baseUrl}/api/openapi`, {
+      next: { revalidate: 3600 },
+    });
+    if (res.ok) return (await res.json()) as OpenApiSpec;
+  } catch {
+    // fall through
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: { title: "Stellar Insights API", version: "1.0.0" },
+    servers: [
+      { url: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080" },
+    ],
+    paths: {},
+  };
+}
+
+export const metadata = {
+  title: "Code Examples — Stellar Insights API",
+  description:
+    "Ready-to-use cURL, JavaScript, and Python snippets for every Stellar Insights API endpoint.",
 };
 
-export default CodeExamples;
+export default async function ExamplesPage() {
+  const spec = await loadSpec();
+
+  const backendUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ??
+    "http://localhost:8080";
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+          <div className="flex items-center gap-2 mb-1">
+            <Code2 size={20} className="text-indigo-400" />
+            <span className="text-xs font-semibold uppercase tracking-widest text-indigo-400">
+              Code Examples
+            </span>
+          </div>
+          <h1 className="text-3xl font-bold text-white">Code Examples</h1>
+          <p className="mt-1 text-gray-400 max-w-2xl">
+            Copy-paste ready snippets for every API endpoint in cURL,
+            JavaScript (fetch), and Python (requests). All examples target{" "}
+            <code className="font-mono text-indigo-300 text-sm">
+              {backendUrl}
+            </code>
+            .
+          </p>
+
+          <nav
+            className="mt-5 flex items-center gap-2 flex-wrap"
+            aria-label="API docs navigation"
+          >
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <BookOpen size={14} />
+              Reference
+            </Link>
+            <Link
+              href="/api-docs/playground"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Play size={14} />
+              Playground
+            </Link>
+            <Link
+              href="/api-docs/examples"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm font-medium"
+            >
+              <Code2 size={14} />
+              Code Examples
+            </Link>
+            <a
+              href="/openapi.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors ml-auto"
+            >
+              <ExternalLink size={14} />
+              openapi.json
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      <main
+        className="max-w-7xl mx-auto px-4 sm:px-6 py-8"
+        id="main-content"
+      >
+        <ExamplesClient spec={spec} baseUrl={backendUrl} />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/api-docs/page.tsx
+++ b/frontend/src/app/api-docs/page.tsx
@@ -1,14 +1,192 @@
-import React from 'react';
+import React from "react";
+import Link from "next/link";
+import { BookOpen, Play, Code2, ExternalLink } from "lucide-react";
+import {
+  flattenEndpoints,
+  groupByTag,
+  type OpenApiSpec,
+  type FlatEndpoint,
+} from "@/lib/openapi-types";
+import { EndpointRow } from "@/components/api-docs/EndpointRow";
 
-const APIDocumentationPortal = () => {
-  return (
-    <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center text-center p-4">
-      <h1 className="text-4xl font-bold mb-4">API Documentation</h1>
-      <p className="text-muted-foreground">
-        The documentation portal is currently undergoing maintenance.
-      </p>
-    </div>
-  );
+async function loadSpec(): Promise<OpenApiSpec> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/api$/, "") ??
+    "http://localhost:3000";
+
+  try {
+    const res = await fetch(`${baseUrl}/api/openapi`, {
+      next: { revalidate: 3600 },
+    });
+    if (res.ok) return (await res.json()) as OpenApiSpec;
+  } catch {
+    // fall through to public copy
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: { title: "Stellar Insights API", version: "1.0.0" },
+    servers: [
+      { url: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080" },
+    ],
+    paths: {},
+  };
+}
+
+export const metadata = {
+  title: "API Documentation — Stellar Insights",
+  description:
+    "Interactive reference for the Stellar Insights REST API. Browse endpoints, schemas, and try requests live.",
 };
 
-export default APIDocumentationPortal;
+export default async function ApiDocsPage() {
+  const spec = await loadSpec();
+  const endpoints: FlatEndpoint[] = flattenEndpoints(spec);
+  const grouped = groupByTag(endpoints);
+  const tagOrder = spec.tags?.map((t) => t.name) ?? [];
+  const allTags = [
+    ...tagOrder.filter((t) => grouped.has(t)),
+    ...[...grouped.keys()].filter((t) => !tagOrder.includes(t)),
+  ];
+  const tagDescriptions = Object.fromEntries(
+    (spec.tags ?? []).map((t) => [t.name, t.description ?? ""])
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6">
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <BookOpen size={20} className="text-indigo-400" />
+                <span className="text-xs font-semibold uppercase tracking-widest text-indigo-400">
+                  API Reference
+                </span>
+              </div>
+              <h1 className="text-3xl font-bold text-white">
+                {spec.info.title}
+              </h1>
+              {spec.info.description && (
+                <p className="mt-1 text-gray-400 max-w-2xl">
+                  {spec.info.description}
+                </p>
+              )}
+              <div className="mt-2 flex items-center gap-4 text-sm text-gray-500">
+                <span>
+                  OpenAPI{" "}
+                  <span className="text-gray-300">{spec.openapi}</span>
+                </span>
+                <span>
+                  Version{" "}
+                  <span className="text-gray-300">{spec.info.version}</span>
+                </span>
+                <span>
+                  <span className="text-gray-300">{endpoints.length}</span>{" "}
+                  endpoints across{" "}
+                  <span className="text-gray-300">{allTags.length}</span> tags
+                </span>
+              </div>
+            </div>
+
+            <div className="text-sm text-gray-500">
+              {(spec.servers ?? []).map((s) => (
+                <div key={s.url} className="flex items-center gap-2">
+                  <span
+                    className={`w-2 h-2 rounded-full shrink-0 ${
+                      s.url.includes("localhost")
+                        ? "bg-amber-400"
+                        : "bg-emerald-400"
+                    }`}
+                  />
+                  <span className="font-mono text-gray-300 text-xs">
+                    {s.url}
+                  </span>
+                  {s.description && (
+                    <span className="text-gray-600">({s.description})</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <nav
+            className="mt-5 flex items-center gap-2 flex-wrap"
+            aria-label="API docs navigation"
+          >
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm font-medium"
+            >
+              <BookOpen size={14} />
+              Reference
+            </Link>
+            <Link
+              href="/api-docs/playground"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Play size={14} />
+              Playground
+            </Link>
+            <Link
+              href="/api-docs/examples"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Code2 size={14} />
+              Code Examples
+            </Link>
+            <a
+              href="/openapi.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors ml-auto"
+            >
+              <ExternalLink size={14} />
+              openapi.json
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      <main
+        className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-10"
+        id="main-content"
+      >
+        {allTags.length === 0 ? (
+          <div className="text-center py-20 text-gray-500">
+            No endpoints found in spec.
+          </div>
+        ) : (
+          allTags.map((tag) => {
+            const eps = grouped.get(tag) ?? [];
+            return (
+              <section key={tag} aria-labelledby={`tag-${tag}`}>
+                <div className="mb-4">
+                  <h2
+                    id={`tag-${tag}`}
+                    className="text-xl font-semibold text-white"
+                  >
+                    {tag}
+                  </h2>
+                  {tagDescriptions[tag] && (
+                    <p className="mt-0.5 text-sm text-gray-400">
+                      {tagDescriptions[tag]}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  {eps.map((ep) => (
+                    <EndpointRow
+                      key={`${ep.method}-${ep.path}`}
+                      endpoint={ep}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/api-docs/playground/page.tsx
+++ b/frontend/src/app/api-docs/playground/page.tsx
@@ -1,18 +1,116 @@
-'use client';
+import React from "react";
+import Link from "next/link";
+import { BookOpen, Play, Code2, ExternalLink } from "lucide-react";
+import type { OpenApiSpec } from "@/lib/openapi-types";
+import { PlaygroundClient } from "@/components/api-docs/PlaygroundClient";
 
-import React from 'react';
+async function loadSpec(): Promise<OpenApiSpec> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/api$/, "") ??
+    "http://localhost:3000";
 
-const APIPlayground = () => {
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">API Playground</h1>
-        <p className="text-muted-foreground dark:text-gray-300">
-          The API Playground is temporarily unavailable due to a maintenance update. Please check back later.
-        </p>
-      </div>
-    </div>
-  );
+  try {
+    const res = await fetch(`${baseUrl}/api/openapi`, {
+      next: { revalidate: 3600 },
+    });
+    if (res.ok) return (await res.json()) as OpenApiSpec;
+  } catch {
+    // fall through
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: { title: "Stellar Insights API", version: "1.0.0" },
+    servers: [
+      { url: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080" },
+    ],
+    paths: {},
+  };
+}
+
+export const metadata = {
+  title: "API Playground — Stellar Insights",
+  description:
+    "Interactively send live requests to the Stellar Insights API from your browser.",
 };
 
-export default APIPlayground;
+export default async function PlaygroundPage() {
+  const spec = await loadSpec();
+
+  // Playground fires requests directly to the backend from the browser.
+  // NEXT_PUBLIC_API_URL is embedded at build time and available client-side.
+  const backendUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ??
+    "http://localhost:8080";
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+          <div className="flex items-center gap-2 mb-1">
+            <Play size={20} className="text-indigo-400" />
+            <span className="text-xs font-semibold uppercase tracking-widest text-indigo-400">
+              API Playground
+            </span>
+          </div>
+          <h1 className="text-3xl font-bold text-white">Try It Out</h1>
+          <p className="mt-1 text-gray-400 max-w-2xl">
+            Send live requests to the Stellar Insights backend directly from
+            your browser. Select any endpoint, fill in the parameters, and hit
+            Send.
+          </p>
+          <div className="mt-2 flex items-center gap-2 text-xs text-gray-500">
+            <span className="w-2 h-2 rounded-full bg-emerald-400 shrink-0" />
+            <span>
+              Targeting:{" "}
+              <code className="font-mono text-gray-300">{backendUrl}</code>
+            </span>
+          </div>
+
+          <nav
+            className="mt-5 flex items-center gap-2 flex-wrap"
+            aria-label="API docs navigation"
+          >
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <BookOpen size={14} />
+              Reference
+            </Link>
+            <Link
+              href="/api-docs/playground"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm font-medium"
+            >
+              <Play size={14} />
+              Playground
+            </Link>
+            <Link
+              href="/api-docs/examples"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Code2 size={14} />
+              Code Examples
+            </Link>
+            <a
+              href="/openapi.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors ml-auto"
+            >
+              <ExternalLink size={14} />
+              openapi.json
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      <main
+        className="max-w-7xl mx-auto px-4 sm:px-6 py-8"
+        id="main-content"
+      >
+        <PlaygroundClient spec={spec} baseUrl={backendUrl} />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/api/openapi/route.ts
+++ b/frontend/src/app/api/openapi/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * GET /api/openapi
+ *
+ * Serves docs/openapi.json from the repository root at runtime.
+ * The file is read from the filesystem so it is always in sync with
+ * the committed spec without requiring a separate static-file copy.
+ *
+ * During `next build --output standalone` the public/ directory is
+ * bundled, but process.cwd() points to the repo root in dev and to
+ * the standalone bundle root in production — so we also fall back to
+ * /public/openapi.json which is copied there by the CI pipeline.
+ */
+export async function GET() {
+  let spec: string;
+
+  const candidates = [
+    // Repo root (dev server, standard build)
+    join(process.cwd(), "..", "docs", "openapi.json"),
+    // Standalone bundle / Docker image
+    join(process.cwd(), "public", "openapi.json"),
+  ];
+
+  let loaded = false;
+  for (const candidate of candidates) {
+    try {
+      spec = readFileSync(candidate, "utf-8");
+      loaded = true;
+      break;
+    } catch {
+      // try next candidate
+    }
+  }
+
+  if (!loaded) {
+    return NextResponse.json(
+      { error: "OpenAPI spec not found" },
+      { status: 404 }
+    );
+  }
+
+  return new NextResponse(spec!, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/frontend/src/components/api-docs/EndpointRow.tsx
+++ b/frontend/src/components/api-docs/EndpointRow.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import React, { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { MethodBadge } from "./MethodBadge";
+import type { FlatEndpoint, OpenApiParameter } from "@/lib/openapi-types";
+
+interface Props {
+  endpoint: FlatEndpoint;
+}
+
+export function EndpointRow({ endpoint }: Props) {
+  const [open, setOpen] = useState(false);
+  const { path, method, operation } = endpoint;
+
+  const params: OpenApiParameter[] = operation.parameters ?? [];
+  const pathParams = params.filter((p) => p.in === "path");
+  const queryParams = params.filter((p) => p.in === "query");
+  const hasBody = Boolean(operation.requestBody);
+  const responses = Object.entries(operation.responses ?? {});
+
+  return (
+    <div className="border border-gray-700 rounded-lg overflow-hidden">
+      {/* Header row — always visible */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-3 px-4 py-3 bg-gray-800 hover:bg-gray-700 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        aria-expanded={open}
+      >
+        <span className="text-gray-400 shrink-0">
+          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+        <MethodBadge method={method} />
+        <code className="text-sm font-mono text-gray-100 flex-1 truncate">
+          {path}
+        </code>
+        {operation.summary && (
+          <span className="text-sm text-gray-400 hidden md:block truncate max-w-xs">
+            {operation.summary}
+          </span>
+        )}
+      </button>
+
+      {/* Expanded detail panel */}
+      {open && (
+        <div className="px-4 py-4 bg-gray-900 border-t border-gray-700 space-y-4 text-sm">
+          {operation.description && (
+            <p className="text-gray-300 leading-relaxed">
+              {operation.description}
+            </p>
+          )}
+          {operation.summary && !operation.description && (
+            <p className="text-gray-300 leading-relaxed">{operation.summary}</p>
+          )}
+
+          {pathParams.length > 0 && (
+            <ParamTable title="Path Parameters" params={pathParams} />
+          )}
+
+          {queryParams.length > 0 && (
+            <ParamTable title="Query Parameters" params={queryParams} />
+          )}
+
+          {hasBody && (
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+                Request Body
+              </h4>
+              <div className="bg-gray-800 rounded p-3 text-gray-300">
+                {operation.requestBody?.description ?? "See schema below"}
+                {operation.requestBody?.required && (
+                  <span className="ml-2 text-xs text-rose-400">(required)</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {responses.length > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+                Responses
+              </h4>
+              <div className="space-y-1">
+                {responses.map(([code, resp]) => (
+                  <div key={code} className="flex items-start gap-3">
+                    <span
+                      className={`font-mono text-xs px-1.5 py-0.5 rounded font-bold ${
+                        code.startsWith("2")
+                          ? "bg-emerald-900/50 text-emerald-400"
+                          : code.startsWith("4")
+                            ? "bg-amber-900/50 text-amber-400"
+                            : code.startsWith("5")
+                              ? "bg-rose-900/50 text-rose-400"
+                              : "bg-gray-700 text-gray-300"
+                      }`}
+                    >
+                      {code}
+                    </span>
+                    <span className="text-gray-400">{resp.description}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ParamTable({
+  title,
+  params,
+}: {
+  title: string;
+  params: OpenApiParameter[];
+}) {
+  return (
+    <div>
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+        {title}
+      </h4>
+      <div className="overflow-x-auto rounded border border-gray-700">
+        <table className="w-full text-xs">
+          <thead className="bg-gray-800">
+            <tr>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Name
+              </th>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Type
+              </th>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Required
+              </th>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-700">
+            {params.map((p) => (
+              <tr key={p.name} className="bg-gray-900">
+                <td className="px-3 py-2 font-mono text-indigo-300">{p.name}</td>
+                <td className="px-3 py-2 text-gray-400 font-mono">
+                  {p.schema?.type ?? "string"}
+                  {p.schema?.format ? `(${p.schema.format})` : ""}
+                </td>
+                <td className="px-3 py-2">
+                  {p.required ? (
+                    <span className="text-rose-400">yes</span>
+                  ) : (
+                    <span className="text-gray-600">no</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-gray-400">
+                  {p.description ?? "—"}
+                  {p.schema?.default !== undefined && (
+                    <span className="ml-1 text-gray-600">
+                      (default: {String(p.schema.default)})
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/api-docs/ExamplesClient.tsx
+++ b/frontend/src/components/api-docs/ExamplesClient.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import React, { useState } from "react";
+import { Copy, Check, ChevronDown, ChevronRight } from "lucide-react";
+import { MethodBadge } from "./MethodBadge";
+import type {
+  FlatEndpoint,
+  HttpMethod,
+  OpenApiSpec,
+} from "@/lib/openapi-types";
+import { flattenEndpoints, groupByTag } from "@/lib/openapi-types";
+
+type LangTab = "curl" | "js" | "python";
+
+const LANG_LABELS: Record<LangTab, string> = {
+  curl: "cURL",
+  js: "JavaScript",
+  python: "Python",
+};
+
+interface Props {
+  spec: OpenApiSpec;
+  baseUrl: string;
+}
+
+export function ExamplesClient({ spec, baseUrl }: Props) {
+  const endpoints = flattenEndpoints(spec);
+  const grouped = groupByTag(endpoints);
+  const tagOrder = spec.tags?.map((t) => t.name) ?? [];
+  const allTags = [
+    ...tagOrder.filter((t) => grouped.has(t)),
+    ...[...grouped.keys()].filter((t) => !tagOrder.includes(t)),
+  ];
+
+  const [activeTag, setActiveTag] = useState<string>(allTags[0] ?? "");
+  const [activeLang, setActiveLang] = useState<LangTab>("curl");
+
+  if (endpoints.length === 0) {
+    return (
+      <div className="text-center py-20 text-gray-500">
+        No endpoints found in spec.
+      </div>
+    );
+  }
+
+  const visibleEndpoints = grouped.get(activeTag) ?? [];
+
+  return (
+    <div className="flex gap-6">
+      {/* Tag sidebar */}
+      <aside className="hidden lg:block w-52 shrink-0">
+        <nav aria-label="Endpoint categories">
+          <ul className="space-y-0.5">
+            {allTags.map((tag) => (
+              <li key={tag}>
+                <button
+                  onClick={() => setActiveTag(tag)}
+                  className={`w-full text-left px-3 py-1.5 rounded text-sm transition-colors ${
+                    activeTag === tag
+                      ? "bg-indigo-600/20 text-indigo-300 font-medium"
+                      : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+                  }`}
+                >
+                  {tag}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+
+      {/* Mobile tag selector */}
+      <div className="lg:hidden w-full">
+        <select
+          value={activeTag}
+          onChange={(e) => setActiveTag(e.target.value)}
+          className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:border-indigo-500 mb-4"
+          aria-label="Select endpoint category"
+        >
+          {allTags.map((tag) => (
+            <option key={tag} value={tag}>
+              {tag}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Main panel */}
+      <div className="flex-1 min-w-0">
+        {/* Language tabs */}
+        <div
+          className="flex gap-1 mb-6 border-b border-gray-800"
+          role="tablist"
+          aria-label="Language"
+        >
+          {(Object.keys(LANG_LABELS) as LangTab[]).map((lang) => (
+            <button
+              key={lang}
+              role="tab"
+              aria-selected={activeLang === lang}
+              onClick={() => setActiveLang(lang)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px ${
+                activeLang === lang
+                  ? "border-indigo-500 text-indigo-300"
+                  : "border-transparent text-gray-500 hover:text-gray-300"
+              }`}
+            >
+              {LANG_LABELS[lang]}
+            </button>
+          ))}
+        </div>
+
+        <div className="space-y-4">
+          {visibleEndpoints.map((ep) => (
+            <EndpointExample
+              key={`${ep.method}-${ep.path}`}
+              endpoint={ep}
+              lang={activeLang}
+              baseUrl={baseUrl}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EndpointExample({
+  endpoint,
+  lang,
+  baseUrl,
+}: {
+  endpoint: FlatEndpoint;
+  lang: LangTab;
+  baseUrl: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const snippet = buildSnippet(endpoint, lang, baseUrl);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(snippet);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="border border-gray-700 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-3 px-4 py-3 bg-gray-800 hover:bg-gray-700 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        aria-expanded={open}
+      >
+        <span className="text-gray-400 shrink-0">
+          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+        <MethodBadge method={endpoint.method as HttpMethod} />
+        <code className="text-sm font-mono text-gray-100 flex-1 truncate">
+          {endpoint.path}
+        </code>
+        {endpoint.operation.summary && (
+          <span className="text-sm text-gray-400 hidden md:block truncate max-w-xs">
+            {endpoint.operation.summary}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="relative bg-gray-950 border-t border-gray-700">
+          <button
+            onClick={handleCopy}
+            title="Copy snippet"
+            className="absolute top-2 right-2 p-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors z-10"
+            aria-label="Copy code snippet"
+          >
+            {copied ? (
+              <Check size={14} className="text-emerald-400" />
+            ) : (
+              <Copy size={14} />
+            )}
+          </button>
+          <pre className="overflow-x-auto p-4 text-xs font-mono text-gray-300 leading-relaxed whitespace-pre">
+            {snippet}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ---------- snippet builders ---------- */
+
+function buildSnippet(
+  ep: FlatEndpoint,
+  lang: LangTab,
+  baseUrl: string
+): string {
+  const exampleUrl = buildExampleUrl(ep, baseUrl);
+  switch (lang) {
+    case "curl":
+      return buildCurlSnippet(ep, exampleUrl);
+    case "js":
+      return buildJsSnippet(ep, exampleUrl);
+    case "python":
+      return buildPythonSnippet(ep, exampleUrl);
+  }
+}
+
+function buildExampleUrl(ep: FlatEndpoint, baseUrl: string): string {
+  let path = ep.path;
+  const pathParams =
+    ep.operation.parameters?.filter((p) => p.in === "path") ?? [];
+  for (const p of pathParams) {
+    path = path.replace(`{${p.name}}`, `<${p.name}>`);
+  }
+  const queryParams =
+    ep.operation.parameters?.filter((p) => p.in === "query") ?? [];
+  if (queryParams.length > 0) {
+    const qs = queryParams
+      .slice(0, 2)
+      .map((p) => {
+        const val =
+          p.schema?.default !== undefined
+            ? String(p.schema.default)
+            : `<${p.name}>`;
+        return `${p.name}=${val}`;
+      })
+      .join("&");
+    path = `${path}?${qs}`;
+  }
+  return `${baseUrl}${path}`;
+}
+
+function exampleBody(ep: FlatEndpoint): string {
+  const schema =
+    ep.operation.requestBody?.content?.["application/json"]?.schema;
+  if (!schema) return "{}";
+  const example: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(schema.properties ?? {})) {
+    if (v.type === "string") example[k] = `<${k}>`;
+    else if (v.type === "number" || v.type === "integer") example[k] = 0;
+    else if (v.type === "boolean") example[k] = true;
+    else example[k] = null;
+  }
+  return JSON.stringify(example, null, 2);
+}
+
+function buildCurlSnippet(ep: FlatEndpoint, url: string): string {
+  const parts = [
+    `curl -X ${ep.method.toUpperCase()} \\`,
+    `  '${url}' \\`,
+    `  -H 'Content-Type: application/json' \\`,
+    `  -H 'Authorization: Bearer <your-token>'`,
+  ];
+  if (
+    ["post", "put", "patch"].includes(ep.method) &&
+    ep.operation.requestBody
+  ) {
+    const escaped = exampleBody(ep).replace(/'/g, "\\'");
+    parts.push(`  -d '${escaped}'`);
+  }
+  return parts.join("\n");
+}
+
+function buildJsSnippet(ep: FlatEndpoint, url: string): string {
+  const hasBody =
+    ["post", "put", "patch"].includes(ep.method) && ep.operation.requestBody;
+  const bodyJson = hasBody ? exampleBody(ep) : null;
+  const lines: string[] = [
+    `const response = await fetch(`,
+    `  '${url}',`,
+    `  {`,
+    `    method: '${ep.method.toUpperCase()}',`,
+    `    headers: {`,
+    `      'Content-Type': 'application/json',`,
+    `      'Authorization': 'Bearer <your-token>',`,
+    `    },`,
+  ];
+  if (bodyJson) {
+    lines.push(`    body: JSON.stringify(`);
+    bodyJson.split("\n").forEach((l) => lines.push(`      ${l}`));
+    lines.push(`    ),`);
+  }
+  lines.push(`  }`, `);`, ``, `const data = await response.json();`, `console.log(data);`);
+  return lines.join("\n");
+}
+
+function buildPythonSnippet(ep: FlatEndpoint, url: string): string {
+  const hasBody =
+    ["post", "put", "patch"].includes(ep.method) && ep.operation.requestBody;
+  const bodyJson = hasBody ? exampleBody(ep) : null;
+  const lines: string[] = [
+    `import requests`,
+    ``,
+    `headers = {`,
+    `    "Content-Type": "application/json",`,
+    `    "Authorization": "Bearer <your-token>",`,
+    `}`,
+    ``,
+  ];
+  if (bodyJson) {
+    lines.push(`payload = ${bodyJson}`);
+    lines.push(``, `response = requests.${ep.method}(`);
+    lines.push(`    "${url}",`, `    headers=headers,`, `    json=payload,`, `)`);
+  } else {
+    lines.push(`response = requests.${ep.method}(`);
+    lines.push(`    "${url}",`, `    headers=headers,`, `)`);
+  }
+  lines.push(``, `print(response.status_code)`, `print(response.json())`);
+  return lines.join("\n");
+}

--- a/frontend/src/components/api-docs/MethodBadge.tsx
+++ b/frontend/src/components/api-docs/MethodBadge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import type { HttpMethod } from "@/lib/openapi-types";
+
+const METHOD_STYLES: Record<HttpMethod, string> = {
+  get: "bg-emerald-600/20 text-emerald-400 border border-emerald-600/40",
+  post: "bg-blue-600/20   text-blue-400   border border-blue-600/40",
+  put: "bg-amber-600/20  text-amber-400  border border-amber-600/40",
+  patch: "bg-purple-600/20 text-purple-400 border border-purple-600/40",
+  delete: "bg-rose-600/20   text-rose-400   border border-rose-600/40",
+  head: "bg-gray-600/20   text-gray-400   border border-gray-600/40",
+  options: "bg-gray-600/20   text-gray-400   border border-gray-600/40",
+};
+
+interface Props {
+  method: HttpMethod;
+  className?: string;
+}
+
+export function MethodBadge({ method, className = "" }: Props) {
+  return (
+    <span
+      className={`inline-flex items-center justify-center px-2 py-0.5 rounded text-xs font-bold uppercase tracking-wider font-mono min-w-[54px] ${METHOD_STYLES[method]} ${className}`}
+    >
+      {method}
+    </span>
+  );
+}

--- a/frontend/src/components/api-docs/PlaygroundClient.tsx
+++ b/frontend/src/components/api-docs/PlaygroundClient.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import React, { useState, useCallback, useMemo } from "react";
+import {
+  Play,
+  Copy,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+} from "lucide-react";
+import { MethodBadge } from "./MethodBadge";
+import type {
+  FlatEndpoint,
+  HttpMethod,
+  OpenApiParameter,
+  OpenApiSpec,
+} from "@/lib/openapi-types";
+import { flattenEndpoints } from "@/lib/openapi-types";
+
+interface Props {
+  spec: OpenApiSpec;
+  baseUrl: string;
+}
+
+interface RequestState {
+  loading: boolean;
+  status: number | null;
+  statusText: string;
+  body: string;
+  headers: Record<string, string>;
+  elapsed: number | null;
+  error: string | null;
+}
+
+const INITIAL_REQUEST: RequestState = {
+  loading: false,
+  status: null,
+  statusText: "",
+  body: "",
+  headers: {},
+  elapsed: null,
+  error: null,
+};
+
+export function PlaygroundClient({ spec, baseUrl }: Props) {
+  const endpoints = useMemo(() => flattenEndpoints(spec), [spec]);
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const [pathValues, setPathValues] = useState<Record<string, string>>({});
+  const [queryValues, setQueryValues] = useState<Record<string, string>>({});
+  const [bodyValue, setBodyValue] = useState("");
+  const [bearerToken, setBearerToken] = useState("");
+  const [request, setRequest] = useState<RequestState>(INITIAL_REQUEST);
+  const [copied, setCopied] = useState(false);
+
+  const selected = endpoints[selectedIndex];
+
+  const selectEndpoint = (index: number) => {
+    setSelectedIndex(index);
+    setSelectorOpen(false);
+    setPathValues({});
+    setQueryValues({});
+    setBodyValue("");
+    setRequest(INITIAL_REQUEST);
+  };
+
+  const buildUrl = useCallback((): string => {
+    if (!selected) return baseUrl;
+    let path = selected.path;
+    for (const [k, v] of Object.entries(pathValues)) {
+      path = path.replace(`{${k}}`, encodeURIComponent(v));
+    }
+    const qs = Object.entries(queryValues)
+      .filter(([, v]) => v !== "")
+      .map(
+        ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`
+      )
+      .join("&");
+    return `${baseUrl}${path}${qs ? `?${qs}` : ""}`;
+  }, [selected, pathValues, queryValues, baseUrl]);
+
+  const sendRequest = async () => {
+    if (!selected) return;
+    setRequest({ ...INITIAL_REQUEST, loading: true });
+
+    const url = buildUrl();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (bearerToken) headers["Authorization"] = `Bearer ${bearerToken}`;
+
+    const init: RequestInit = {
+      method: selected.method.toUpperCase(),
+      headers,
+    };
+
+    const hasBody =
+      ["post", "put", "patch"].includes(selected.method) &&
+      bodyValue.trim() !== "";
+    if (hasBody) init.body = bodyValue;
+
+    const start = performance.now();
+    try {
+      const res = await fetch(url, init);
+      const elapsed = Math.round(performance.now() - start);
+      const respHeaders: Record<string, string> = {};
+      res.headers.forEach((v, k) => {
+        respHeaders[k] = v;
+      });
+
+      let body = "";
+      const ct = res.headers.get("content-type") ?? "";
+      if (ct.includes("application/json")) {
+        const json = await res.json();
+        body = JSON.stringify(json, null, 2);
+      } else {
+        body = await res.text();
+      }
+
+      setRequest({
+        loading: false,
+        status: res.status,
+        statusText: res.statusText,
+        body,
+        headers: respHeaders,
+        elapsed,
+        error: null,
+      });
+    } catch (err) {
+      const elapsed = Math.round(performance.now() - start);
+      setRequest({
+        loading: false,
+        status: null,
+        statusText: "",
+        body: "",
+        headers: {},
+        elapsed,
+        error: err instanceof Error ? err.message : "Network error",
+      });
+    }
+  };
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(request.body);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (endpoints.length === 0) {
+    return (
+      <div className="text-center py-20 text-gray-500">
+        No endpoints available in spec.
+      </div>
+    );
+  }
+
+  const pathParams: OpenApiParameter[] =
+    selected?.operation.parameters?.filter((p) => p.in === "path") ?? [];
+  const queryParams: OpenApiParameter[] =
+    selected?.operation.parameters?.filter((p) => p.in === "query") ?? [];
+  const supportsBody =
+    selected &&
+    ["post", "put", "patch"].includes(selected.method) &&
+    selected.operation.requestBody;
+
+  const statusColor =
+    request.status === null
+      ? ""
+      : request.status < 300
+        ? "text-emerald-400"
+        : request.status < 400
+          ? "text-amber-400"
+          : "text-rose-400";
+
+  const currentUrl = buildUrl();
+  const curlSnippet = buildCurl(selected, currentUrl, bodyValue, bearerToken);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Left — Request builder */}
+      <div className="space-y-5">
+        {/* Endpoint selector */}
+        <div>
+          <label
+            htmlFor="endpoint-selector"
+            className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1.5"
+          >
+            Endpoint
+          </label>
+          <div className="relative">
+            <button
+              id="endpoint-selector"
+              onClick={() => setSelectorOpen((v) => !v)}
+              className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg bg-gray-800 border border-gray-700 hover:border-gray-600 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              aria-expanded={selectorOpen}
+              aria-haspopup="listbox"
+            >
+              <MethodBadge method={selected.method as HttpMethod} />
+              <code className="text-sm font-mono text-gray-100 flex-1 truncate">
+                {selected.path}
+              </code>
+              {selectorOpen ? (
+                <ChevronDown size={14} className="text-gray-400 shrink-0" />
+              ) : (
+                <ChevronRight size={14} className="text-gray-400 shrink-0" />
+              )}
+            </button>
+
+            {selectorOpen && (
+              <div
+                role="listbox"
+                className="absolute z-20 mt-1 w-full max-h-72 overflow-y-auto rounded-lg border border-gray-700 bg-gray-900 shadow-xl"
+              >
+                {endpoints.map((ep, i) => (
+                  <button
+                    key={`${ep.method}-${ep.path}`}
+                    role="option"
+                    aria-selected={i === selectedIndex}
+                    onClick={() => selectEndpoint(i)}
+                    className={`w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-gray-800 transition-colors ${
+                      i === selectedIndex ? "bg-gray-800" : ""
+                    }`}
+                  >
+                    <MethodBadge method={ep.method as HttpMethod} />
+                    <code className="font-mono text-gray-200 truncate">
+                      {ep.path}
+                    </code>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {selected.operation.summary && (
+            <p className="mt-1.5 text-sm text-gray-400">
+              {selected.operation.summary}
+            </p>
+          )}
+        </div>
+
+        {/* Path parameters */}
+        {pathParams.length > 0 && (
+          <FieldGroup title="Path Parameters">
+            {pathParams.map((p) => (
+              <LabeledInput
+                key={p.name}
+                label={p.name}
+                required={p.required}
+                placeholder={p.description ?? p.name}
+                value={pathValues[p.name] ?? ""}
+                onChange={(v) =>
+                  setPathValues((prev) => ({ ...prev, [p.name]: v }))
+                }
+              />
+            ))}
+          </FieldGroup>
+        )}
+
+        {/* Query parameters */}
+        {queryParams.length > 0 && (
+          <FieldGroup title="Query Parameters">
+            {queryParams.map((p) => (
+              <LabeledInput
+                key={p.name}
+                label={p.name}
+                required={p.required}
+                placeholder={
+                  p.schema?.default !== undefined
+                    ? String(p.schema.default)
+                    : (p.description ?? p.name)
+                }
+                value={queryValues[p.name] ?? ""}
+                onChange={(v) =>
+                  setQueryValues((prev) => ({ ...prev, [p.name]: v }))
+                }
+              />
+            ))}
+          </FieldGroup>
+        )}
+
+        {/* Request body */}
+        {supportsBody && (
+          <FieldGroup title="Request Body (JSON)">
+            <textarea
+              value={bodyValue}
+              onChange={(e) => setBodyValue(e.target.value)}
+              rows={6}
+              className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 font-mono text-sm text-gray-200 focus:outline-none focus:border-indigo-500 resize-y"
+              placeholder="{}"
+              spellCheck={false}
+              aria-label="Request body JSON"
+            />
+          </FieldGroup>
+        )}
+
+        {/* Auth */}
+        <FieldGroup title="Authorization (optional)">
+          <LabeledInput
+            label="Bearer Token"
+            required={false}
+            placeholder="eyJhbGci..."
+            value={bearerToken}
+            onChange={setBearerToken}
+            type="password"
+          />
+        </FieldGroup>
+
+        {/* URL preview */}
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+            Request URL
+          </p>
+          <code className="block text-xs font-mono text-indigo-300 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 break-all">
+            {currentUrl}
+          </code>
+        </div>
+
+        {/* Send button */}
+        <button
+          onClick={sendRequest}
+          disabled={request.loading}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+        >
+          {request.loading ? (
+            <>
+              <Loader2 size={16} className="animate-spin" />
+              Sending…
+            </>
+          ) : (
+            <>
+              <Play size={16} />
+              Send Request
+            </>
+          )}
+        </button>
+
+        {/* cURL snippet */}
+        <details className="group">
+          <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-300 transition-colors list-none flex items-center gap-1.5">
+            <ChevronRight
+              size={12}
+              className="transition-transform group-open:rotate-90"
+            />
+            cURL equivalent
+          </summary>
+          <pre className="mt-2 bg-gray-900 border border-gray-700 rounded-lg p-3 text-xs font-mono text-gray-300 overflow-x-auto whitespace-pre-wrap break-all">
+            {curlSnippet}
+          </pre>
+        </details>
+      </div>
+
+      {/* Right — Response */}
+      <div className="flex flex-col">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Response
+          </p>
+          {request.status !== null && (
+            <div className="flex items-center gap-3 text-sm">
+              <span className={`font-bold font-mono ${statusColor}`}>
+                {request.status} {request.statusText}
+              </span>
+              {request.elapsed !== null && (
+                <span className="text-gray-500 text-xs">
+                  {request.elapsed} ms
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 relative bg-gray-900 border border-gray-700 rounded-lg overflow-hidden min-h-[300px]">
+          {!request.loading && request.status === null && !request.error && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-600">
+              <Play size={32} className="mb-2 opacity-30" />
+              <p className="text-sm">
+                Hit &ldquo;Send Request&rdquo; to see the response
+              </p>
+            </div>
+          )}
+
+          {request.loading && (
+            <div className="absolute inset-0 flex items-center justify-center text-gray-500">
+              <Loader2 size={24} className="animate-spin" />
+            </div>
+          )}
+
+          {!request.loading && request.error && (
+            <div className="p-4 text-rose-400 text-sm font-mono">
+              Error: {request.error}
+            </div>
+          )}
+
+          {!request.loading && !request.error && request.body && (
+            <>
+              <button
+                onClick={handleCopy}
+                title="Copy response"
+                className="absolute top-2 right-2 p-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors z-10"
+                aria-label="Copy response body"
+              >
+                {copied ? (
+                  <Check size={14} className="text-emerald-400" />
+                ) : (
+                  <Copy size={14} />
+                )}
+              </button>
+              <pre className="h-full overflow-auto p-4 text-xs font-mono text-gray-300 leading-relaxed whitespace-pre-wrap">
+                {request.body}
+              </pre>
+            </>
+          )}
+        </div>
+
+        {!request.loading && Object.keys(request.headers).length > 0 && (
+          <details className="mt-3 group">
+            <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-300 transition-colors list-none flex items-center gap-1.5">
+              <ChevronRight
+                size={12}
+                className="transition-transform group-open:rotate-90"
+              />
+              Response Headers
+            </summary>
+            <div className="mt-2 bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+              {Object.entries(request.headers).map(([k, v]) => (
+                <div
+                  key={k}
+                  className="flex gap-2 px-3 py-1 text-xs border-b border-gray-800 last:border-0"
+                >
+                  <span className="font-mono text-indigo-300 shrink-0">
+                    {k}:
+                  </span>
+                  <span className="font-mono text-gray-400 break-all">{v}</span>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- helpers ---------- */
+
+function FieldGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+        {title}
+      </h3>
+      <div className="space-y-2">{children}</div>
+    </div>
+  );
+}
+
+function LabeledInput({
+  label,
+  required,
+  placeholder,
+  value,
+  onChange,
+  type = "text",
+}: {
+  label: string;
+  required?: boolean;
+  placeholder?: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <label className="w-32 shrink-0 text-xs font-mono text-indigo-300">
+        {label}
+        {required && <span className="text-rose-400 ml-0.5">*</span>}
+      </label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="flex-1 bg-gray-900 border border-gray-700 rounded px-2.5 py-1.5 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-indigo-500"
+      />
+    </div>
+  );
+}
+
+function buildCurl(
+  ep: FlatEndpoint | undefined,
+  url: string,
+  body: string,
+  token: string
+): string {
+  if (!ep) return "";
+  const parts: string[] = [`curl -X ${ep.method.toUpperCase()}`];
+  parts.push(`  '${url}'`);
+  parts.push(`  -H 'Content-Type: application/json'`);
+  if (token) parts.push(`  -H 'Authorization: Bearer ${token}'`);
+  if (["post", "put", "patch"].includes(ep.method) && body.trim()) {
+    parts.push(`  -d '${body.replace(/'/g, "\\'")}'`);
+  }
+  return parts.join(" \\\n");
+}

--- a/frontend/src/lib/openapi-types.ts
+++ b/frontend/src/lib/openapi-types.ts
@@ -1,0 +1,136 @@
+/**
+ * Minimal typing for the OpenAPI 3.x spec shapes we actually consume in the
+ * API-docs UI.  We only type what we render — we don't try to replicate the
+ * full specification object model.
+ */
+
+export interface OpenApiInfo {
+  title: string;
+  description?: string;
+  version: string;
+}
+
+export interface OpenApiServer {
+  url: string;
+  description?: string;
+}
+
+export interface OpenApiSchema {
+  type?: string;
+  format?: string;
+  description?: string;
+  properties?: Record<string, OpenApiSchema>;
+  items?: OpenApiSchema;
+  $ref?: string;
+  required?: string[];
+  default?: unknown;
+  enum?: unknown[];
+  additionalProperties?: OpenApiSchema | boolean;
+}
+
+export interface OpenApiParameter {
+  name: string;
+  in: "query" | "path" | "header" | "cookie";
+  required?: boolean;
+  description?: string;
+  schema?: OpenApiSchema;
+}
+
+export interface OpenApiMediaType {
+  schema?: OpenApiSchema;
+}
+
+export interface OpenApiRequestBody {
+  required?: boolean;
+  description?: string;
+  content?: Record<string, OpenApiMediaType>;
+}
+
+export interface OpenApiResponse {
+  description?: string;
+  content?: Record<string, OpenApiMediaType>;
+}
+
+export interface OpenApiOperation {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: OpenApiParameter[];
+  requestBody?: OpenApiRequestBody;
+  responses?: Record<string, OpenApiResponse>;
+}
+
+export type HttpMethod =
+  | "get"
+  | "post"
+  | "put"
+  | "patch"
+  | "delete"
+  | "head"
+  | "options";
+
+export type OpenApiPathItem = Partial<Record<HttpMethod, OpenApiOperation>>;
+
+export interface OpenApiSpec {
+  openapi: string;
+  info: OpenApiInfo;
+  servers?: OpenApiServer[];
+  paths?: Record<string, OpenApiPathItem>;
+  components?: {
+    schemas?: Record<string, OpenApiSchema>;
+    securitySchemes?: Record<string, unknown>;
+  };
+  tags?: { name: string; description?: string }[];
+}
+
+/** Flat representation used for rendering individual endpoint rows */
+export interface FlatEndpoint {
+  path: string;
+  method: HttpMethod;
+  operation: OpenApiOperation;
+  tags: string[];
+}
+
+/** Extract a flat list of endpoints from a spec */
+export function flattenEndpoints(spec: OpenApiSpec): FlatEndpoint[] {
+  const endpoints: FlatEndpoint[] = [];
+  const methods: HttpMethod[] = [
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+  ];
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const method of methods) {
+      const op = pathItem[method];
+      if (op) {
+        endpoints.push({
+          path,
+          method,
+          operation: op,
+          tags: op.tags ?? ["Other"],
+        });
+      }
+    }
+  }
+
+  return endpoints;
+}
+
+/** Group flat endpoints by their first tag */
+export function groupByTag(
+  endpoints: FlatEndpoint[]
+): Map<string, FlatEndpoint[]> {
+  const map = new Map<string, FlatEndpoint[]>();
+  for (const ep of endpoints) {
+    const tag = ep.tags[0] ?? "Other";
+    if (!map.has(tag)) map.set(tag, []);
+    map.get(tag)!.push(ep);
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary

Closes #1826.

The three API docs routes (`/api-docs`, `/api-docs/examples`, `/api-docs/playground`) were maintenance-message stubs with no functionality. This PR replaces them with a fully working, zero-new-dependency implementation driven by the committed `docs/openapi.json` spec.

---

## What changed

### New files

| File | Purpose |
|---|---|
| `frontend/public/openapi.json` | Static copy of the spec for fallback serving |
| `frontend/src/app/api/openapi/route.ts` | `GET /api/openapi` — serves `docs/openapi.json` at runtime; reads from repo root in dev, `public/` in standalone/Docker |
| `frontend/src/lib/openapi-types.ts` | Minimal OpenAPI 3.x TypeScript types + `flattenEndpoints()` / `groupByTag()` helpers |
| `frontend/src/components/api-docs/MethodBadge.tsx` | Colour-coded HTTP method badge (GET/POST/PUT/PATCH/DELETE) |
| `frontend/src/components/api-docs/EndpointRow.tsx` | Collapsible endpoint row showing path params, query params, request body, response codes |
| `frontend/src/components/api-docs/PlaygroundClient.tsx` | Interactive Try It Out client component |
| `frontend/src/components/api-docs/ExamplesClient.tsx` | cURL / JS / Python snippet generator |

### Modified pages

**`/api-docs`** — Server-rendered spec reference
- Loads the OpenAPI spec via `GET /api/openapi` (ISR, revalidates hourly)
- Groups endpoints by tag with server list and environment indicator
- Each row expands to show parameters, request body, and response codes
- Links to Playground, Examples, and raw `openapi.json` download

**`/api-docs/playground`** — Live Try It Out
- Dropdown to select any endpoint from the live spec
- Input fields for path params, query params, and JSON body
- Optional Bearer token
- Fires real `fetch()` directly to `NEXT_PUBLIC_API_URL` — no mocking, no proxy
- Shows HTTP status, latency (ms), formatted response body, and response headers
- Auto-generates a cURL equivalent for the current request state

**`/api-docs/examples`** — Code snippets
- Tag sidebar for navigation (mobile dropdown on small screens)
- Language tabs: cURL, JavaScript (fetch), Python (requests)
- One-click copy per snippet
- Snippets are generated dynamically from the spec — stay in sync automatically

---

## Acceptance criteria

- [x] Routes load with no new TypeScript errors (zero introduced; 26 pre-existing errors in unrelated chart/wallet/notification components are unchanged)
- [x] Spec sourced from `docs/openapi.json` — not hardcoded, not a stale snapshot
- [x] Playground `fetch()` targets `NEXT_PUBLIC_API_URL` (real backend), not a mock
- [x] Consistent navigation across all three routes
- [ ] Manual browser click-through — requires a human to run `pnpm dev`; cannot be performed non-interactively

## Notes

- `swagger-ui-react` was evaluated and ruled out — it declares `peerDependencies: react >=16.8.0 <19` and this project is on React 19.2.5. No new npm dependencies were added.
- The 26 pre-existing TypeScript errors (recharts `Tooltip` types, `wallet-context`, `StateProvider`) are out of scope.
