### PR TITLE
fix: resolve wallet Window type conflict, offline-banner hydration mismatch, and dev CSP eval error

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -40,9 +40,11 @@ const securityHeaders = [
   },
   {
     key: "Content-Security-Policy",
+    // 'unsafe-eval' is only added outside production — see proxy.ts's
+    // buildCsp() for why dev mode needs it.
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
+      `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV === "production" ? "" : " 'unsafe-eval'"}`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https://*.stellar.org",
       "font-src 'self'",

--- a/frontend/src/components/lib/wallet-context.tsx
+++ b/frontend/src/components/lib/wallet-context.tsx
@@ -6,32 +6,14 @@ import { createContext, useContext, useState, useCallback, useEffect } from 'rea
 import { sep10AuthService } from '../../services/sep10Auth'
 import { logger } from "@/lib/logger"
 
-interface FreighterWallet {
-  getPublicKey: () => Promise<string>
-}
-
-interface AlbedoWallet {
-  publicKey: (options?: Record<string, unknown>) => Promise<{ pubkey: string }>
-}
-
-interface XBullSDKWallet {
-  signTransaction: (options: Record<string, unknown>) => Promise<string>
-}
-
-interface RabetWallet {
-  connect: () => Promise<{ publicKey: string }>
-}
-
-// Extend Window interface for Stellar wallets
+// Extend Window interface for the generic `stellar` wallet bridge.
+// freighter/albedo/xBullSDK/rabet are typed globally in services/sep10Auth.ts —
+// declaring them again here with different types would conflict.
 declare global {
   interface Window {
     stellar?: {
       requestPublicKey: () => Promise<string>
     }
-    freighter?: FreighterWallet
-    albedo?: AlbedoWallet
-    xBullSDK?: XBullSDKWallet
-    rabet?: RabetWallet
   }
 }
 

--- a/frontend/src/hooks/useOfflineStatus.ts
+++ b/frontend/src/hooks/useOfflineStatus.ts
@@ -16,8 +16,14 @@ export interface OfflineStatus {
  * without pulling in the full PWA installation machinery.
  */
 export function useOfflineStatus(): OfflineStatus {
+  // Guard on `window`, not `navigator`: Node.js ships a built-in global
+  // `navigator` (for fetch-spec compatibility) that has no `onLine`
+  // property, so `typeof navigator !== 'undefined'` is true during SSR too.
+  // That made `navigator.onLine` evaluate to `undefined` (falsy) on the
+  // server, rendering the offline banner on every SSR pass and causing a
+  // hydration mismatch as soon as the real browser value took over.
   const [isOnline, setIsOnline] = useState(() =>
-    typeof navigator !== 'undefined' ? navigator.onLine : true,
+    typeof window !== 'undefined' ? navigator.onLine : true,
   );
   const [justReconnected, setJustReconnected] = useState(false);
   const [offlineSince, setOfflineSince] = useState<Date | null>(null);

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -19,7 +19,10 @@ const intlMiddleware = createMiddleware(routing);
 function buildCsp(isProd: boolean): string {
   const directives: string[] = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
+    // 'unsafe-eval' is only added outside production: Next.js dev mode
+    // (Turbopack/Fast Refresh) evals modules to reconstruct call stacks,
+    // and without it every page load throws a CSP console error.
+    `script-src 'self' 'unsafe-inline'${isProd ? "" : " 'unsafe-eval'"}`,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https://*.stellar.org",
     "font-src 'self'",

--- a/frontend/src/services/sep10Auth.ts
+++ b/frontend/src/services/sep10Auth.ts
@@ -37,6 +37,7 @@ export interface Sep10Info {
 }
 
 interface FreighterApi {
+  getPublicKey(): Promise<string>;
   signTransaction(
     xdr: string,
     opts: { network: string; networkPassphrase: string; accountToSign: string },
@@ -44,6 +45,7 @@ interface FreighterApi {
 }
 
 interface AlbedoApi {
+  publicKey(opts: Record<string, unknown>): Promise<{ pubkey: string }>;
   tx(opts: {
     xdr: string;
     network: string;
@@ -60,6 +62,7 @@ interface XBullSDKApi {
 }
 
 interface RabetApi {
+  connect(): Promise<{ publicKey: string }>;
   sign(xdr: string, network: string): Promise<{ xdr: string }>;
 }
 


### PR DESCRIPTION
## Summary
- `wallet-context.tsx` and `services/sep10Auth.ts` each declared conflicting global `Window.freighter/albedo/xBullSDK/rabet` types, breaking `tsc` (TS2717) on `main` right now — introduced by a recent ESLint-fix commit that didn't account for `sep10Auth.ts`'s existing declaration. Consolidated onto `sep10Auth.ts`'s types, which `wallet-context.tsx`'s `connectWallet()` already relied on for its `getPublicKey`/`publicKey`/`connect` calls.
- `useOfflineStatus` guarded its initial state with `typeof navigator !== 'undefined'`, but Node.js ships a built-in `navigator` global without `onLine`, so the check passed during SSR while `navigator.onLine` evaluated to `undefined` (falsy). That rendered the offline banner on every server render, causing a **hydration mismatch on every single page load**. Now guards on `window` instead.
- Dev mode's CSP lacked `'unsafe-eval'`, which Next.js needs in development for Fast Refresh/Turbopack — logged a console error on every page load. Scoped `'unsafe-eval'` to non-production builds only.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors in the touched files (confirmed `main` currently fails on `wallet-context.tsx`, this branch doesn't)
- [x] Ran `npm run dev` and clicked through the app — no hydration-error overlay, no CSP eval console errors
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DznLUYAQnDr4szHkAUcZ2