### PR TITLE
fix(backend): remove duplicate Cargo.toml keys blocking cargo build

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -69,8 +69,6 @@ redis = { version = "1.3", features = ["aio", "tokio-comp", "connection-manager"
 async-lock = "3.3"
 futures = "0.3"
 tokio-tungstenite = "0.30"
-dashmap = "5.5"
-tokio-tungstenite = "0.29"
 dashmap = "6.2"
 stellar-xdr = { version = "25.0.0", features = ["std", "curr"] }
 stellar_sdk = "0.1"


### PR DESCRIPTION
## Summary
- backend/Cargo.toml had tokio-tungstenite and dashmap each declared twice under [dependencies] with conflicting version requirements (0.30/0.29 and 5.5/6.2). Cargo treats this as a duplicate-key manifest error and refuses to build - cargo build fails immediately on a fresh clone, before any code compiles.
- Kept the versions already resolved in the checked-in Cargo.lock (tokio-tungstenite = 0.30, dashmap = 6.2), so no dependency re-resolution is needed.

## Note on remaining build issues
After this fix, cargo build still fails with ~134 errors unrelated to this manifest bug: redis = 1.3 no longer matches the redis-rs API the code was written against (e.g. get_multiplexed_tokio_connection was renamed get_multiplexed_async_connection), affecting src/cache.rs, src/features/redis_caching_layer.rs, src/features/rate_limiting_advanced.rs, src/distributed_lock.rs, src/websocket.rs, src/api/gdpr.rs, src/ingestion/*, src/rate_limit.rs. Separately, hmac = 0.13 and sha2 = 0.10 pull incompatible digest trait versions, breaking src/webhooks/mod.rs, src/auth/sep10_simple.rs, src/request_signing_middleware.rs. Those are larger, separate fixes and intentionally out of scope for this PR.

## Test plan
- cargo build gets past manifest parsing (no longer fails on duplicate keys)
- Full cargo build success blocked on the redis/hmac issues noted above - tracked separately

Generated with Claude Code