### PR TITLE
fix(monitoring): gate internal dashboard behind INTERNAL_SECRET and wire to real backend (#1828)

### DIFF
--- a/backend/src/api/gdpr.rs
+++ b/backend/src/api/gdpr.rs
@@ -1,0 +1,730 @@
+//! GDPR compliance API handlers.
+//!
+//! Implements the Right to Access (data export), Right to be Forgotten (data
+//! deletion), and consent management endpoints required by issue #1827.
+//!
+//! All endpoints require a valid JWT (`AuthUser` extractor). The underlying
+//! tables (`user_consents`, `data_export_requests`, `data_deletion_requests`,
+//! `data_processing_log`) were created by migration 015.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post, put},
+    Json, Router,
+};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::auth_middleware::AuthUser;
+use crate::error::{ApiError, ApiResult};
+
+// ── Route registration ────────────────────────────────────────────────────────
+
+pub fn routes(pool: SqlitePool) -> Router {
+    Router::new()
+        .route("/summary", get(get_summary))
+        .route("/consents", get(get_consents).put(update_consent))
+        .route("/consents/batch", put(batch_update_consents))
+        .route("/export", get(list_export_requests).post(create_export_request))
+        .route("/export/:id", get(get_export_request))
+        .route("/export-types", get(get_export_types))
+        .route("/deletion", get(list_deletion_requests).post(create_deletion_request))
+        .route("/deletion/:id", get(get_deletion_request))
+        .route("/deletion/:id/cancel", post(cancel_deletion_request))
+        .route("/deletion/confirm", post(confirm_deletion))
+        .with_state(pool)
+}
+
+// ── Response / request types ─────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ConsentResponse {
+    pub consent_type: String,
+    pub consent_given: bool,
+    pub consent_version: String,
+    pub granted_at: Option<String>,
+    pub revoked_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateConsentRequest {
+    pub consent_type: String,
+    pub consent_given: bool,
+    pub consent_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BatchUpdateConsentsRequest {
+    pub consents: Vec<UpdateConsentRequest>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExportRequestResponse {
+    pub id: String,
+    pub status: String,
+    pub requested_at: String,
+    pub expires_at: Option<String>,
+    /// Constructed as `/api/gdpr/export/{id}/download` when status is completed.
+    pub download_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateExportRequest {
+    pub data_types: Vec<String>,
+    pub export_format: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeletionRequestResponse {
+    pub id: String,
+    pub status: String,
+    pub requested_at: String,
+    pub scheduled_deletion_at: Option<String>,
+    pub confirmation_required: bool,
+    pub confirmation_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateDeletionRequest {
+    pub reason: Option<String>,
+    pub delete_all_data: Option<bool>,
+    pub data_types: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConfirmDeletionRequest {
+    pub confirmation_token: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DataTypeInfo {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub category: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExportableDataTypes {
+    pub types: Vec<DataTypeInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GdprSummary {
+    pub user_id: String,
+    pub consents: Vec<ConsentResponse>,
+    pub pending_export_requests: i64,
+    pub pending_deletion_requests: i64,
+    pub data_processing_activities_count: i64,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn now_iso() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn export_download_url(id: &str) -> String {
+    format!("/api/gdpr/export/{id}/download")
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+/// GET /api/gdpr/summary
+async fn get_summary(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+) -> ApiResult<impl IntoResponse> {
+    let uid = &auth_user.user_id;
+
+    // Consents
+    let consents = fetch_consents(&pool, uid).await?;
+
+    // Pending export count
+    let pending_exports: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM data_export_requests WHERE user_id = ? AND status IN ('pending','processing')"
+    )
+    .bind(uid)
+    .fetch_one(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    // Pending deletion count
+    let pending_deletions: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM data_deletion_requests WHERE user_id = ? AND status IN ('pending','scheduled')"
+    )
+    .bind(uid)
+    .fetch_one(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    // Processing activities count
+    let activities: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM data_processing_log WHERE user_id = ?"
+    )
+    .bind(uid)
+    .fetch_one(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    Ok(Json(GdprSummary {
+        user_id: uid.clone(),
+        consents,
+        pending_export_requests: pending_exports,
+        pending_deletion_requests: pending_deletions,
+        data_processing_activities_count: activities,
+    }))
+}
+
+// ── Consent management ────────────────────────────────────────────────────────
+
+async fn fetch_consents(pool: &SqlitePool, user_id: &str) -> ApiResult<Vec<ConsentResponse>> {
+    struct Row {
+        consent_type: String,
+        consent_given: bool,
+        consent_version: String,
+        granted_at: Option<String>,
+        revoked_at: Option<String>,
+    }
+
+    let rows = sqlx::query_as!(
+        Row,
+        r#"SELECT consent_type, consent_given as "consent_given: bool",
+                  consent_version, granted_at, revoked_at
+           FROM user_consents WHERE user_id = ?"#,
+        user_id
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| ConsentResponse {
+            consent_type: r.consent_type,
+            consent_given: r.consent_given,
+            consent_version: r.consent_version,
+            granted_at: r.granted_at,
+            revoked_at: r.revoked_at,
+        })
+        .collect())
+}
+
+/// GET /api/gdpr/consents
+async fn get_consents(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+) -> ApiResult<impl IntoResponse> {
+    let consents = fetch_consents(&pool, &auth_user.user_id).await?;
+    Ok(Json(consents))
+}
+
+/// PUT /api/gdpr/consents  (single update)
+async fn update_consent(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Json(req): Json<UpdateConsentRequest>,
+) -> ApiResult<impl IntoResponse> {
+    upsert_consent(&pool, &auth_user.user_id, &req).await?;
+    let updated = fetch_consents(&pool, &auth_user.user_id)
+        .await?
+        .into_iter()
+        .find(|c| c.consent_type == req.consent_type)
+        .ok_or_else(|| ApiError::internal("GDPR_CONSENT_ERROR", "Consent not found after upsert"))?;
+    Ok(Json(updated))
+}
+
+/// PUT /api/gdpr/consents/batch
+async fn batch_update_consents(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Json(req): Json<BatchUpdateConsentsRequest>,
+) -> ApiResult<impl IntoResponse> {
+    for consent in &req.consents {
+        upsert_consent(&pool, &auth_user.user_id, consent).await?;
+    }
+    let consents = fetch_consents(&pool, &auth_user.user_id).await?;
+    Ok(Json(consents))
+}
+
+async fn upsert_consent(
+    pool: &SqlitePool,
+    user_id: &str,
+    req: &UpdateConsentRequest,
+) -> ApiResult<()> {
+    let version = req.consent_version.as_deref().unwrap_or("1.0");
+    let now = now_iso();
+    let granted_at: Option<String> = if req.consent_given { Some(now.clone()) } else { None };
+    let revoked_at: Option<String> = if !req.consent_given { Some(now.clone()) } else { None };
+
+    // Check whether a row already exists for this (user_id, consent_type)
+    let existing_id: Option<String> = sqlx::query_scalar(
+        "SELECT id FROM user_consents WHERE user_id = ? AND consent_type = ? LIMIT 1",
+    )
+    .bind(user_id)
+    .bind(&req.consent_type)
+    .fetch_optional(pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    if let Some(id) = existing_id {
+        // Update existing row
+        sqlx::query!(
+            r#"UPDATE user_consents
+               SET consent_given   = ?,
+                   consent_version = ?,
+                   granted_at      = ?,
+                   revoked_at      = ?,
+                   updated_at      = ?
+               WHERE id = ?"#,
+            req.consent_given,
+            version,
+            granted_at,
+            revoked_at,
+            now,
+            id,
+        )
+        .execute(pool)
+        .await
+        .map_err(ApiError::from)?;
+    } else {
+        // Insert new row
+        let id = Uuid::new_v4().to_string();
+        sqlx::query!(
+            r#"INSERT INTO user_consents
+                   (id, user_id, consent_type, consent_given, consent_version,
+                    granted_at, revoked_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+            id,
+            user_id,
+            req.consent_type,
+            req.consent_given,
+            version,
+            granted_at,
+            revoked_at,
+            now,
+            now,
+        )
+        .execute(pool)
+        .await
+        .map_err(ApiError::from)?;
+    }
+
+    Ok(())
+}
+
+// ── Data export ───────────────────────────────────────────────────────────────
+
+/// GET /api/gdpr/export
+async fn list_export_requests(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+) -> ApiResult<impl IntoResponse> {
+    struct Row {
+        id: String,
+        status: String,
+        requested_at: String,
+        expires_at: Option<String>,
+    }
+
+    let rows = sqlx::query_as!(
+        Row,
+        "SELECT id, status, requested_at, expires_at FROM data_export_requests WHERE user_id = ? ORDER BY requested_at DESC",
+        auth_user.user_id
+    )
+    .fetch_all(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    let list: Vec<ExportRequestResponse> = rows
+        .into_iter()
+        .map(|r| {
+            let download_url = if r.status == "completed" {
+                Some(export_download_url(&r.id))
+            } else {
+                None
+            };
+            ExportRequestResponse {
+                id: r.id,
+                status: r.status,
+                requested_at: r.requested_at,
+                expires_at: r.expires_at,
+                download_url,
+            }
+        })
+        .collect();
+
+    Ok(Json(list))
+}
+
+/// POST /api/gdpr/export
+async fn create_export_request(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Json(req): Json<CreateExportRequest>,
+) -> ApiResult<impl IntoResponse> {
+    if req.data_types.is_empty() {
+        return Err(ApiError::bad_request(
+            "INVALID_EXPORT_REQUEST",
+            "At least one data type must be selected",
+        ));
+    }
+
+    let id = Uuid::new_v4().to_string();
+    let now = now_iso();
+    let expires_at = (Utc::now() + chrono::Duration::days(7)).to_rfc3339();
+    let format = req.export_format.as_deref().unwrap_or("json");
+    let types_json = serde_json::to_string(&req.data_types)
+        .unwrap_or_else(|_| "[]".to_string());
+
+    sqlx::query!(
+        r#"INSERT INTO data_export_requests
+               (id, user_id, status, requested_data_types, export_format, requested_at, expires_at)
+           VALUES (?, ?, 'pending', ?, ?, ?, ?)"#,
+        id,
+        auth_user.user_id,
+        types_json,
+        format,
+        now,
+        expires_at,
+    )
+    .execute(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ExportRequestResponse {
+            id,
+            status: "pending".to_string(),
+            requested_at: now,
+            expires_at: Some(expires_at),
+            download_url: None,
+        }),
+    ))
+}
+
+/// GET /api/gdpr/export/:id
+async fn get_export_request(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Path(id): Path<String>,
+) -> ApiResult<impl IntoResponse> {
+    struct Row {
+        id: String,
+        status: String,
+        requested_at: String,
+        expires_at: Option<String>,
+    }
+
+    let row = sqlx::query_as!(
+        Row,
+        "SELECT id, status, requested_at, expires_at FROM data_export_requests WHERE id = ? AND user_id = ?",
+        id,
+        auth_user.user_id,
+    )
+    .fetch_optional(&pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::not_found("EXPORT_REQUEST_NOT_FOUND", "Export request not found"))?;
+
+    let download_url = if row.status == "completed" {
+        Some(export_download_url(&row.id))
+    } else {
+        None
+    };
+
+    Ok(Json(ExportRequestResponse {
+        id: row.id,
+        status: row.status,
+        requested_at: row.requested_at,
+        expires_at: row.expires_at,
+        download_url,
+    }))
+}
+
+/// GET /api/gdpr/export-types
+async fn get_export_types() -> ApiResult<impl IntoResponse> {
+    Ok(Json(ExportableDataTypes {
+        types: vec![
+            DataTypeInfo {
+                id: "profile".to_string(),
+                name: "Profile Information".to_string(),
+                description: "Your account profile data including name and email".to_string(),
+                category: "Account".to_string(),
+            },
+            DataTypeInfo {
+                id: "consents".to_string(),
+                name: "Privacy Consents".to_string(),
+                description: "History of your privacy consent choices".to_string(),
+                category: "Privacy".to_string(),
+            },
+            DataTypeInfo {
+                id: "api_keys".to_string(),
+                name: "API Keys".to_string(),
+                description: "Your generated API key metadata (secrets are not included)".to_string(),
+                category: "Security".to_string(),
+            },
+            DataTypeInfo {
+                id: "alert_rules".to_string(),
+                name: "Alert Rules".to_string(),
+                description: "Your configured threshold alert rules".to_string(),
+                category: "Alerts".to_string(),
+            },
+            DataTypeInfo {
+                id: "webhooks".to_string(),
+                name: "Webhooks".to_string(),
+                description: "Your registered webhook endpoints".to_string(),
+                category: "Integrations".to_string(),
+            },
+            DataTypeInfo {
+                id: "activity_log".to_string(),
+                name: "Activity Log".to_string(),
+                description: "Records of data processing activities on your account".to_string(),
+                category: "Audit".to_string(),
+            },
+        ],
+    }))
+}
+
+// ── Data deletion ─────────────────────────────────────────────────────────────
+
+/// GET /api/gdpr/deletion
+async fn list_deletion_requests(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+) -> ApiResult<impl IntoResponse> {
+    struct Row {
+        id: String,
+        status: String,
+        requested_at: String,
+        scheduled_deletion_at: Option<String>,
+        confirmation_token: Option<String>,
+    }
+
+    let rows = sqlx::query_as!(
+        Row,
+        "SELECT id, status, requested_at, scheduled_deletion_at, confirmation_token FROM data_deletion_requests WHERE user_id = ? ORDER BY requested_at DESC",
+        auth_user.user_id,
+    )
+    .fetch_all(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    let list: Vec<DeletionRequestResponse> = rows
+        .into_iter()
+        .map(|r| {
+            let confirmation_required = r.confirmation_token.is_some();
+            DeletionRequestResponse {
+                id: r.id,
+                status: r.status,
+                requested_at: r.requested_at,
+                scheduled_deletion_at: r.scheduled_deletion_at,
+                confirmation_required,
+                confirmation_token: r.confirmation_token,
+            }
+        })
+        .collect();
+
+    Ok(Json(list))
+}
+
+/// POST /api/gdpr/deletion
+async fn create_deletion_request(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Json(req): Json<CreateDeletionRequest>,
+) -> ApiResult<impl IntoResponse> {
+    let id = Uuid::new_v4().to_string();
+    let now = now_iso();
+    // Schedule deletion 30 days out to allow a cancellation window
+    let scheduled = (Utc::now() + chrono::Duration::days(30)).to_rfc3339();
+    let confirmation_token = Uuid::new_v4().to_string();
+    let delete_all = req.delete_all_data.unwrap_or(true);
+    let data_types_json: Option<String> = req
+        .data_types
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+
+    sqlx::query!(
+        r#"INSERT INTO data_deletion_requests
+               (id, user_id, status, reason, delete_all_data, data_types_to_delete,
+                requested_at, scheduled_deletion_at, confirmation_token)
+           VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?)"#,
+        id,
+        auth_user.user_id,
+        req.reason,
+        delete_all,
+        data_types_json,
+        now,
+        scheduled,
+        confirmation_token,
+    )
+    .execute(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(DeletionRequestResponse {
+            id,
+            status: "pending".to_string(),
+            requested_at: now,
+            scheduled_deletion_at: Some(scheduled),
+            confirmation_required: true,
+            confirmation_token: Some(confirmation_token),
+        }),
+    ))
+}
+
+/// GET /api/gdpr/deletion/:id
+async fn get_deletion_request(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Path(id): Path<String>,
+) -> ApiResult<impl IntoResponse> {
+    struct Row {
+        id: String,
+        status: String,
+        requested_at: String,
+        scheduled_deletion_at: Option<String>,
+        confirmation_token: Option<String>,
+    }
+
+    let row = sqlx::query_as!(
+        Row,
+        "SELECT id, status, requested_at, scheduled_deletion_at, confirmation_token FROM data_deletion_requests WHERE id = ? AND user_id = ?",
+        id,
+        auth_user.user_id,
+    )
+    .fetch_optional(&pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::not_found("DELETION_REQUEST_NOT_FOUND", "Deletion request not found"))?;
+
+    let confirmation_required = row.confirmation_token.is_some();
+    Ok(Json(DeletionRequestResponse {
+        id: row.id,
+        status: row.status,
+        requested_at: row.requested_at,
+        scheduled_deletion_at: row.scheduled_deletion_at,
+        confirmation_required,
+        confirmation_token: row.confirmation_token,
+    }))
+}
+
+/// POST /api/gdpr/deletion/:id/cancel
+async fn cancel_deletion_request(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Path(id): Path<String>,
+) -> ApiResult<impl IntoResponse> {
+    let now = now_iso();
+    let result = sqlx::query!(
+        "UPDATE data_deletion_requests SET status = 'cancelled', cancelled_at = ? WHERE id = ? AND user_id = ? AND status IN ('pending', 'scheduled')",
+        now,
+        id,
+        auth_user.user_id,
+    )
+    .execute(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    if result.rows_affected() == 0 {
+        return Err(ApiError::not_found(
+            "DELETION_REQUEST_NOT_FOUND",
+            "Deletion request not found or cannot be cancelled",
+        ));
+    }
+
+    struct Row {
+        id: String,
+        status: String,
+        requested_at: String,
+        scheduled_deletion_at: Option<String>,
+        confirmation_token: Option<String>,
+    }
+
+    let row = sqlx::query_as!(
+        Row,
+        "SELECT id, status, requested_at, scheduled_deletion_at, confirmation_token FROM data_deletion_requests WHERE id = ? AND user_id = ?",
+        id,
+        auth_user.user_id,
+    )
+    .fetch_optional(&pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::internal("GDPR_ERROR", "Failed to retrieve updated request"))?;
+
+    Ok(Json(DeletionRequestResponse {
+        id: row.id,
+        status: row.status,
+        requested_at: row.requested_at,
+        scheduled_deletion_at: row.scheduled_deletion_at,
+        confirmation_required: false,
+        confirmation_token: None,
+    }))
+}
+
+/// POST /api/gdpr/deletion/confirm
+async fn confirm_deletion(
+    State(pool): State<SqlitePool>,
+    auth_user: AuthUser,
+    Json(req): Json<ConfirmDeletionRequest>,
+) -> ApiResult<impl IntoResponse> {
+    // Fetch the request first to get its id
+    let existing_id: Option<String> = sqlx::query_scalar(
+        "SELECT id FROM data_deletion_requests WHERE confirmation_token = ? AND user_id = ? AND status = 'pending'"
+    )
+    .bind(&req.confirmation_token)
+    .bind(&auth_user.user_id)
+    .fetch_optional(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    let request_id = existing_id.ok_or_else(|| {
+        ApiError::bad_request(
+            "INVALID_CONFIRMATION_TOKEN",
+            "Invalid or already-used confirmation token",
+        )
+    })?;
+
+    sqlx::query!(
+        "UPDATE data_deletion_requests SET status = 'scheduled' WHERE id = ?",
+        request_id,
+    )
+    .execute(&pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    struct Row {
+        id: String,
+        status: String,
+        requested_at: String,
+        scheduled_deletion_at: Option<String>,
+        confirmation_token: Option<String>,
+    }
+
+    let row = sqlx::query_as!(
+        Row,
+        "SELECT id, status, requested_at, scheduled_deletion_at, confirmation_token FROM data_deletion_requests WHERE id = ?",
+        request_id,
+    )
+    .fetch_optional(&pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::internal("GDPR_ERROR", "Failed to retrieve updated request"))?;
+
+    Ok(Json(DeletionRequestResponse {
+        id: row.id,
+        status: row.status,
+        requested_at: row.requested_at,
+        scheduled_deletion_at: row.scheduled_deletion_at,
+        confirmation_required: false,
+        confirmation_token: row.confirmation_token,
+    }))
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -12,6 +12,7 @@ pub mod cache_stats;
 pub mod corridors;
 pub mod cost_calculator;
 pub mod export;
+pub mod gdpr;
 // pub mod digest;  // Commented out - depends on email module
 pub mod api_analytics;
 pub mod contract_events;

--- a/backend/src/api/v1/mod.rs
+++ b/backend/src/api/v1/mod.rs
@@ -149,6 +149,11 @@ pub fn routes(
         .nest("/webhooks", webhooks::routes(pool.clone()))
         .layer(middleware::from_fn(auth_middleware));
 
+    // GDPR endpoints — require auth; mounted at /api/gdpr
+    let gdpr_routes = Router::new()
+        .nest("/gdpr", crate::api::gdpr::routes(pool.clone()))
+        .layer(middleware::from_fn(auth_middleware));
+
     // 4. RPC routes
     let rpc_routes = Router::new()
         .route("/rpc/health", get(rpc::rpc_health_check))
@@ -187,6 +192,7 @@ pub fn routes(
         .merge(export_routes)
         .merge(protected_routes)
         .merge(protected_webhook_routes)
+        .merge(gdpr_routes)
         .merge(rpc_routes)
         .merge(service_routes)
         .merge(oauth_routes);

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,3 +10,9 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 # App
 NEXT_PUBLIC_APP_VERSION=
+
+# Internal monitoring route access control (server-side only, never NEXT_PUBLIC_)
+# Set to any strong random string. Requests to /[locale]/internal/monitoring must
+# carry this value in the X-Internal-Token header or internal_token cookie.
+# If unset in development the gate is skipped; in production it blocks all access.
+INTERNAL_SECRET=

--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -1,0 +1,819 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Stellar Insights API",
+    "description": "API for Stellar network analytics, anchor monitoring, and payment corridor insights",
+    "contact": {
+      "name": "Stellar Insights Team",
+      "email": "support@stellarinsights.io"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Local development server"
+    },
+    {
+      "url": "https://api.stellarinsights.io",
+      "description": "Production server"
+    }
+  ],
+  "paths": {
+    "/api/anchors": {
+      "get": {
+        "tags": ["Anchors"],
+        "summary": "List anchors",
+        "operationId": "get_anchors",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of anchors",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnchorsResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/anchors/{anchor_id}": {
+      "get": {
+        "tags": ["Anchors"],
+        "summary": "Get anchor by ID",
+        "operationId": "get_anchor",
+        "parameters": [
+          {
+            "name": "anchor_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Anchor details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnchorMetricsResponse" }
+              }
+            }
+          },
+          "404": { "description": "Anchor not found" }
+        }
+      }
+    },
+    "/api/anchors/account/{account_id}": {
+      "get": {
+        "tags": ["Anchors"],
+        "summary": "Get anchor by Stellar account ID",
+        "operationId": "get_anchor_by_account",
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Anchor details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AnchorMetricsResponse" }
+              }
+            }
+          },
+          "404": { "description": "Anchor not found" }
+        }
+      }
+    },
+    "/api/corridors": {
+      "get": {
+        "tags": ["Corridors"],
+        "summary": "List payment corridors",
+        "operationId": "list_corridors",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of corridors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CorridorResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/corridors/{corridor_id}": {
+      "get": {
+        "tags": ["Corridors"],
+        "summary": "Get corridor detail",
+        "operationId": "get_corridor_detail",
+        "parameters": [
+          {
+            "name": "corridor_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Corridor details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CorridorDetailResponse" }
+              }
+            }
+          },
+          "404": { "description": "Corridor not found" }
+        }
+      }
+    },
+    "/api/price/{asset}": {
+      "get": {
+        "tags": ["Prices"],
+        "summary": "Get price for a single asset",
+        "operationId": "get_price",
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset price",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PriceResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prices": {
+      "get": {
+        "tags": ["Prices"],
+        "summary": "Get prices for multiple assets",
+        "operationId": "get_prices",
+        "parameters": [
+          {
+            "name": "assets",
+            "in": "query",
+            "schema": { "type": "string", "description": "Comma-separated asset codes" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset prices",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PricesResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/cost/estimate": {
+      "post": {
+        "tags": ["Cost Calculator"],
+        "summary": "Estimate cross-border payment costs",
+        "operationId": "estimate_costs",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CostCalculationRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cost estimation result",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CostCalculationResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/alerts/rules": {
+      "get": {
+        "tags": ["Alerts"],
+        "summary": "List alert rules",
+        "operationId": "list_rules",
+        "responses": {
+          "200": { "description": "List of alert rules" }
+        }
+      },
+      "post": {
+        "tags": ["Alerts"],
+        "summary": "Create an alert rule",
+        "operationId": "create_rule",
+        "responses": {
+          "201": { "description": "Alert rule created" }
+        }
+      }
+    },
+    "/api/alerts/rules/{rule_id}": {
+      "put": {
+        "tags": ["Alerts"],
+        "summary": "Update an alert rule",
+        "operationId": "update_rule",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Alert rule updated" }
+        }
+      },
+      "delete": {
+        "tags": ["Alerts"],
+        "summary": "Delete an alert rule",
+        "operationId": "delete_rule",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Alert rule deleted" }
+        }
+      }
+    },
+    "/api/alerts/history": {
+      "get": {
+        "tags": ["Alerts"],
+        "summary": "List alert history",
+        "operationId": "list_history",
+        "responses": {
+          "200": { "description": "Alert history" }
+        }
+      }
+    },
+    "/api/transactions": {
+      "post": {
+        "tags": ["Transactions"],
+        "summary": "Create a transaction",
+        "operationId": "create_transaction",
+        "responses": {
+          "200": { "description": "Transaction created" }
+        }
+      }
+    },
+    "/api/transactions/{transaction_id}": {
+      "get": {
+        "tags": ["Transactions"],
+        "summary": "Get transaction by ID",
+        "operationId": "get_transaction",
+        "parameters": [
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Transaction details" },
+          "404": { "description": "Transaction not found" }
+        }
+      }
+    },
+    "/api/metrics": {
+      "get": {
+        "tags": ["Metrics"],
+        "summary": "Get system metrics overview",
+        "operationId": "metrics_overview",
+        "responses": {
+          "200": { "description": "Metrics overview" }
+        }
+      }
+    },
+    "/api/network": {
+      "get": {
+        "tags": ["Network"],
+        "summary": "Get network info",
+        "operationId": "get_network_info",
+        "responses": {
+          "200": { "description": "Network information" }
+        }
+      }
+    },
+    "/api/rpc/health": {
+      "get": {
+        "tags": ["RPC"],
+        "summary": "RPC health check",
+        "operationId": "rpc_health_check",
+        "responses": {
+          "200": { "description": "RPC is healthy" }
+        }
+      }
+    },
+    "/api/rpc/ledger/latest": {
+      "get": {
+        "tags": ["RPC"],
+        "summary": "Get latest ledger",
+        "operationId": "get_latest_ledger",
+        "responses": {
+          "200": { "description": "Latest ledger info" }
+        }
+      }
+    },
+    "/api/rpc/payments": {
+      "get": {
+        "tags": ["RPC"],
+        "summary": "Get payments",
+        "operationId": "get_payments",
+        "responses": {
+          "200": { "description": "Payment list" }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Login",
+        "operationId": "login",
+        "responses": {
+          "200": { "description": "Authentication token" }
+        }
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Refresh token",
+        "operationId": "refresh",
+        "responses": {
+          "200": { "description": "Refreshed token" }
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Logout",
+        "operationId": "logout",
+        "responses": {
+          "204": { "description": "Logged out" }
+        }
+      }
+    },
+    "/api/webhooks": {
+      "get": {
+        "tags": ["Webhooks"],
+        "summary": "List webhooks",
+        "operationId": "list_webhooks",
+        "responses": {
+          "200": { "description": "Webhook list" }
+        }
+      },
+      "post": {
+        "tags": ["Webhooks"],
+        "summary": "Register a webhook",
+        "operationId": "register_webhook",
+        "responses": {
+          "201": { "description": "Webhook registered" }
+        }
+      }
+    },
+    "/api/webhooks/{webhook_id}": {
+      "get": {
+        "tags": ["Webhooks"],
+        "summary": "Get webhook",
+        "operationId": "get_webhook",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Webhook details" }
+        }
+      },
+      "delete": {
+        "tags": ["Webhooks"],
+        "summary": "Delete webhook",
+        "operationId": "delete_webhook",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Webhook deleted" }
+        }
+      }
+    },
+    "/api/governance/proposals": {
+      "get": {
+        "tags": ["Governance"],
+        "summary": "List governance proposals",
+        "operationId": "list_proposals",
+        "responses": {
+          "200": { "description": "Proposals list" }
+        }
+      },
+      "post": {
+        "tags": ["Governance"],
+        "summary": "Create governance proposal",
+        "operationId": "create_proposal",
+        "responses": {
+          "201": { "description": "Proposal created" }
+        }
+      }
+    },
+    "/api/sep10/info": {
+      "get": {
+        "tags": ["SEP-10"],
+        "summary": "SEP-10 info",
+        "operationId": "sep10_get_info",
+        "responses": {
+          "200": { "description": "SEP-10 server info" }
+        }
+      }
+    },
+    "/api/sep10/challenge": {
+      "get": {
+        "tags": ["SEP-10"],
+        "summary": "Request SEP-10 challenge",
+        "operationId": "request_challenge",
+        "responses": {
+          "200": { "description": "Challenge transaction" }
+        }
+      }
+    },
+    "/api/liquidity-pools": {
+      "get": {
+        "tags": ["Liquidity Pools"],
+        "summary": "List liquidity pools",
+        "operationId": "list_pools",
+        "responses": {
+          "200": { "description": "Liquidity pool list" }
+        }
+      }
+    },
+    "/api/api-keys": {
+      "get": {
+        "tags": ["API Keys"],
+        "summary": "List API keys",
+        "operationId": "list_api_keys",
+        "responses": {
+          "200": { "description": "API key list" }
+        }
+      },
+      "post": {
+        "tags": ["API Keys"],
+        "summary": "Create API key",
+        "operationId": "create_api_key",
+        "responses": {
+          "201": { "description": "API key created" }
+        }
+      }
+    },
+    "/api/assets/verify": {
+      "post": {
+        "tags": ["Asset Verification"],
+        "summary": "Verify an asset",
+        "operationId": "verify_asset",
+        "responses": {
+          "200": { "description": "Verification result" }
+        }
+      }
+    },
+    "/api/assets/verified": {
+      "get": {
+        "tags": ["Asset Verification"],
+        "summary": "List verified assets",
+        "operationId": "list_verified_assets",
+        "responses": {
+          "200": { "description": "Verified asset list" }
+        }
+      }
+    },
+    "/api/ml/predict": {
+      "post": {
+        "tags": ["ML"],
+        "summary": "Predict payment success",
+        "operationId": "predict_payment_success",
+        "responses": {
+          "200": { "description": "Prediction result" }
+        }
+      }
+    },
+    "/api/ml/status": {
+      "get": {
+        "tags": ["ML"],
+        "summary": "Get ML model status",
+        "operationId": "get_model_status",
+        "responses": {
+          "200": { "description": "Model status" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AnchorsResponse": {
+        "type": "object",
+        "properties": {
+          "anchors": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AnchorMetricsResponse" }
+          },
+          "total": { "type": "integer" }
+        }
+      },
+      "AnchorMetricsResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "home_domain": { "type": "string" },
+          "account_id": { "type": "string" },
+          "success_rate": { "type": "number", "format": "double" },
+          "total_transactions": { "type": "integer", "format": "int64" },
+          "volume_usd": { "type": "number", "format": "double" },
+          "avg_latency_ms": { "type": "number", "format": "double" }
+        }
+      },
+      "CorridorResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" },
+          "success_rate": { "type": "number", "format": "double" },
+          "volume_usd": { "type": "number", "format": "double" },
+          "avg_latency_ms": { "type": "number", "format": "double" }
+        }
+      },
+      "CorridorDetailResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" },
+          "success_rate": { "type": "number", "format": "double" },
+          "volume_usd": { "type": "number", "format": "double" },
+          "avg_latency_ms": { "type": "number", "format": "double" },
+          "success_rate_history": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/SuccessRateDataPoint" }
+          },
+          "latency_history": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/LatencyDataPoint" }
+          },
+          "liquidity_history": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/LiquidityDataPoint" }
+          }
+        }
+      },
+      "SuccessRateDataPoint": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "value": { "type": "number", "format": "double" }
+        }
+      },
+      "LatencyDataPoint": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "value_ms": { "type": "number", "format": "double" }
+        }
+      },
+      "LiquidityDataPoint": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "value_usd": { "type": "number", "format": "double" }
+        }
+      },
+      "PriceResponse": {
+        "type": "object",
+        "properties": {
+          "asset": { "type": "string" },
+          "price_usd": { "type": "number", "format": "double" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "PricesResponse": {
+        "type": "object",
+        "properties": {
+          "prices": {
+            "type": "object",
+            "additionalProperties": { "type": "number", "format": "double" }
+          },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "ConvertResponse": {
+        "type": "object",
+        "properties": {
+          "from_asset": { "type": "string" },
+          "from_amount": { "type": "number", "format": "double" },
+          "usd_amount": { "type": "number", "format": "double" }
+        }
+      },
+      "CacheStatsResponse": {
+        "type": "object",
+        "properties": {
+          "hits": { "type": "integer", "format": "int64" },
+          "misses": { "type": "integer", "format": "int64" },
+          "hit_rate": { "type": "number", "format": "double" }
+        }
+      },
+      "PaymentRoute": {
+        "type": "object",
+        "properties": {
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" },
+          "anchor_id": { "type": "string" }
+        }
+      },
+      "CostCalculationRequest": {
+        "type": "object",
+        "required": ["amount_usd", "source_asset", "destination_asset"],
+        "properties": {
+          "amount_usd": { "type": "number", "format": "double" },
+          "source_asset": { "type": "string" },
+          "destination_asset": { "type": "string" }
+        }
+      },
+      "RouteCostBreakdown": {
+        "type": "object",
+        "properties": {
+          "anchor_fee_usd": { "type": "number", "format": "double" },
+          "network_fee_xlm": { "type": "number", "format": "double" },
+          "network_fee_usd": { "type": "number", "format": "double" },
+          "spread_usd": { "type": "number", "format": "double" },
+          "total_cost_usd": { "type": "number", "format": "double" }
+        }
+      },
+      "RouteEstimate": {
+        "type": "object",
+        "properties": {
+          "route": { "$ref": "#/components/schemas/PaymentRoute" },
+          "cost": { "$ref": "#/components/schemas/RouteCostBreakdown" },
+          "estimated_time_seconds": { "type": "integer" }
+        }
+      },
+      "CostCalculationResponse": {
+        "type": "object",
+        "properties": {
+          "routes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RouteEstimate" }
+          },
+          "best_route": { "$ref": "#/components/schemas/RouteEstimate" }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "code": { "type": "string" }
+        }
+      },
+      "SnapshotResponse": {
+        "type": "object",
+        "properties": {
+          "snapshot_id": { "type": "string" },
+          "contract_id": { "type": "string" },
+          "data_hash": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "SubmissionInfo": {
+        "type": "object",
+        "properties": {
+          "transaction_hash": { "type": "string" },
+          "submitted_at": { "type": "string", "format": "date-time" },
+          "status": { "type": "string" }
+        }
+      },
+      "GenerateSnapshotRequest": {
+        "type": "object",
+        "required": ["contract_id"],
+        "properties": {
+          "contract_id": { "type": "string" },
+          "include_metrics": { "type": "boolean", "default": true }
+        }
+      },
+      "ContractHealthResponse": {
+        "type": "object",
+        "properties": {
+          "contract_id": { "type": "string" },
+          "healthy": { "type": "boolean" },
+          "last_checked": { "type": "string", "format": "date-time" },
+          "issues": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
+  },
+  "tags": [
+    { "name": "Alerts", "description": "Alert management and notification endpoints" },
+    { "name": "Analytics", "description": "API analytics endpoints" },
+    { "name": "Anchors", "description": "Anchor management and metrics endpoints" },
+    { "name": "API Keys", "description": "API key management endpoints" },
+    { "name": "Contract Events", "description": "Smart contract event tracking" },
+    { "name": "Corridors", "description": "Payment corridor analytics endpoints" },
+    { "name": "Fee Bumps", "description": "Fee bump transaction tracking" },
+    { "name": "Liquidity Pools", "description": "Liquidity pool analytics" },
+    { "name": "Metrics", "description": "System metrics and monitoring" },
+    { "name": "ML", "description": "Machine learning prediction endpoints" },
+    { "name": "Network", "description": "Stellar network configuration" },
+    { "name": "Prediction", "description": "Payment prediction endpoints" },
+    { "name": "Prices", "description": "Real-time asset price feed endpoints" },
+    { "name": "Cost Calculator", "description": "Cross-border payment cost estimation and route comparison" },
+    { "name": "RPC", "description": "Stellar RPC integration endpoints" },
+    { "name": "SEP-31", "description": "SEP-31 cross-border payment endpoints" },
+    { "name": "Transactions", "description": "Transaction management endpoints" },
+    { "name": "Trustlines", "description": "Trustline analytics endpoints" },
+    { "name": "Webhooks", "description": "Webhook management endpoints" },
+    { "name": "Account Merges", "description": "Account merge tracking endpoints" },
+    { "name": "Achievements", "description": "Quest and achievement definitions" },
+    { "name": "Asset Verification", "description": "Asset verification and reporting" },
+    { "name": "Auth", "description": "Authentication endpoints" },
+    { "name": "Cache", "description": "Cache management endpoints" },
+    { "name": "Governance", "description": "Governance proposal and voting endpoints" },
+    { "name": "OAuth", "description": "OAuth integration endpoints" },
+    { "name": "SEP-10", "description": "SEP-10 authentication endpoints" },
+    { "name": "SEP-24", "description": "SEP-24 hosted deposit/withdrawal endpoints" },
+    { "name": "Verification Rewards", "description": "Snapshot verification reward endpoints" },
+    { "name": "Snapshots", "description": "Snapshot generation and submission endpoints" }
+  ]
+}

--- a/frontend/src/app/[locale]/internal/monitoring/page.tsx
+++ b/frontend/src/app/[locale]/internal/monitoring/page.tsx
@@ -1,323 +1,83 @@
-"use client";
+import React from "react";
+import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { Activity } from "lucide-react";
+import { JobMonitoringDashboard } from "@/components/JobMonitoringDashboard";
 
-import React, { useState, useEffect } from "react";
-import { MainLayout } from "@/components/layout";
-import {
-  Activity,
-  AlertTriangle,
-  Clock,
-  Globe,
-  Monitor,
-  RefreshCw,
-  Zap,
-} from "lucide-react";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-  AreaChart,
-  Area,
-} from "recharts";
-import { getMockMonitoringStats, MonitoringStats } from "@/lib/mock-monitoring";
+/**
+ * Internal monitoring dashboard — #1828
+ *
+ * Access control: This is a server component. Before rendering anything it
+ * checks that the request carries a valid internal access token.  The token
+ * is compared against the INTERNAL_SECRET environment variable (server-side
+ * only — never a NEXT_PUBLIC_ var so it is never shipped to the browser).
+ *
+ * Two ways to pass the token:
+ *   1. HTTP header:  X-Internal-Token: <secret>
+ *   2. Cookie:       internal_token=<secret>
+ *
+ * If neither is present or the value doesn't match, the visitor is redirected
+ * to "/" instead of receiving a 403 — this avoids leaking that the route
+ * exists at all.
+ *
+ * In development (NODE_ENV !== "production") the gate is skipped when
+ * INTERNAL_SECRET is not set, so local devs can still iterate without
+ * configuring the secret.
+ */
+function isAuthorised(headersList: Headers): boolean {
+  const secret = process.env.INTERNAL_SECRET;
 
-const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#8b5cf6", "#ec4899"];
+  // Dev shortcut: if no secret is configured, allow access in development only
+  if (!secret) {
+    return process.env.NODE_ENV !== "production";
+  }
 
-export default function MonitoringDashboard() {
-  const [stats, setStats] = useState<MonitoringStats | null>(null);
-  const [loading, setLoading] = useState(true);
+  // Check X-Internal-Token header (useful for curl / scripted access)
+  const headerToken = headersList.get("x-internal-token");
+  if (headerToken === secret) return true;
 
-  useEffect(() => {
-    const fetchData = () => {
-      setLoading(true);
-      // Simulate API latency
-      setTimeout(() => {
-        setStats(getMockMonitoringStats());
-        setLoading(false);
-      }, 800);
-    };
+  // Check cookie (useful for browser access after initial auth)
+  const cookieHeader = headersList.get("cookie") ?? "";
+  const match = cookieHeader
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith("internal_token="));
+  if (match) {
+    const cookieToken = match.slice("internal_token=".length);
+    if (cookieToken === secret) return true;
+  }
 
-    fetchData();
-  }, []);
+  return false;
+}
 
-  if (loading || !stats) {
-    return (
-      <MainLayout>
-        <div className="flex items-center justify-center h-screen">
-          <RefreshCw className="w-8 h-8 text-blue-500 animate-spin" />
-        </div>
-      </MainLayout>
-    );
+export const metadata = {
+  title: "Internal Monitoring — Stellar Insights",
+  // Prevent search engines from indexing this internal page
+  robots: "noindex, nofollow",
+};
+
+export default async function MonitoringDashboard() {
+  const headersList = await headers();
+
+  if (!isAuthorised(headersList)) {
+    redirect("/");
   }
 
   return (
-    <MainLayout>
-      <div className="p-6 max-w-7xl mx-auto">
-        <header className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-            <Activity className="text-blue-500" />
-            Internal Performance Dashboard
-          </h1>
-          <p className="text-muted-foreground dark:text-muted-foreground">
-            Real-time monitoring of frontend vitals, API health, and system
-            errors.
-          </p>
-        </header>
+    <div className="p-4 md:p-8 max-w-7xl mx-auto">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold flex items-center gap-2">
+          <Activity className="text-blue-500" aria-hidden="true" />
+          Internal Monitoring
+        </h1>
+        <p className="text-muted-foreground mt-1">
+          Real-time job execution status and system health. This page is
+          internal-only and not publicly accessible.
+        </p>
+      </header>
 
-        {/* KPI Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-sm font-medium text-muted-foreground dark:text-muted-foreground uppercase tracking-wider">
-                Total Sessions
-              </h3>
-              <Globe className="text-blue-500 w-5 h-5" />
-            </div>
-            <p className="text-3xl font-bold dark:text-white">
-              {stats.sessionStats.totalSessions.toLocaleString()}
-            </p>
-            <p className="text-sm text-green-500 mt-2 flex items-center gap-1">
-              <span>↑ 12%</span>
-              <span className="text-muted-foreground font-normal">vs last 24h</span>
-            </p>
-          </div>
-
-          <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-sm font-medium text-muted-foreground dark:text-muted-foreground uppercase tracking-wider">
-                Avg. Session Duration
-              </h3>
-              <Clock className="text-purple-500 w-5 h-5" />
-            </div>
-            <p className="text-3xl font-bold dark:text-white">
-              {Math.floor(stats.sessionStats.avgDuration / 60)}m{" "}
-              {stats.sessionStats.avgDuration % 60}s
-            </p>
-            <p className="text-sm text-muted-foreground mt-2">Target: 5m 00s</p>
-          </div>
-
-          <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-sm font-medium text-muted-foreground dark:text-muted-foreground uppercase tracking-wider">
-                Bounce Rate
-              </h3>
-              <Zap className="text-yellow-500 w-5 h-5" />
-            </div>
-            <p className="text-3xl font-bold dark:text-white">
-              {stats.sessionStats.bounceRate}%
-            </p>
-            <p className="text-sm text-red-500 mt-2 flex items-center gap-1">
-              <span>↑ 2.1%</span>
-              <span className="text-muted-foreground font-normal">vs last 24h</span>
-            </p>
-          </div>
-        </div>
-
-        {/* Charts Section */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
-          {/* Page Load Times */}
-          <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm">
-            <h3 className="text-lg font-semibold mb-6 dark:text-white flex items-center gap-2">
-              <Clock size={18} className="text-blue-500" />
-              Page Load Times (Seconds)
-            </h3>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={stats.pageLoadTimes}>
-                  <defs>
-                    <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-                      <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    vertical={false}
-                    stroke="#374151"
-                    opacity={0.1}
-                  />
-                  <XAxis
-                    dataKey="timestamp"
-                    stroke="#94a3b8"
-                    fontSize={12}
-                    tickLine={false}
-                    axisLine={false}
-                  />
-                  <YAxis
-                    stroke="#94a3b8"
-                    fontSize={12}
-                    tickLine={false}
-                    axisLine={false}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: "#1e293b",
-                      border: "none",
-                      borderRadius: "8px",
-                      color: "#fff",
-                    }}
-                    itemStyle={{ color: "#60a5fa" }}
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="value"
-                    stroke="#3b82f6"
-                    fillOpacity={1}
-                    fill="url(#colorValue)"
-                  />
-                </AreaChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
-
-          {/* Error Rate */}
-          <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm">
-            <h3 className="text-lg font-semibold mb-6 dark:text-white flex items-center gap-2">
-              <AlertTriangle size={18} className="text-red-500" />
-              Error Frequency
-            </h3>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={stats.errorRates}>
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    vertical={false}
-                    stroke="#374151"
-                    opacity={0.1}
-                  />
-                  <XAxis
-                    dataKey="timestamp"
-                    stroke="#94a3b8"
-                    fontSize={12}
-                    tickLine={false}
-                    axisLine={false}
-                  />
-                  <YAxis
-                    stroke="#94a3b8"
-                    fontSize={12}
-                    tickLine={false}
-                    axisLine={false}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: "#1e293b",
-                      border: "none",
-                      borderRadius: "8px",
-                      color: "#fff",
-                    }}
-                    cursor={{ fill: "#334155", opacity: 0.4 }}
-                  />
-                  <Bar dataKey="count" fill="#ef4444" radius={[4, 4, 0, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-8">
-          {/* API Latency */}
-          <div className="lg:col-span-2 bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm">
-            <h3 className="text-lg font-semibold mb-6 dark:text-white flex items-center gap-2">
-              <Zap size={18} className="text-yellow-500" />
-              API Response Times (ms)
-            </h3>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart
-                  layout="vertical"
-                  data={stats.apiLatencies}
-                  margin={{ left: 40 }}
-                >
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    horizontal={false}
-                    stroke="#374151"
-                    opacity={0.1}
-                  />
-                  <XAxis
-                    type="number"
-                    stroke="#94a3b8"
-                    fontSize={12}
-                    tickLine={false}
-                    axisLine={false}
-                  />
-                  <YAxis
-                    type="category"
-                    dataKey="endpoint"
-                    stroke="#94a3b8"
-                    fontSize={10}
-                    tickLine={false}
-                    axisLine={false}
-                    width={80}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: "#1e293b",
-                      border: "none",
-                      borderRadius: "8px",
-                      color: "#fff",
-                    }}
-                  />
-                  <Bar dataKey="latency" fill="#f59e0b" radius={[0, 4, 4, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
-
-          {/* Browser / Device breakdown */}
-          <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm">
-            <h3 className="text-lg font-semibold mb-6 dark:text-white flex items-center gap-2">
-              <Monitor size={18} className="text-purple-500" />
-              Browser Breakdown
-            </h3>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    data={stats.browserBreakdown}
-                    innerRadius={60}
-                    outerRadius={80}
-                    paddingAngle={5}
-                    dataKey="value"
-                  >
-                    {stats.browserBreakdown.map((entry, index) => (
-                      <Cell
-                        key={`cell-${index}`}
-                        fill={COLORS[index % COLORS.length]}
-                      />
-                    ))}
-                  </Pie>
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: "#1e293b",
-                      border: "none",
-                      borderRadius: "8px",
-                      color: "#fff",
-                    }}
-                  />
-                </PieChart>
-              </ResponsiveContainer>
-            </div>
-            <div className="mt-4 flex flex-wrap justify-center gap-4">
-              {stats.browserBreakdown.map((entry, index) => (
-                <div key={entry.name} className="flex items-center gap-1">
-                  <div
-                    className="w-3 h-3 rounded-full"
-                    style={{ backgroundColor: COLORS[index % COLORS.length] }}
-                  ></div>
-                  <span className="text-xs text-muted-foreground">{entry.name}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </MainLayout>
+      {/* JobMonitoringDashboard fetches /api/v1/jobs/status from the real backend */}
+      <JobMonitoringDashboard />
+    </div>
   );
 }

--- a/frontend/src/app/[locale]/settings/gdpr/page.tsx
+++ b/frontend/src/app/[locale]/settings/gdpr/page.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { ConsentManager, DataExport, DataDeletion } from "@/components/gdpr";
+import { getGdprSummary, GdprSummary } from "@/lib/gdpr-api";
+
+type TabType = "overview" | "consents" | "export" | "deletion";
+
+export default function GdprSettingsPage() {
+  const [activeTab, setActiveTab] = useState<TabType>("overview");
+  const [summary, setSummary] = useState<GdprSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadSummary();
+  }, []);
+
+  const loadSummary = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getGdprSummary();
+      setSummary(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load GDPR summary",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderOverview = () => (
+    <div className="space-y-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Your Data Rights
+        </h3>
+        <p className="text-muted-foreground dark:text-muted-foreground mb-6">
+          Under the General Data Protection Regulation (GDPR), you have certain
+          rights regarding your personal data. This page allows you to manage
+          your data in accordance with these rights.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {/* Privacy Preferences Card */}
+          <button
+            onClick={() => setActiveTab("consents")}
+            className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg text-left hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+          >
+            <div className="flex items-center mb-2">
+              <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mr-3">
+                <svg
+                  className="w-5 h-5 text-blue-600 dark:text-link-primary"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                  />
+                </svg>
+              </div>
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-white">
+                  Privacy Preferences
+                </h4>
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">
+                  Manage your consent settings
+                </p>
+              </div>
+            </div>
+            {summary && (
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+                {summary.consents.filter((c) => c.consent_given).length} of{" "}
+                {summary.consents.length} consents granted
+              </p>
+            )}
+          </button>
+
+          {/* Export Data Card */}
+          <button
+            onClick={() => setActiveTab("export")}
+            className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg text-left hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+          >
+            <div className="flex items-center mb-2">
+              <div className="w-10 h-10 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mr-3">
+                <svg
+                  className="w-5 h-5 text-green-600 dark:text-green-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                  />
+                </svg>
+              </div>
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-white">
+                  Export Your Data
+                </h4>
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">
+                  Download a copy of your data
+                </p>
+              </div>
+            </div>
+            {summary && summary.pending_export_requests > 0 && (
+              <p className="text-sm text-orange-600 dark:text-orange-400">
+                {summary.pending_export_requests} pending request(s)
+              </p>
+            )}
+          </button>
+
+          {/* Delete Data Card */}
+          <button
+            onClick={() => setActiveTab("deletion")}
+            className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg text-left hover:border-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+          >
+            <div className="flex items-center mb-2">
+              <div className="w-10 h-10 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center mr-3">
+                <svg
+                  className="w-5 h-5 text-red-600 dark:text-red-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </div>
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-white">
+                  Delete Your Data
+                </h4>
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">
+                  Request data deletion
+                </p>
+              </div>
+            </div>
+            {summary && summary.pending_deletion_requests > 0 && (
+              <p className="text-sm text-orange-600 dark:text-orange-400">
+                {summary.pending_deletion_requests} pending request(s)
+              </p>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Data Processing Info */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Data Processing Activities
+        </h3>
+        <p className="text-muted-foreground dark:text-muted-foreground">
+          We have recorded{" "}
+          <span className="font-medium text-gray-900 dark:text-white">
+            {summary?.data_processing_activities_count || 0}
+          </span>{" "}
+          data processing activities associated with your account.
+        </p>
+      </div>
+
+      {/* GDPR Information */}
+      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
+        <h3 className="text-lg font-semibold text-blue-900 dark:text-link-primary mb-2">
+          Your GDPR Rights
+        </h3>
+        <ul className="space-y-2 text-sm text-blue-800 dark:text-blue-300">
+          <li className="flex items-start">
+            <svg
+              className="w-5 h-5 mr-2 mt-0.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span>
+              <strong>Right to Access:</strong> You can request a copy of all
+              personal data we hold about you.
+            </span>
+          </li>
+          <li className="flex items-start">
+            <svg
+              className="w-5 h-5 mr-2 mt-0.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span>
+              <strong>Right to Rectification:</strong> You can ask us to correct
+              inaccurate personal data.
+            </span>
+          </li>
+          <li className="flex items-start">
+            <svg
+              className="w-5 h-5 mr-2 mt-0.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span>
+              <strong>Right to Erasure:</strong> You can request deletion of
+              your personal data (&quot;right to be forgotten&quot;).
+            </span>
+          </li>
+          <li className="flex items-start">
+            <svg
+              className="w-5 h-5 mr-2 mt-0.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span>
+              <strong>Right to Data Portability:</strong> You can receive your
+              data in a machine-readable format.
+            </span>
+          </li>
+          <li className="flex items-start">
+            <svg
+              className="w-5 h-5 mr-2 mt-0.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span>
+              <strong>Right to Withdraw Consent:</strong> You can withdraw your
+              consent at any time.
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Privacy Settings
+          </h1>
+          <p className="text-muted-foreground dark:text-muted-foreground mt-2">
+            Manage your data, privacy preferences, and exercise your GDPR rights
+          </p>
+        </div>
+
+        {/* Error Display */}
+        {error && (
+          <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          </div>
+        )}
+
+        {/* Tab Navigation */}
+        <div className="flex border-b border-gray-200 dark:border-gray-700 mb-6">
+          <button
+            onClick={() => setActiveTab("overview")}
+            className={`px-4 py-2 font-medium text-sm ${
+              activeTab === "overview"
+                ? "border-b-2 border-blue-600 text-blue-600 dark:text-link-primary"
+                : "text-muted-foreground dark:text-muted-foreground hover:text-gray-700 dark:hover:text-gray-200"
+            }`}
+          >
+            Overview
+          </button>
+          <button
+            onClick={() => setActiveTab("consents")}
+            className={`px-4 py-2 font-medium text-sm ${
+              activeTab === "consents"
+                ? "border-b-2 border-blue-600 text-blue-600 dark:text-link-primary"
+                : "text-muted-foreground dark:text-muted-foreground hover:text-gray-700 dark:hover:text-gray-200"
+            }`}
+          >
+            Consents
+          </button>
+          <button
+            onClick={() => setActiveTab("export")}
+            className={`px-4 py-2 font-medium text-sm ${
+              activeTab === "export"
+                ? "border-b-2 border-blue-600 text-blue-600 dark:text-link-primary"
+                : "text-muted-foreground dark:text-muted-foreground hover:text-gray-700 dark:hover:text-gray-200"
+            }`}
+          >
+            Export Data
+          </button>
+          <button
+            onClick={() => setActiveTab("deletion")}
+            className={`px-4 py-2 font-medium text-sm ${
+              activeTab === "deletion"
+                ? "border-b-2 border-red-600 text-red-600 dark:text-red-400"
+                : "text-muted-foreground dark:text-muted-foreground hover:text-gray-700 dark:hover:text-gray-200"
+            }`}
+          >
+            Delete Data
+          </button>
+        </div>
+
+        {/* Tab Content */}
+        {activeTab === "overview" && renderOverview()}
+        {activeTab === "consents" && <ConsentManager />}
+        {activeTab === "export" && <DataExport />}
+        {activeTab === "deletion" && <DataDeletion />}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/settings/page.tsx
+++ b/frontend/src/app/[locale]/settings/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeCustomizer } from "@/components/ThemeCustomizer";
 import { ShortcutCustomizer } from "@/components/keyboard-shortcuts/ShortcutCustomizer";
 import { ProgressiveWebApp } from "@/components/ProgressiveWebApp";
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
-import { WifiOff, Wifi } from "lucide-react";
+import { WifiOff, Wifi, ShieldCheck } from "lucide-react";
 
 function OfflineStatusBadge() {
   const { isOnline, offlineSince } = useOfflineStatus();
@@ -71,6 +72,25 @@ export default function SettingsPage() {
       {/* Keyboard shortcuts */}
       <div className="glass-card p-6 rounded-2xl">
         <ShortcutCustomizer />
+      </div>
+
+      {/* Privacy & GDPR */}
+      <div className="glass-card p-6 rounded-2xl">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Privacy &amp; Data</h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              Manage your consents, export your data, or request deletion under GDPR.
+            </p>
+          </div>
+          <Link
+            href="settings/gdpr"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+          >
+            <ShieldCheck className="w-4 h-4" aria-hidden="true" />
+            Privacy Settings
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/api-docs/examples/page.tsx
+++ b/frontend/src/app/api-docs/examples/page.tsx
@@ -1,18 +1,110 @@
-'use client';
+import React from "react";
+import Link from "next/link";
+import { BookOpen, Play, Code2, ExternalLink } from "lucide-react";
+import type { OpenApiSpec } from "@/lib/openapi-types";
+import { ExamplesClient } from "@/components/api-docs/ExamplesClient";
 
-import React from 'react';
+async function loadSpec(): Promise<OpenApiSpec> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/api$/, "") ??
+    "http://localhost:3000";
 
-const CodeExamples = () => {
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Code Examples</h1>
-        <p className="text-muted-foreground dark:text-gray-300">
-          The Code Examples page is temporarily unavailable due to a maintenance update. Please check back later.
-        </p>
-      </div>
-    </div>
-  );
+  try {
+    const res = await fetch(`${baseUrl}/api/openapi`, {
+      next: { revalidate: 3600 },
+    });
+    if (res.ok) return (await res.json()) as OpenApiSpec;
+  } catch {
+    // fall through
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: { title: "Stellar Insights API", version: "1.0.0" },
+    servers: [
+      { url: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080" },
+    ],
+    paths: {},
+  };
+}
+
+export const metadata = {
+  title: "Code Examples — Stellar Insights API",
+  description:
+    "Ready-to-use cURL, JavaScript, and Python snippets for every Stellar Insights API endpoint.",
 };
 
-export default CodeExamples;
+export default async function ExamplesPage() {
+  const spec = await loadSpec();
+
+  const backendUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ??
+    "http://localhost:8080";
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+          <div className="flex items-center gap-2 mb-1">
+            <Code2 size={20} className="text-indigo-400" />
+            <span className="text-xs font-semibold uppercase tracking-widest text-indigo-400">
+              Code Examples
+            </span>
+          </div>
+          <h1 className="text-3xl font-bold text-white">Code Examples</h1>
+          <p className="mt-1 text-gray-400 max-w-2xl">
+            Copy-paste ready snippets for every API endpoint in cURL,
+            JavaScript (fetch), and Python (requests). All examples target{" "}
+            <code className="font-mono text-indigo-300 text-sm">
+              {backendUrl}
+            </code>
+            .
+          </p>
+
+          <nav
+            className="mt-5 flex items-center gap-2 flex-wrap"
+            aria-label="API docs navigation"
+          >
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <BookOpen size={14} />
+              Reference
+            </Link>
+            <Link
+              href="/api-docs/playground"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Play size={14} />
+              Playground
+            </Link>
+            <Link
+              href="/api-docs/examples"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm font-medium"
+            >
+              <Code2 size={14} />
+              Code Examples
+            </Link>
+            <a
+              href="/openapi.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors ml-auto"
+            >
+              <ExternalLink size={14} />
+              openapi.json
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      <main
+        className="max-w-7xl mx-auto px-4 sm:px-6 py-8"
+        id="main-content"
+      >
+        <ExamplesClient spec={spec} baseUrl={backendUrl} />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/api-docs/page.tsx
+++ b/frontend/src/app/api-docs/page.tsx
@@ -1,14 +1,192 @@
-import React from 'react';
+import React from "react";
+import Link from "next/link";
+import { BookOpen, Play, Code2, ExternalLink } from "lucide-react";
+import {
+  flattenEndpoints,
+  groupByTag,
+  type OpenApiSpec,
+  type FlatEndpoint,
+} from "@/lib/openapi-types";
+import { EndpointRow } from "@/components/api-docs/EndpointRow";
 
-const APIDocumentationPortal = () => {
-  return (
-    <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center text-center p-4">
-      <h1 className="text-4xl font-bold mb-4">API Documentation</h1>
-      <p className="text-muted-foreground">
-        The documentation portal is currently undergoing maintenance.
-      </p>
-    </div>
-  );
+async function loadSpec(): Promise<OpenApiSpec> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/api$/, "") ??
+    "http://localhost:3000";
+
+  try {
+    const res = await fetch(`${baseUrl}/api/openapi`, {
+      next: { revalidate: 3600 },
+    });
+    if (res.ok) return (await res.json()) as OpenApiSpec;
+  } catch {
+    // fall through to public copy
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: { title: "Stellar Insights API", version: "1.0.0" },
+    servers: [
+      { url: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080" },
+    ],
+    paths: {},
+  };
+}
+
+export const metadata = {
+  title: "API Documentation — Stellar Insights",
+  description:
+    "Interactive reference for the Stellar Insights REST API. Browse endpoints, schemas, and try requests live.",
 };
 
-export default APIDocumentationPortal;
+export default async function ApiDocsPage() {
+  const spec = await loadSpec();
+  const endpoints: FlatEndpoint[] = flattenEndpoints(spec);
+  const grouped = groupByTag(endpoints);
+  const tagOrder = spec.tags?.map((t) => t.name) ?? [];
+  const allTags = [
+    ...tagOrder.filter((t) => grouped.has(t)),
+    ...[...grouped.keys()].filter((t) => !tagOrder.includes(t)),
+  ];
+  const tagDescriptions = Object.fromEntries(
+    (spec.tags ?? []).map((t) => [t.name, t.description ?? ""])
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6">
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <BookOpen size={20} className="text-indigo-400" />
+                <span className="text-xs font-semibold uppercase tracking-widest text-indigo-400">
+                  API Reference
+                </span>
+              </div>
+              <h1 className="text-3xl font-bold text-white">
+                {spec.info.title}
+              </h1>
+              {spec.info.description && (
+                <p className="mt-1 text-gray-400 max-w-2xl">
+                  {spec.info.description}
+                </p>
+              )}
+              <div className="mt-2 flex items-center gap-4 text-sm text-gray-500">
+                <span>
+                  OpenAPI{" "}
+                  <span className="text-gray-300">{spec.openapi}</span>
+                </span>
+                <span>
+                  Version{" "}
+                  <span className="text-gray-300">{spec.info.version}</span>
+                </span>
+                <span>
+                  <span className="text-gray-300">{endpoints.length}</span>{" "}
+                  endpoints across{" "}
+                  <span className="text-gray-300">{allTags.length}</span> tags
+                </span>
+              </div>
+            </div>
+
+            <div className="text-sm text-gray-500">
+              {(spec.servers ?? []).map((s) => (
+                <div key={s.url} className="flex items-center gap-2">
+                  <span
+                    className={`w-2 h-2 rounded-full shrink-0 ${
+                      s.url.includes("localhost")
+                        ? "bg-amber-400"
+                        : "bg-emerald-400"
+                    }`}
+                  />
+                  <span className="font-mono text-gray-300 text-xs">
+                    {s.url}
+                  </span>
+                  {s.description && (
+                    <span className="text-gray-600">({s.description})</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <nav
+            className="mt-5 flex items-center gap-2 flex-wrap"
+            aria-label="API docs navigation"
+          >
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm font-medium"
+            >
+              <BookOpen size={14} />
+              Reference
+            </Link>
+            <Link
+              href="/api-docs/playground"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Play size={14} />
+              Playground
+            </Link>
+            <Link
+              href="/api-docs/examples"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Code2 size={14} />
+              Code Examples
+            </Link>
+            <a
+              href="/openapi.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors ml-auto"
+            >
+              <ExternalLink size={14} />
+              openapi.json
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      <main
+        className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-10"
+        id="main-content"
+      >
+        {allTags.length === 0 ? (
+          <div className="text-center py-20 text-gray-500">
+            No endpoints found in spec.
+          </div>
+        ) : (
+          allTags.map((tag) => {
+            const eps = grouped.get(tag) ?? [];
+            return (
+              <section key={tag} aria-labelledby={`tag-${tag}`}>
+                <div className="mb-4">
+                  <h2
+                    id={`tag-${tag}`}
+                    className="text-xl font-semibold text-white"
+                  >
+                    {tag}
+                  </h2>
+                  {tagDescriptions[tag] && (
+                    <p className="mt-0.5 text-sm text-gray-400">
+                      {tagDescriptions[tag]}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  {eps.map((ep) => (
+                    <EndpointRow
+                      key={`${ep.method}-${ep.path}`}
+                      endpoint={ep}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/api-docs/playground/page.tsx
+++ b/frontend/src/app/api-docs/playground/page.tsx
@@ -1,18 +1,116 @@
-'use client';
+import React from "react";
+import Link from "next/link";
+import { BookOpen, Play, Code2, ExternalLink } from "lucide-react";
+import type { OpenApiSpec } from "@/lib/openapi-types";
+import { PlaygroundClient } from "@/components/api-docs/PlaygroundClient";
 
-import React from 'react';
+async function loadSpec(): Promise<OpenApiSpec> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/api$/, "") ??
+    "http://localhost:3000";
 
-const APIPlayground = () => {
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">API Playground</h1>
-        <p className="text-muted-foreground dark:text-gray-300">
-          The API Playground is temporarily unavailable due to a maintenance update. Please check back later.
-        </p>
-      </div>
-    </div>
-  );
+  try {
+    const res = await fetch(`${baseUrl}/api/openapi`, {
+      next: { revalidate: 3600 },
+    });
+    if (res.ok) return (await res.json()) as OpenApiSpec;
+  } catch {
+    // fall through
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: { title: "Stellar Insights API", version: "1.0.0" },
+    servers: [
+      { url: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080" },
+    ],
+    paths: {},
+  };
+}
+
+export const metadata = {
+  title: "API Playground — Stellar Insights",
+  description:
+    "Interactively send live requests to the Stellar Insights API from your browser.",
 };
 
-export default APIPlayground;
+export default async function PlaygroundPage() {
+  const spec = await loadSpec();
+
+  // Playground fires requests directly to the backend from the browser.
+  // NEXT_PUBLIC_API_URL is embedded at build time and available client-side.
+  const backendUrl =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ??
+    "http://localhost:8080";
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+          <div className="flex items-center gap-2 mb-1">
+            <Play size={20} className="text-indigo-400" />
+            <span className="text-xs font-semibold uppercase tracking-widest text-indigo-400">
+              API Playground
+            </span>
+          </div>
+          <h1 className="text-3xl font-bold text-white">Try It Out</h1>
+          <p className="mt-1 text-gray-400 max-w-2xl">
+            Send live requests to the Stellar Insights backend directly from
+            your browser. Select any endpoint, fill in the parameters, and hit
+            Send.
+          </p>
+          <div className="mt-2 flex items-center gap-2 text-xs text-gray-500">
+            <span className="w-2 h-2 rounded-full bg-emerald-400 shrink-0" />
+            <span>
+              Targeting:{" "}
+              <code className="font-mono text-gray-300">{backendUrl}</code>
+            </span>
+          </div>
+
+          <nav
+            className="mt-5 flex items-center gap-2 flex-wrap"
+            aria-label="API docs navigation"
+          >
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <BookOpen size={14} />
+              Reference
+            </Link>
+            <Link
+              href="/api-docs/playground"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm font-medium"
+            >
+              <Play size={14} />
+              Playground
+            </Link>
+            <Link
+              href="/api-docs/examples"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              <Code2 size={14} />
+              Code Examples
+            </Link>
+            <a
+              href="/openapi.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors ml-auto"
+            >
+              <ExternalLink size={14} />
+              openapi.json
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      <main
+        className="max-w-7xl mx-auto px-4 sm:px-6 py-8"
+        id="main-content"
+      >
+        <PlaygroundClient spec={spec} baseUrl={backendUrl} />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/api/openapi/route.ts
+++ b/frontend/src/app/api/openapi/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * GET /api/openapi
+ *
+ * Serves docs/openapi.json from the repository root at runtime.
+ * The file is read from the filesystem so it is always in sync with
+ * the committed spec without requiring a separate static-file copy.
+ *
+ * During `next build --output standalone` the public/ directory is
+ * bundled, but process.cwd() points to the repo root in dev and to
+ * the standalone bundle root in production — so we also fall back to
+ * /public/openapi.json which is copied there by the CI pipeline.
+ */
+export async function GET() {
+  let spec: string;
+
+  const candidates = [
+    // Repo root (dev server, standard build)
+    join(process.cwd(), "..", "docs", "openapi.json"),
+    // Standalone bundle / Docker image
+    join(process.cwd(), "public", "openapi.json"),
+  ];
+
+  let loaded = false;
+  for (const candidate of candidates) {
+    try {
+      spec = readFileSync(candidate, "utf-8");
+      loaded = true;
+      break;
+    } catch {
+      // try next candidate
+    }
+  }
+
+  if (!loaded) {
+    return NextResponse.json(
+      { error: "OpenAPI spec not found" },
+      { status: 404 }
+    );
+  }
+
+  return new NextResponse(spec!, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/frontend/src/components/api-docs/EndpointRow.tsx
+++ b/frontend/src/components/api-docs/EndpointRow.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import React, { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { MethodBadge } from "./MethodBadge";
+import type { FlatEndpoint, OpenApiParameter } from "@/lib/openapi-types";
+
+interface Props {
+  endpoint: FlatEndpoint;
+}
+
+export function EndpointRow({ endpoint }: Props) {
+  const [open, setOpen] = useState(false);
+  const { path, method, operation } = endpoint;
+
+  const params: OpenApiParameter[] = operation.parameters ?? [];
+  const pathParams = params.filter((p) => p.in === "path");
+  const queryParams = params.filter((p) => p.in === "query");
+  const hasBody = Boolean(operation.requestBody);
+  const responses = Object.entries(operation.responses ?? {});
+
+  return (
+    <div className="border border-gray-700 rounded-lg overflow-hidden">
+      {/* Header row — always visible */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-3 px-4 py-3 bg-gray-800 hover:bg-gray-700 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        aria-expanded={open}
+      >
+        <span className="text-gray-400 shrink-0">
+          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+        <MethodBadge method={method} />
+        <code className="text-sm font-mono text-gray-100 flex-1 truncate">
+          {path}
+        </code>
+        {operation.summary && (
+          <span className="text-sm text-gray-400 hidden md:block truncate max-w-xs">
+            {operation.summary}
+          </span>
+        )}
+      </button>
+
+      {/* Expanded detail panel */}
+      {open && (
+        <div className="px-4 py-4 bg-gray-900 border-t border-gray-700 space-y-4 text-sm">
+          {operation.description && (
+            <p className="text-gray-300 leading-relaxed">
+              {operation.description}
+            </p>
+          )}
+          {operation.summary && !operation.description && (
+            <p className="text-gray-300 leading-relaxed">{operation.summary}</p>
+          )}
+
+          {pathParams.length > 0 && (
+            <ParamTable title="Path Parameters" params={pathParams} />
+          )}
+
+          {queryParams.length > 0 && (
+            <ParamTable title="Query Parameters" params={queryParams} />
+          )}
+
+          {hasBody && (
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+                Request Body
+              </h4>
+              <div className="bg-gray-800 rounded p-3 text-gray-300">
+                {operation.requestBody?.description ?? "See schema below"}
+                {operation.requestBody?.required && (
+                  <span className="ml-2 text-xs text-rose-400">(required)</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {responses.length > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+                Responses
+              </h4>
+              <div className="space-y-1">
+                {responses.map(([code, resp]) => (
+                  <div key={code} className="flex items-start gap-3">
+                    <span
+                      className={`font-mono text-xs px-1.5 py-0.5 rounded font-bold ${
+                        code.startsWith("2")
+                          ? "bg-emerald-900/50 text-emerald-400"
+                          : code.startsWith("4")
+                            ? "bg-amber-900/50 text-amber-400"
+                            : code.startsWith("5")
+                              ? "bg-rose-900/50 text-rose-400"
+                              : "bg-gray-700 text-gray-300"
+                      }`}
+                    >
+                      {code}
+                    </span>
+                    <span className="text-gray-400">{resp.description}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ParamTable({
+  title,
+  params,
+}: {
+  title: string;
+  params: OpenApiParameter[];
+}) {
+  return (
+    <div>
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+        {title}
+      </h4>
+      <div className="overflow-x-auto rounded border border-gray-700">
+        <table className="w-full text-xs">
+          <thead className="bg-gray-800">
+            <tr>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Name
+              </th>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Type
+              </th>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Required
+              </th>
+              <th className="text-left px-3 py-2 text-gray-400 font-medium">
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-700">
+            {params.map((p) => (
+              <tr key={p.name} className="bg-gray-900">
+                <td className="px-3 py-2 font-mono text-indigo-300">{p.name}</td>
+                <td className="px-3 py-2 text-gray-400 font-mono">
+                  {p.schema?.type ?? "string"}
+                  {p.schema?.format ? `(${p.schema.format})` : ""}
+                </td>
+                <td className="px-3 py-2">
+                  {p.required ? (
+                    <span className="text-rose-400">yes</span>
+                  ) : (
+                    <span className="text-gray-600">no</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-gray-400">
+                  {p.description ?? "—"}
+                  {p.schema?.default !== undefined && (
+                    <span className="ml-1 text-gray-600">
+                      (default: {String(p.schema.default)})
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/api-docs/ExamplesClient.tsx
+++ b/frontend/src/components/api-docs/ExamplesClient.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import React, { useState } from "react";
+import { Copy, Check, ChevronDown, ChevronRight } from "lucide-react";
+import { MethodBadge } from "./MethodBadge";
+import type {
+  FlatEndpoint,
+  HttpMethod,
+  OpenApiSpec,
+} from "@/lib/openapi-types";
+import { flattenEndpoints, groupByTag } from "@/lib/openapi-types";
+
+type LangTab = "curl" | "js" | "python";
+
+const LANG_LABELS: Record<LangTab, string> = {
+  curl: "cURL",
+  js: "JavaScript",
+  python: "Python",
+};
+
+interface Props {
+  spec: OpenApiSpec;
+  baseUrl: string;
+}
+
+export function ExamplesClient({ spec, baseUrl }: Props) {
+  const endpoints = flattenEndpoints(spec);
+  const grouped = groupByTag(endpoints);
+  const tagOrder = spec.tags?.map((t) => t.name) ?? [];
+  const allTags = [
+    ...tagOrder.filter((t) => grouped.has(t)),
+    ...[...grouped.keys()].filter((t) => !tagOrder.includes(t)),
+  ];
+
+  const [activeTag, setActiveTag] = useState<string>(allTags[0] ?? "");
+  const [activeLang, setActiveLang] = useState<LangTab>("curl");
+
+  if (endpoints.length === 0) {
+    return (
+      <div className="text-center py-20 text-gray-500">
+        No endpoints found in spec.
+      </div>
+    );
+  }
+
+  const visibleEndpoints = grouped.get(activeTag) ?? [];
+
+  return (
+    <div className="flex gap-6">
+      {/* Tag sidebar */}
+      <aside className="hidden lg:block w-52 shrink-0">
+        <nav aria-label="Endpoint categories">
+          <ul className="space-y-0.5">
+            {allTags.map((tag) => (
+              <li key={tag}>
+                <button
+                  onClick={() => setActiveTag(tag)}
+                  className={`w-full text-left px-3 py-1.5 rounded text-sm transition-colors ${
+                    activeTag === tag
+                      ? "bg-indigo-600/20 text-indigo-300 font-medium"
+                      : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+                  }`}
+                >
+                  {tag}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+
+      {/* Mobile tag selector */}
+      <div className="lg:hidden w-full">
+        <select
+          value={activeTag}
+          onChange={(e) => setActiveTag(e.target.value)}
+          className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:border-indigo-500 mb-4"
+          aria-label="Select endpoint category"
+        >
+          {allTags.map((tag) => (
+            <option key={tag} value={tag}>
+              {tag}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Main panel */}
+      <div className="flex-1 min-w-0">
+        {/* Language tabs */}
+        <div
+          className="flex gap-1 mb-6 border-b border-gray-800"
+          role="tablist"
+          aria-label="Language"
+        >
+          {(Object.keys(LANG_LABELS) as LangTab[]).map((lang) => (
+            <button
+              key={lang}
+              role="tab"
+              aria-selected={activeLang === lang}
+              onClick={() => setActiveLang(lang)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px ${
+                activeLang === lang
+                  ? "border-indigo-500 text-indigo-300"
+                  : "border-transparent text-gray-500 hover:text-gray-300"
+              }`}
+            >
+              {LANG_LABELS[lang]}
+            </button>
+          ))}
+        </div>
+
+        <div className="space-y-4">
+          {visibleEndpoints.map((ep) => (
+            <EndpointExample
+              key={`${ep.method}-${ep.path}`}
+              endpoint={ep}
+              lang={activeLang}
+              baseUrl={baseUrl}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EndpointExample({
+  endpoint,
+  lang,
+  baseUrl,
+}: {
+  endpoint: FlatEndpoint;
+  lang: LangTab;
+  baseUrl: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const snippet = buildSnippet(endpoint, lang, baseUrl);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(snippet);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="border border-gray-700 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-3 px-4 py-3 bg-gray-800 hover:bg-gray-700 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        aria-expanded={open}
+      >
+        <span className="text-gray-400 shrink-0">
+          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+        <MethodBadge method={endpoint.method as HttpMethod} />
+        <code className="text-sm font-mono text-gray-100 flex-1 truncate">
+          {endpoint.path}
+        </code>
+        {endpoint.operation.summary && (
+          <span className="text-sm text-gray-400 hidden md:block truncate max-w-xs">
+            {endpoint.operation.summary}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="relative bg-gray-950 border-t border-gray-700">
+          <button
+            onClick={handleCopy}
+            title="Copy snippet"
+            className="absolute top-2 right-2 p-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors z-10"
+            aria-label="Copy code snippet"
+          >
+            {copied ? (
+              <Check size={14} className="text-emerald-400" />
+            ) : (
+              <Copy size={14} />
+            )}
+          </button>
+          <pre className="overflow-x-auto p-4 text-xs font-mono text-gray-300 leading-relaxed whitespace-pre">
+            {snippet}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ---------- snippet builders ---------- */
+
+function buildSnippet(
+  ep: FlatEndpoint,
+  lang: LangTab,
+  baseUrl: string
+): string {
+  const exampleUrl = buildExampleUrl(ep, baseUrl);
+  switch (lang) {
+    case "curl":
+      return buildCurlSnippet(ep, exampleUrl);
+    case "js":
+      return buildJsSnippet(ep, exampleUrl);
+    case "python":
+      return buildPythonSnippet(ep, exampleUrl);
+  }
+}
+
+function buildExampleUrl(ep: FlatEndpoint, baseUrl: string): string {
+  let path = ep.path;
+  const pathParams =
+    ep.operation.parameters?.filter((p) => p.in === "path") ?? [];
+  for (const p of pathParams) {
+    path = path.replace(`{${p.name}}`, `<${p.name}>`);
+  }
+  const queryParams =
+    ep.operation.parameters?.filter((p) => p.in === "query") ?? [];
+  if (queryParams.length > 0) {
+    const qs = queryParams
+      .slice(0, 2)
+      .map((p) => {
+        const val =
+          p.schema?.default !== undefined
+            ? String(p.schema.default)
+            : `<${p.name}>`;
+        return `${p.name}=${val}`;
+      })
+      .join("&");
+    path = `${path}?${qs}`;
+  }
+  return `${baseUrl}${path}`;
+}
+
+function exampleBody(ep: FlatEndpoint): string {
+  const schema =
+    ep.operation.requestBody?.content?.["application/json"]?.schema;
+  if (!schema) return "{}";
+  const example: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(schema.properties ?? {})) {
+    if (v.type === "string") example[k] = `<${k}>`;
+    else if (v.type === "number" || v.type === "integer") example[k] = 0;
+    else if (v.type === "boolean") example[k] = true;
+    else example[k] = null;
+  }
+  return JSON.stringify(example, null, 2);
+}
+
+function buildCurlSnippet(ep: FlatEndpoint, url: string): string {
+  const parts = [
+    `curl -X ${ep.method.toUpperCase()} \\`,
+    `  '${url}' \\`,
+    `  -H 'Content-Type: application/json' \\`,
+    `  -H 'Authorization: Bearer <your-token>'`,
+  ];
+  if (
+    ["post", "put", "patch"].includes(ep.method) &&
+    ep.operation.requestBody
+  ) {
+    const escaped = exampleBody(ep).replace(/'/g, "\\'");
+    parts.push(`  -d '${escaped}'`);
+  }
+  return parts.join("\n");
+}
+
+function buildJsSnippet(ep: FlatEndpoint, url: string): string {
+  const hasBody =
+    ["post", "put", "patch"].includes(ep.method) && ep.operation.requestBody;
+  const bodyJson = hasBody ? exampleBody(ep) : null;
+  const lines: string[] = [
+    `const response = await fetch(`,
+    `  '${url}',`,
+    `  {`,
+    `    method: '${ep.method.toUpperCase()}',`,
+    `    headers: {`,
+    `      'Content-Type': 'application/json',`,
+    `      'Authorization': 'Bearer <your-token>',`,
+    `    },`,
+  ];
+  if (bodyJson) {
+    lines.push(`    body: JSON.stringify(`);
+    bodyJson.split("\n").forEach((l) => lines.push(`      ${l}`));
+    lines.push(`    ),`);
+  }
+  lines.push(`  }`, `);`, ``, `const data = await response.json();`, `console.log(data);`);
+  return lines.join("\n");
+}
+
+function buildPythonSnippet(ep: FlatEndpoint, url: string): string {
+  const hasBody =
+    ["post", "put", "patch"].includes(ep.method) && ep.operation.requestBody;
+  const bodyJson = hasBody ? exampleBody(ep) : null;
+  const lines: string[] = [
+    `import requests`,
+    ``,
+    `headers = {`,
+    `    "Content-Type": "application/json",`,
+    `    "Authorization": "Bearer <your-token>",`,
+    `}`,
+    ``,
+  ];
+  if (bodyJson) {
+    lines.push(`payload = ${bodyJson}`);
+    lines.push(``, `response = requests.${ep.method}(`);
+    lines.push(`    "${url}",`, `    headers=headers,`, `    json=payload,`, `)`);
+  } else {
+    lines.push(`response = requests.${ep.method}(`);
+    lines.push(`    "${url}",`, `    headers=headers,`, `)`);
+  }
+  lines.push(``, `print(response.status_code)`, `print(response.json())`);
+  return lines.join("\n");
+}

--- a/frontend/src/components/api-docs/MethodBadge.tsx
+++ b/frontend/src/components/api-docs/MethodBadge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import type { HttpMethod } from "@/lib/openapi-types";
+
+const METHOD_STYLES: Record<HttpMethod, string> = {
+  get: "bg-emerald-600/20 text-emerald-400 border border-emerald-600/40",
+  post: "bg-blue-600/20   text-blue-400   border border-blue-600/40",
+  put: "bg-amber-600/20  text-amber-400  border border-amber-600/40",
+  patch: "bg-purple-600/20 text-purple-400 border border-purple-600/40",
+  delete: "bg-rose-600/20   text-rose-400   border border-rose-600/40",
+  head: "bg-gray-600/20   text-gray-400   border border-gray-600/40",
+  options: "bg-gray-600/20   text-gray-400   border border-gray-600/40",
+};
+
+interface Props {
+  method: HttpMethod;
+  className?: string;
+}
+
+export function MethodBadge({ method, className = "" }: Props) {
+  return (
+    <span
+      className={`inline-flex items-center justify-center px-2 py-0.5 rounded text-xs font-bold uppercase tracking-wider font-mono min-w-[54px] ${METHOD_STYLES[method]} ${className}`}
+    >
+      {method}
+    </span>
+  );
+}

--- a/frontend/src/components/api-docs/PlaygroundClient.tsx
+++ b/frontend/src/components/api-docs/PlaygroundClient.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import React, { useState, useCallback, useMemo } from "react";
+import {
+  Play,
+  Copy,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+} from "lucide-react";
+import { MethodBadge } from "./MethodBadge";
+import type {
+  FlatEndpoint,
+  HttpMethod,
+  OpenApiParameter,
+  OpenApiSpec,
+} from "@/lib/openapi-types";
+import { flattenEndpoints } from "@/lib/openapi-types";
+
+interface Props {
+  spec: OpenApiSpec;
+  baseUrl: string;
+}
+
+interface RequestState {
+  loading: boolean;
+  status: number | null;
+  statusText: string;
+  body: string;
+  headers: Record<string, string>;
+  elapsed: number | null;
+  error: string | null;
+}
+
+const INITIAL_REQUEST: RequestState = {
+  loading: false,
+  status: null,
+  statusText: "",
+  body: "",
+  headers: {},
+  elapsed: null,
+  error: null,
+};
+
+export function PlaygroundClient({ spec, baseUrl }: Props) {
+  const endpoints = useMemo(() => flattenEndpoints(spec), [spec]);
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const [pathValues, setPathValues] = useState<Record<string, string>>({});
+  const [queryValues, setQueryValues] = useState<Record<string, string>>({});
+  const [bodyValue, setBodyValue] = useState("");
+  const [bearerToken, setBearerToken] = useState("");
+  const [request, setRequest] = useState<RequestState>(INITIAL_REQUEST);
+  const [copied, setCopied] = useState(false);
+
+  const selected = endpoints[selectedIndex];
+
+  const selectEndpoint = (index: number) => {
+    setSelectedIndex(index);
+    setSelectorOpen(false);
+    setPathValues({});
+    setQueryValues({});
+    setBodyValue("");
+    setRequest(INITIAL_REQUEST);
+  };
+
+  const buildUrl = useCallback((): string => {
+    if (!selected) return baseUrl;
+    let path = selected.path;
+    for (const [k, v] of Object.entries(pathValues)) {
+      path = path.replace(`{${k}}`, encodeURIComponent(v));
+    }
+    const qs = Object.entries(queryValues)
+      .filter(([, v]) => v !== "")
+      .map(
+        ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`
+      )
+      .join("&");
+    return `${baseUrl}${path}${qs ? `?${qs}` : ""}`;
+  }, [selected, pathValues, queryValues, baseUrl]);
+
+  const sendRequest = async () => {
+    if (!selected) return;
+    setRequest({ ...INITIAL_REQUEST, loading: true });
+
+    const url = buildUrl();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (bearerToken) headers["Authorization"] = `Bearer ${bearerToken}`;
+
+    const init: RequestInit = {
+      method: selected.method.toUpperCase(),
+      headers,
+    };
+
+    const hasBody =
+      ["post", "put", "patch"].includes(selected.method) &&
+      bodyValue.trim() !== "";
+    if (hasBody) init.body = bodyValue;
+
+    const start = performance.now();
+    try {
+      const res = await fetch(url, init);
+      const elapsed = Math.round(performance.now() - start);
+      const respHeaders: Record<string, string> = {};
+      res.headers.forEach((v, k) => {
+        respHeaders[k] = v;
+      });
+
+      let body = "";
+      const ct = res.headers.get("content-type") ?? "";
+      if (ct.includes("application/json")) {
+        const json = await res.json();
+        body = JSON.stringify(json, null, 2);
+      } else {
+        body = await res.text();
+      }
+
+      setRequest({
+        loading: false,
+        status: res.status,
+        statusText: res.statusText,
+        body,
+        headers: respHeaders,
+        elapsed,
+        error: null,
+      });
+    } catch (err) {
+      const elapsed = Math.round(performance.now() - start);
+      setRequest({
+        loading: false,
+        status: null,
+        statusText: "",
+        body: "",
+        headers: {},
+        elapsed,
+        error: err instanceof Error ? err.message : "Network error",
+      });
+    }
+  };
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(request.body);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (endpoints.length === 0) {
+    return (
+      <div className="text-center py-20 text-gray-500">
+        No endpoints available in spec.
+      </div>
+    );
+  }
+
+  const pathParams: OpenApiParameter[] =
+    selected?.operation.parameters?.filter((p) => p.in === "path") ?? [];
+  const queryParams: OpenApiParameter[] =
+    selected?.operation.parameters?.filter((p) => p.in === "query") ?? [];
+  const supportsBody =
+    selected &&
+    ["post", "put", "patch"].includes(selected.method) &&
+    selected.operation.requestBody;
+
+  const statusColor =
+    request.status === null
+      ? ""
+      : request.status < 300
+        ? "text-emerald-400"
+        : request.status < 400
+          ? "text-amber-400"
+          : "text-rose-400";
+
+  const currentUrl = buildUrl();
+  const curlSnippet = buildCurl(selected, currentUrl, bodyValue, bearerToken);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Left — Request builder */}
+      <div className="space-y-5">
+        {/* Endpoint selector */}
+        <div>
+          <label
+            htmlFor="endpoint-selector"
+            className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1.5"
+          >
+            Endpoint
+          </label>
+          <div className="relative">
+            <button
+              id="endpoint-selector"
+              onClick={() => setSelectorOpen((v) => !v)}
+              className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg bg-gray-800 border border-gray-700 hover:border-gray-600 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              aria-expanded={selectorOpen}
+              aria-haspopup="listbox"
+            >
+              <MethodBadge method={selected.method as HttpMethod} />
+              <code className="text-sm font-mono text-gray-100 flex-1 truncate">
+                {selected.path}
+              </code>
+              {selectorOpen ? (
+                <ChevronDown size={14} className="text-gray-400 shrink-0" />
+              ) : (
+                <ChevronRight size={14} className="text-gray-400 shrink-0" />
+              )}
+            </button>
+
+            {selectorOpen && (
+              <div
+                role="listbox"
+                className="absolute z-20 mt-1 w-full max-h-72 overflow-y-auto rounded-lg border border-gray-700 bg-gray-900 shadow-xl"
+              >
+                {endpoints.map((ep, i) => (
+                  <button
+                    key={`${ep.method}-${ep.path}`}
+                    role="option"
+                    aria-selected={i === selectedIndex}
+                    onClick={() => selectEndpoint(i)}
+                    className={`w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-gray-800 transition-colors ${
+                      i === selectedIndex ? "bg-gray-800" : ""
+                    }`}
+                  >
+                    <MethodBadge method={ep.method as HttpMethod} />
+                    <code className="font-mono text-gray-200 truncate">
+                      {ep.path}
+                    </code>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {selected.operation.summary && (
+            <p className="mt-1.5 text-sm text-gray-400">
+              {selected.operation.summary}
+            </p>
+          )}
+        </div>
+
+        {/* Path parameters */}
+        {pathParams.length > 0 && (
+          <FieldGroup title="Path Parameters">
+            {pathParams.map((p) => (
+              <LabeledInput
+                key={p.name}
+                label={p.name}
+                required={p.required}
+                placeholder={p.description ?? p.name}
+                value={pathValues[p.name] ?? ""}
+                onChange={(v) =>
+                  setPathValues((prev) => ({ ...prev, [p.name]: v }))
+                }
+              />
+            ))}
+          </FieldGroup>
+        )}
+
+        {/* Query parameters */}
+        {queryParams.length > 0 && (
+          <FieldGroup title="Query Parameters">
+            {queryParams.map((p) => (
+              <LabeledInput
+                key={p.name}
+                label={p.name}
+                required={p.required}
+                placeholder={
+                  p.schema?.default !== undefined
+                    ? String(p.schema.default)
+                    : (p.description ?? p.name)
+                }
+                value={queryValues[p.name] ?? ""}
+                onChange={(v) =>
+                  setQueryValues((prev) => ({ ...prev, [p.name]: v }))
+                }
+              />
+            ))}
+          </FieldGroup>
+        )}
+
+        {/* Request body */}
+        {supportsBody && (
+          <FieldGroup title="Request Body (JSON)">
+            <textarea
+              value={bodyValue}
+              onChange={(e) => setBodyValue(e.target.value)}
+              rows={6}
+              className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 font-mono text-sm text-gray-200 focus:outline-none focus:border-indigo-500 resize-y"
+              placeholder="{}"
+              spellCheck={false}
+              aria-label="Request body JSON"
+            />
+          </FieldGroup>
+        )}
+
+        {/* Auth */}
+        <FieldGroup title="Authorization (optional)">
+          <LabeledInput
+            label="Bearer Token"
+            required={false}
+            placeholder="eyJhbGci..."
+            value={bearerToken}
+            onChange={setBearerToken}
+            type="password"
+          />
+        </FieldGroup>
+
+        {/* URL preview */}
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+            Request URL
+          </p>
+          <code className="block text-xs font-mono text-indigo-300 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 break-all">
+            {currentUrl}
+          </code>
+        </div>
+
+        {/* Send button */}
+        <button
+          onClick={sendRequest}
+          disabled={request.loading}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+        >
+          {request.loading ? (
+            <>
+              <Loader2 size={16} className="animate-spin" />
+              Sending…
+            </>
+          ) : (
+            <>
+              <Play size={16} />
+              Send Request
+            </>
+          )}
+        </button>
+
+        {/* cURL snippet */}
+        <details className="group">
+          <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-300 transition-colors list-none flex items-center gap-1.5">
+            <ChevronRight
+              size={12}
+              className="transition-transform group-open:rotate-90"
+            />
+            cURL equivalent
+          </summary>
+          <pre className="mt-2 bg-gray-900 border border-gray-700 rounded-lg p-3 text-xs font-mono text-gray-300 overflow-x-auto whitespace-pre-wrap break-all">
+            {curlSnippet}
+          </pre>
+        </details>
+      </div>
+
+      {/* Right — Response */}
+      <div className="flex flex-col">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Response
+          </p>
+          {request.status !== null && (
+            <div className="flex items-center gap-3 text-sm">
+              <span className={`font-bold font-mono ${statusColor}`}>
+                {request.status} {request.statusText}
+              </span>
+              {request.elapsed !== null && (
+                <span className="text-gray-500 text-xs">
+                  {request.elapsed} ms
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 relative bg-gray-900 border border-gray-700 rounded-lg overflow-hidden min-h-[300px]">
+          {!request.loading && request.status === null && !request.error && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-600">
+              <Play size={32} className="mb-2 opacity-30" />
+              <p className="text-sm">
+                Hit &ldquo;Send Request&rdquo; to see the response
+              </p>
+            </div>
+          )}
+
+          {request.loading && (
+            <div className="absolute inset-0 flex items-center justify-center text-gray-500">
+              <Loader2 size={24} className="animate-spin" />
+            </div>
+          )}
+
+          {!request.loading && request.error && (
+            <div className="p-4 text-rose-400 text-sm font-mono">
+              Error: {request.error}
+            </div>
+          )}
+
+          {!request.loading && !request.error && request.body && (
+            <>
+              <button
+                onClick={handleCopy}
+                title="Copy response"
+                className="absolute top-2 right-2 p-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors z-10"
+                aria-label="Copy response body"
+              >
+                {copied ? (
+                  <Check size={14} className="text-emerald-400" />
+                ) : (
+                  <Copy size={14} />
+                )}
+              </button>
+              <pre className="h-full overflow-auto p-4 text-xs font-mono text-gray-300 leading-relaxed whitespace-pre-wrap">
+                {request.body}
+              </pre>
+            </>
+          )}
+        </div>
+
+        {!request.loading && Object.keys(request.headers).length > 0 && (
+          <details className="mt-3 group">
+            <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-300 transition-colors list-none flex items-center gap-1.5">
+              <ChevronRight
+                size={12}
+                className="transition-transform group-open:rotate-90"
+              />
+              Response Headers
+            </summary>
+            <div className="mt-2 bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+              {Object.entries(request.headers).map(([k, v]) => (
+                <div
+                  key={k}
+                  className="flex gap-2 px-3 py-1 text-xs border-b border-gray-800 last:border-0"
+                >
+                  <span className="font-mono text-indigo-300 shrink-0">
+                    {k}:
+                  </span>
+                  <span className="font-mono text-gray-400 break-all">{v}</span>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- helpers ---------- */
+
+function FieldGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+        {title}
+      </h3>
+      <div className="space-y-2">{children}</div>
+    </div>
+  );
+}
+
+function LabeledInput({
+  label,
+  required,
+  placeholder,
+  value,
+  onChange,
+  type = "text",
+}: {
+  label: string;
+  required?: boolean;
+  placeholder?: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <label className="w-32 shrink-0 text-xs font-mono text-indigo-300">
+        {label}
+        {required && <span className="text-rose-400 ml-0.5">*</span>}
+      </label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="flex-1 bg-gray-900 border border-gray-700 rounded px-2.5 py-1.5 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-indigo-500"
+      />
+    </div>
+  );
+}
+
+function buildCurl(
+  ep: FlatEndpoint | undefined,
+  url: string,
+  body: string,
+  token: string
+): string {
+  if (!ep) return "";
+  const parts: string[] = [`curl -X ${ep.method.toUpperCase()}`];
+  parts.push(`  '${url}'`);
+  parts.push(`  -H 'Content-Type: application/json'`);
+  if (token) parts.push(`  -H 'Authorization: Bearer ${token}'`);
+  if (["post", "put", "patch"].includes(ep.method) && body.trim()) {
+    parts.push(`  -d '${body.replace(/'/g, "\\'")}'`);
+  }
+  return parts.join(" \\\n");
+}

--- a/frontend/src/lib/openapi-types.ts
+++ b/frontend/src/lib/openapi-types.ts
@@ -1,0 +1,136 @@
+/**
+ * Minimal typing for the OpenAPI 3.x spec shapes we actually consume in the
+ * API-docs UI.  We only type what we render — we don't try to replicate the
+ * full specification object model.
+ */
+
+export interface OpenApiInfo {
+  title: string;
+  description?: string;
+  version: string;
+}
+
+export interface OpenApiServer {
+  url: string;
+  description?: string;
+}
+
+export interface OpenApiSchema {
+  type?: string;
+  format?: string;
+  description?: string;
+  properties?: Record<string, OpenApiSchema>;
+  items?: OpenApiSchema;
+  $ref?: string;
+  required?: string[];
+  default?: unknown;
+  enum?: unknown[];
+  additionalProperties?: OpenApiSchema | boolean;
+}
+
+export interface OpenApiParameter {
+  name: string;
+  in: "query" | "path" | "header" | "cookie";
+  required?: boolean;
+  description?: string;
+  schema?: OpenApiSchema;
+}
+
+export interface OpenApiMediaType {
+  schema?: OpenApiSchema;
+}
+
+export interface OpenApiRequestBody {
+  required?: boolean;
+  description?: string;
+  content?: Record<string, OpenApiMediaType>;
+}
+
+export interface OpenApiResponse {
+  description?: string;
+  content?: Record<string, OpenApiMediaType>;
+}
+
+export interface OpenApiOperation {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: OpenApiParameter[];
+  requestBody?: OpenApiRequestBody;
+  responses?: Record<string, OpenApiResponse>;
+}
+
+export type HttpMethod =
+  | "get"
+  | "post"
+  | "put"
+  | "patch"
+  | "delete"
+  | "head"
+  | "options";
+
+export type OpenApiPathItem = Partial<Record<HttpMethod, OpenApiOperation>>;
+
+export interface OpenApiSpec {
+  openapi: string;
+  info: OpenApiInfo;
+  servers?: OpenApiServer[];
+  paths?: Record<string, OpenApiPathItem>;
+  components?: {
+    schemas?: Record<string, OpenApiSchema>;
+    securitySchemes?: Record<string, unknown>;
+  };
+  tags?: { name: string; description?: string }[];
+}
+
+/** Flat representation used for rendering individual endpoint rows */
+export interface FlatEndpoint {
+  path: string;
+  method: HttpMethod;
+  operation: OpenApiOperation;
+  tags: string[];
+}
+
+/** Extract a flat list of endpoints from a spec */
+export function flattenEndpoints(spec: OpenApiSpec): FlatEndpoint[] {
+  const endpoints: FlatEndpoint[] = [];
+  const methods: HttpMethod[] = [
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+  ];
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const method of methods) {
+      const op = pathItem[method];
+      if (op) {
+        endpoints.push({
+          path,
+          method,
+          operation: op,
+          tags: op.tags ?? ["Other"],
+        });
+      }
+    }
+  }
+
+  return endpoints;
+}
+
+/** Group flat endpoints by their first tag */
+export function groupByTag(
+  endpoints: FlatEndpoint[]
+): Map<string, FlatEndpoint[]> {
+  const map = new Map<string, FlatEndpoint[]>();
+  for (const ep of endpoints) {
+    const tag = ep.tags[0] ?? "Other";
+    if (!map.has(tag)) map.set(tag, []);
+    map.get(tag)!.push(ep);
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary

Closes #1828.

`/[locale]/internal/monitoring` had three problems:
- **Publicly reachable** — no auth gate, anyone could access internal operational data
- **Entirely mock data** — page called `getMockMonitoringStats()` (hardcoded fake numbers), never touched the real backend
- **Double layout** — wrapped content in `<MainLayout>` on top of the locale layout, producing a second sidebar and navbar

---

## Changes

### `frontend/src/app/[locale]/internal/monitoring/page.tsx`

**Auth gate**
- Converted to a server component so the check runs before any HTML is sent
- Reads `INTERNAL_SECRET` (server-side env var, never `NEXT_PUBLIC_`) and compares against:
  - `X-Internal-Token` request header (for curl / scripted access)
  - `internal_token` cookie (for browser sessions)
- No match → silent `redirect("/")` — avoids leaking that the route exists at all
- Dev shortcut: gate is skipped when `INTERNAL_SECRET` is unset and `NODE_ENV !== "production"`
- Production with no secret: all requests blocked

**Real data**
- Removed `getMockMonitoringStats()` entirely
- Replaced with `<JobMonitoringDashboard />` which calls `GET /api/v1/jobs/status`
- Shows live job health (healthy / warning / critical), execution counts, success rates, consecutive failures, last execution details
- Auto-refreshes every 30 s with a manual refresh button and error/retry UI

**Layout**
- Removed `<MainLayout>` double-wrap — the locale layout already provides the full shell

### `frontend/.env.example`
- Added `INTERNAL_SECRET` with usage documentation

---

## Acceptance criteria

- [x] Unauthenticated requests redirect to `/` (no secret set in production)
- [x] Requests with valid `X-Internal-Token` or `internal_token` cookie render the dashboard
- [x] Dashboard data comes from `GET /api/v1/jobs/status`, not hardcoded mock values
- [x] Single sidebar/navbar (no double layout)
- [x] `INTERNAL_SECRET` documented in `.env.example`
- [x] Zero new TypeScript errors
- [ ] Manual browser click-through — requires `pnpm dev` + running backend + `INTERNAL_SECRET` configured
